### PR TITLE
Add WorkspaceFolders support

### DIFF
--- a/extensions/org.eclipse.lsp4xml.extensions.emmet/pom.xml
+++ b/extensions/org.eclipse.lsp4xml.extensions.emmet/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.lsp4xml</groupId>
 		<artifactId>lsp4xml-extensions</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4xml.extensions.emmet</artifactId>
 	<dependencies>

--- a/extensions/org.eclipse.lsp4xml.extensions.web/pom.xml
+++ b/extensions/org.eclipse.lsp4xml.extensions.web/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.lsp4xml</groupId>
 		<artifactId>lsp4xml-extensions</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4xml.extensions.web</artifactId>
 	<dependencies>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.lsp4xml</groupId>
 		<artifactId>lsp4xml</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>lsp4xml-extensions</artifactId>
 	<packaging>pom</packaging>

--- a/org.eclipse.lsp4xml/pom.xml
+++ b/org.eclipse.lsp4xml/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.lsp4xml</groupId>
 		<artifactId>lsp4xml</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4xml</artifactId>
 	<properties>

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ServerCapabilitiesInitializer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ServerCapabilitiesInitializer.java
@@ -17,6 +17,8 @@ import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConsta
 
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.WorkspaceFoldersOptions;
+import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 
 /**
  * All default capabilities of this server
@@ -61,6 +63,14 @@ public class ServerCapabilitiesInitializer {
 		if (!clientCapabilities.isCompletionDynamicRegistrationSupported()) {
 			serverCapabilities.setCompletionProvider(DEFAULT_COMPLETION_OPTIONS);
 		}
+		
+		WorkspaceServerCapabilities wsCapabilities = new WorkspaceServerCapabilities();
+		WorkspaceFoldersOptions wsFoldersOptions = new WorkspaceFoldersOptions();
+		wsFoldersOptions.setSupported(Boolean.TRUE);
+		wsFoldersOptions.setChangeNotifications(Boolean.TRUE);
+		wsCapabilities.setWorkspaceFolders(wsFoldersOptions);
+		serverCapabilities.setWorkspace(wsCapabilities);
+		
 		return serverCapabilities;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.lsp4xml</groupId>
 	<artifactId>lsp4xml</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<description>lsp4xml is an XML specific implementation of the Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>
 	<properties>


### PR DESCRIPTION
This adds support for workspaceFolders to ServerCapabilities, which addresses https://github.com/eclipse/wildwebdeveloper/issues/124 where XML LS is started multiple times when opening different files from different projects. 

Signed-off-by: Xi Yan <xixiyan@redhat.com>