### PR TITLE
Fix ignore quote style for attributes in prolog

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -674,7 +674,7 @@ class XMLFormatter {
 				return;
 			}
 			for (DOMAttr attr : attrs) {
-				xmlBuilder.addSingleAttribute(attr, true);
+				xmlBuilder.addPrologAttribute(attr);
 			}
 		}
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -120,18 +120,16 @@ public class XMLBuilder {
 	}
 
 	/**
-	 * Used when only one attribute is being added to a node.
+	 * Add prolog attribute
 	 * 
 	 * It will not perform any linefeeds and only basic indentation.
 	 * 
 	 * @param attr               attribute
-	 * @param surroundWithQuotes true if value should be added with quotes, false
-	 *                           otherwise
 	 * @return this XML Builder
 	 */
-	public XMLBuilder addSingleAttribute(DOMAttr attr, boolean surroundWithQuotes) {
+	public XMLBuilder addPrologAttribute(DOMAttr attr) {
 		appendSpace();
-		addAttributeContents(attr.getName(), attr.hasDelimiter(), attr.getValue(), surroundWithQuotes);
+		addAttributeContents(attr.getName(), attr.hasDelimiter(), attr.getOriginalValue(), false);
 		return this;
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2330,6 +2330,30 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void enforceSingleQuoteStyleProlog() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.preferred);
+
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		String expected = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>";
+		format(content, expected, settings);
+		format(expected, expected, settings);
+	}
+
+	@Test
+	public void enforceDoubleQuoteStyleProlog() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.doubleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.preferred);
+
+		String content = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>";
+		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		format(content, expected, settings);
+		format(expected, expected, settings);
+	}
+
+	@Test
 	public void dontEnforceSingleQuoteStyle() throws BadLocationException {
 		SharedSettings settings = new SharedSettings();
 		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
@@ -2339,6 +2363,29 @@ public class XMLFormatterTest {
 		String expected = "<a attr=\"\'\" attr2=\'\"\' />";
 		format(content, expected, settings);
 	}
+
+	@Test
+	public void dontEnforceSingleQuoteStyleProlog() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.ignore);
+
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void dontEnforceDoubleQuoteStyleProlog() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.ignore);
+
+		String content = "<?xml version=\'1.0\' encoding=\'UTF-8\'?>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
 
 	@Test
 	public void dontEnforceDoubleQuoteStyle() throws BadLocationException {


### PR DESCRIPTION
In the current master branch, there is a formatting problem where `xml.fomat.enforceQuoteStyle = "ignore"` doesn't apply to prolog attributes.

For example, if this was set in the settings:
![image](https://user-images.githubusercontent.com/20326645/81447726-2a82a080-914b-11ea-924e-6b1148a8de0d.png)

This:
`<?xml version="1.0" encoding="UTF-8"?>`

turns into this after formatting:
`<?xml version='1.0' encoding='UTF-8'?>`

This PR fixes this issue.

Signed-off-by: David Kwon <dakwon@redhat.com>