### PR TITLE
MSG_ATTRIBUTE_NOT_DECLARED must highlight attribute name instead of attribute value

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DTDErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DTDErrorCode.java
@@ -122,7 +122,7 @@ public enum DTDErrorCode implements IXMLErrorCode {
 			return XMLPositionUtility.selectStartTagName(offset, document);
 		}
 		case MSG_ATTRIBUTE_NOT_DECLARED: {
-			return XMLPositionUtility.selectAttributeValueAt(getString(arguments[1]), offset, document);
+			return XMLPositionUtility.selectAttributeNameFromGivenNameAt(getString(arguments[1]), offset, document);
 		}
 		case MSG_FIXED_ATTVALUE_INVALID: {
 			String attrName = getString(arguments[1]);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
@@ -74,7 +74,7 @@ public class DTDDiagnosticsTest {
 				"    <heading>Reminder</heading>\r\n" + //
 				"    <body>Don't forget me this weekend</body>\r\n" + //
 				"</note> ";
-		XMLAssert.testDiagnosticsFor(xml, d(10, 15, 17, DTDErrorCode.MSG_ATTRIBUTE_NOT_DECLARED));
+		XMLAssert.testDiagnosticsFor(xml, d(10, 10, 14, DTDErrorCode.MSG_ATTRIBUTE_NOT_DECLARED));
 	}
 
 	@Test


### PR DESCRIPTION
MSG_ATTRIBUTE_NOT_DECLARED must highlight attribute name instead of attribute value.

Signed-off-by: azerr <azerr@redhat.com>