### PR TITLE
Cache uris that received "limit exceeded" warnings

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitExceededWarnings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitExceededWarnings.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.client;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.lemminx.customservice.ActionableNotification;
+import org.eclipse.lemminx.customservice.XMLLanguageClientAPI;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+
+
+/**
+ * LimitExceededWarnings sends a warning to the
+ * client via a jsonrpc notification
+ */
+public class LimitExceededWarnings {
+
+	private final XMLLanguageClientAPI client;
+	private final SharedSettings sharedSettings;
+	private final Set<String /* file URI */> cache;
+
+	public LimitExceededWarnings(XMLLanguageClientAPI client, SharedSettings sharedSettings) {
+		this.client = client;
+		this.sharedSettings = sharedSettings;
+		this.cache = new HashSet<String>();
+	}
+
+	/**
+	 * Sends the limit exceeded warning to the client only if the provided
+	 * uri does not exist in the cache
+	 * 
+	 * After sending the warning, the uri is added to the cache
+	 * 
+	 * @param uri            the file uri
+	 * @param featureName    the feature name
+	 */
+	public void onResultLimitExceeded(String uri, LimitFeature feature) {
+		int resultLimit = 0;
+		switch(feature) {
+			case SYMBOLS:
+				resultLimit = sharedSettings.getSymbolSettings().getMaxItemsComputed();
+		}
+		onResultLimitExceeded(uri, resultLimit, feature.getName());
+	}
+
+	/**
+	 * Sends the limit exceeded warning to the client only if the provided
+	 * uri does not exist in the cache
+	 * 
+	 * After sending the warning, the uri is added to the cache
+	 * 
+	 * @param uri            the file uri
+	 * @param resultLimit    the result limit
+	 * @param featureName    the feature name
+	 */
+	public void onResultLimitExceeded(String uri, int resultLimit, String featureName) {
+		if (cache.contains(uri)) {
+			return;
+		}
+		sendLimitExceededWarning(uri, resultLimit, featureName);
+		cache.add(uri);
+	}
+
+	/**
+	 * Evict the provided uri from cache
+	 * 
+	 * @param uri
+	 */
+	public void evict(String uri) {
+		cache.remove(uri);
+	}
+
+	/**
+	 * Evict all contents from cache
+	 */
+	public void evictAll() {
+		cache.clear();
+	}
+
+	/**
+	 * Send limit exceeded warning to client
+	 * 
+	 * @param uri            the file uri
+	 * @param resultLimit    the result limit
+	 * @param featureName    the feature name
+	 */
+	private void sendLimitExceededWarning(String uri, int resultLimit, String featureName) {
+		String filename = Paths.get(URI.create(uri)).getFileName().toString();
+		String message = filename != null ? filename + ": " : "";
+		message += "For performance reasons, " + featureName + " have been limited to " + resultLimit
+				+ " items.\nIf a new limit is set, please close and reopen this file to recompute " + featureName + ".";
+
+		if (sharedSettings.isActionableNotificationSupport() && sharedSettings.isOpenSettingsCommandSupport()) {
+			// create command that opens the settings UI on the client side, in order to
+			// quickly edit xml.symbols.maxItemsComputed
+			Command command = new Command("Configure limit", ClientCommands.OPEN_SETTINGS,
+					Collections.singletonList("xml.symbols.maxItemsComputed"));
+			ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Info)
+					.withMessage(message).withCommands(Collections.singletonList(command));
+					client.actionableNotification(notification);
+		} else {
+			// the open settings command is not supported by the client, display a simple
+			// message with LSP
+			client.showMessage(new MessageParams(MessageType.Warning, message));
+		}
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitFeature.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitFeature.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.client;
+
+/**
+ * Features that are associated with some limit
+ * For example, document symbols have a maximum limit for performance reasons
+ */
+public enum LimitFeature {
+	
+	SYMBOLS("document symbols");
+	
+	private final String name;
+	
+	private LimitFeature(String name) {
+		this.name = name;
+	}
+	
+	public String getName() {
+		return name;
+	}
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/LimitExceededWarningsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/LimitExceededWarningsTest.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.eclipse.lemminx.XMLLanguageServer;
+import org.eclipse.lemminx.XMLTextDocumentService;
+import org.eclipse.lemminx.client.ExtendedClientCapabilities;
+import org.eclipse.lemminx.customservice.ActionableNotification;
+import org.eclipse.lemminx.customservice.XMLLanguageClientAPI;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for LimitExceededWarnings
+ */
+public class LimitExceededWarningsTest {
+
+	private final String TEST_FEATURE = "";
+	private final int TEST_LIMIT = 0;
+
+	private XMLLanguageServer languageServer;
+	private XMLTextDocumentService textDocumentService;
+	private MutableInt actionableNotificationCount;
+	private MutableInt showMessageCount;
+
+	@BeforeEach
+	public void before() {
+		actionableNotificationCount = new MutableInt(0);
+		showMessageCount = new MutableInt(0);
+		languageServer = createServer(actionableNotificationCount, showMessageCount);
+		textDocumentService = (XMLTextDocumentService) languageServer.getTextDocumentService();
+	}
+
+	@Test
+	public void testSendActionableNotification() {
+		String uri1 = "file:///uri1.xml";
+		String uri2 = "file:///uri2.xml";
+		setSupportCapabilities(true, true);
+
+		sendNotification(uri1);
+		assertCounts(1, 0);
+
+		sendNotification(uri1);
+		assertCounts(1, 0);
+
+		sendNotification(uri2);
+		assertCounts(2, 0);
+
+		sendNotification(uri2);
+		assertCounts(2, 0);
+	}
+
+	@Test
+	public void testActionableNotificationEvict() {
+		String uri1 = "file:///uri1.xml";
+		String uri2 = "file:///uri2.xml";
+		setSupportCapabilities(true, true);
+
+		sendNotification(uri1);
+		assertCounts(1, 0);
+		sendNotification(uri2);
+		assertCounts(2, 0);
+
+		textDocumentService.getLimitExceededWarnings().evict(uri1);
+
+		sendNotification(uri1);
+		assertCounts(3, 0);
+		sendNotification(uri2);
+		assertCounts(3, 0);
+
+		textDocumentService.getLimitExceededWarnings().evict(uri2);
+
+		sendNotification(uri1);
+		assertCounts(3, 0);
+		sendNotification(uri2);
+		assertCounts(4, 0);
+	}
+
+	@Test
+	public void testSendMessage() {
+		String uri1 = "file:///uri1.xml";
+		String uri2 = "file:///uri2.xml";
+		setSupportCapabilities(false, false);
+
+		sendNotification(uri1);
+		assertCounts(0, 1);
+
+		sendNotification(uri1);
+		assertCounts(0, 1);
+
+		sendNotification(uri2);
+		assertCounts(0, 2);
+
+		sendNotification(uri2);
+		assertCounts(0, 2);
+	}
+
+	@Test
+	public void testSendMessage2() {
+		String uri = "file:///uri.xml";
+		setSupportCapabilities(true, false);
+		sendNotification(uri);
+		assertCounts(0, 1);
+	}
+
+	@Test
+	public void testSendMessage3() {
+		String uri = "file:///uri.xml";
+		setSupportCapabilities(false, true);
+		sendNotification(uri);
+		assertCounts(0, 1);
+	}
+
+	@Test
+	public void testSendMessageEvict() {
+		String uri1 = "file:///uri1.xml";
+		String uri2 = "file:///uri2.xml";
+		setSupportCapabilities(false, false);
+
+		sendNotification(uri1);
+		assertCounts(0, 1);
+		sendNotification(uri2);
+		assertCounts(0, 2);
+
+		textDocumentService.getLimitExceededWarnings().evict(uri1);
+
+		sendNotification(uri1);
+		assertCounts(0, 3);
+		sendNotification(uri2);
+		assertCounts(0, 3);
+
+		textDocumentService.getLimitExceededWarnings().evict(uri2);
+
+		sendNotification(uri1);
+		assertCounts(0, 3);
+		sendNotification(uri2);
+		assertCounts(0, 4);
+	}
+
+	private static XMLLanguageServer createServer(MutableInt actionableNotificationCount, MutableInt showMessageCount) {
+
+		XMLLanguageServer languageServer = new XMLLanguageServer();
+		XMLLanguageClientAPI client = new XMLLanguageClientAPI() {
+
+			@Override
+			public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+				return null;
+			}
+
+			@Override
+			public void showMessage(MessageParams messageParams) {
+				showMessageCount.increment();
+			}
+
+			@Override
+			public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+
+			}
+
+			@Override
+			public void logMessage(MessageParams message) {
+
+			}
+
+			@Override
+			public void telemetryEvent(Object object) {
+
+			}
+
+			@Override
+			public void actionableNotification(ActionableNotification notification) {
+				actionableNotificationCount.increment();
+			}
+		};
+		languageServer.setClient(client);
+		return languageServer;
+	}
+
+	private void setSupportCapabilities(boolean supportActionableNotification, boolean supportOpenSettings) {
+		ExtendedClientCapabilities capabilities = new ExtendedClientCapabilities();
+		capabilities.setActionableNotificationSupport(supportActionableNotification);
+		capabilities.setOpenSettingsCommandSupport(supportOpenSettings);
+		textDocumentService.updateClientCapabilities(new ClientCapabilities(), capabilities);
+	}
+
+	private void sendNotification(String uri) {
+		textDocumentService.getLimitExceededWarnings()
+				.onResultLimitExceeded(uri, TEST_LIMIT, TEST_FEATURE);
+	}
+
+	/**
+	 * Assert "actionable notification" and "send message" counts
+	 * 
+	 * @param actionableNotification expected "actionable notification" count
+	 * @param sendMessage            expected "send message" count
+	 */
+	private void assertCounts(int actionableNotification, int sendMessage) {
+		assertEquals(actionableNotification, actionableNotificationCount.intValue());
+		assertEquals(sendMessage, showMessageCount.intValue());
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/243

To implement this fix, there is a hashset that keep tracks of uris for files that already received the notification. In this PR, the cache for the file uri is evicted only after the file has been closed.

To test this PR, set `xml.symbols.maxItemsComputed` to a very low value.

Demo:
![demo](https://raw.githubusercontent.com/xorye/gifs/master/pr/limit_notif.gif?token=AE3CR5LJJSDYIAYE4JZE4ZK6VRKPE)

Signed-off-by: David Kwon <dakwon@redhat.com>