### PR TITLE
Separate xsd documentation and appinfo contents on hover and completion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,5 @@
 	//Use consistent indentation
 	"editor.detectIndentation": false,
 	"editor.tabSize": 4,
-	"editor.insertSpaces": false,
-	"java.test.defaultConfig": "default",
+	"editor.insertSpaces": false
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -195,7 +195,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
 		return computeDOMAsync(params.getTextDocument(), (cancelChecker, xmlDocument) -> {
-			return getXMLLanguageService().doHover(xmlDocument, params.getPosition(), sharedSettings.getHoverSettings(),
+			return getXMLLanguageService().doHover(xmlDocument, params.getPosition(), sharedSettings,
 					cancelChecker);
 		});
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMAttributeDeclaration.java
@@ -14,6 +14,8 @@ package org.eclipse.lemminx.extensions.contentmodel.model;
 
 import java.util.Collection;
 
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
+
 /**
  * Content model element which abstracts attribute declaration from a given
  * grammar (XML Schema, DTD).
@@ -31,9 +33,26 @@ public interface CMAttributeDeclaration {
 
 	Collection<String> getEnumerationValues(); 
 	
-	String getDocumentation();
+	/**
+	 * Returns formatted documentation of the declared
+	 * attribute according to settings defined in <code>request</code>
+	 * 
+	 * @param request the request that contains settings
+	 * @return formatted documentation of the declared
+	 * attribute according to settings defined in <code>request</code>
+	 */
+	String getDocumentation(ISharedSettingsRequest request);
 
-	String getValueDocumentation(String value);
+	/**
+	 * Returns formatted documentation about <code>value</code>,
+	 * according to settings defined in <code>request</code>
+	 * 
+	 * @param value the attribute value to find documentation for
+	 * @param request the request containing settings
+	 * @return formatted documentation about <code>value</code>,
+	 * according to settings defined in <code>request</code>
+	 */
+	String getValueDocumentation(String value, ISharedSettingsRequest request);
 
 	/**
 	 * Returns true if the attribute is required and false otherwise.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
 
 /**
  * Content model element which abstracts element declaration from a given
@@ -99,11 +100,14 @@ public interface CMElementDeclaration {
 	CMAttributeDeclaration findCMAttribute(String attributeName);
 
 	/**
-	 * Returns the documentation of the declared element.
+	 * Returns formatted documentation of the declared element,
+	 * according to settings defined in <code>request</code>.
 	 * 
-	 * @return the documentation of the declared element.
+	 * @param request the request containing settings
+	 * @return formatted documentation of the declared element,
+	 * according to settings defined in <code>request</code>.
 	 */
-	String getDocumentation();
+	String getDocumentation(ISharedSettingsRequest request);
 
 	/**
 	 * Returns true if the element cannot contains element children or text content

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -30,7 +30,6 @@ import org.eclipse.lemminx.services.AttributeCompletionItem;
 import org.eclipse.lemminx.services.extensions.CompletionParticipantAdapter;
 import org.eclipse.lemminx.services.extensions.ICompletionRequest;
 import org.eclipse.lemminx.services.extensions.ICompletionResponse;
-import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.uriresolver.CacheResourceDownloadingException;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CompletionItem;
@@ -271,7 +270,6 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 		try {
 			Range fullRange = request.getReplaceRange();
 			boolean canSupportSnippet = request.isCompletionSnippetsSupported();
-			SharedSettings sharedSettings = request.getSharedSettings();
 			ContentModelManager contentModelManager = request.getComponent(ContentModelManager.class);
 			// Completion on attribute name based on
 			// - internal grammar (ex: DOCTYPE with subset)
@@ -282,7 +280,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 						parentElement.getNamespaceURI());
 				if (cmElement != null) {
 					fillAttributesWithCMAttributeDeclarations(parentElement, fullRange, cmElement, canSupportSnippet,
-							generateValue, request, response, sharedSettings);
+							generateValue, request, response);
 				}
 			}
 		} catch (CacheResourceDownloadingException e) {
@@ -292,7 +290,8 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 
 	private void fillAttributesWithCMAttributeDeclarations(DOMElement parentElement, Range fullRange,
 			CMElementDeclaration cmElement, boolean canSupportSnippet, boolean generateValue,
-			ICompletionRequest request, ICompletionResponse response, SharedSettings sharedSettings) {
+			ICompletionRequest request, ICompletionResponse response) {
+
 		Collection<CMAttributeDeclaration> attributes = cmElement.getAttributes();
 		if (attributes == null) {
 			return;
@@ -301,7 +300,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 			String attrName = cmAttribute.getName();
 			if (!parentElement.hasAttribute(attrName)) {
 				CompletionItem item = new AttributeCompletionItem(attrName, canSupportSnippet, fullRange, generateValue,
-						cmAttribute.getDefaultValue(), cmAttribute.getEnumerationValues(), sharedSettings);
+						cmAttribute.getDefaultValue(), cmAttribute.getEnumerationValues(), request.getSharedSettings());
 				MarkupContent documentation = XMLGenerator.createMarkupContent(cmAttribute, cmElement, request);
 				item.setDocumentation(documentation);
 				response.addCompletionAttribute(item);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelHoverParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelHoverParticipant.java
@@ -28,9 +28,9 @@ import org.eclipse.lemminx.extensions.contentmodel.utils.XMLGenerator;
 import org.eclipse.lemminx.extensions.xsi.XSISchemaModel;
 import org.eclipse.lemminx.services.extensions.HoverParticipantAdapter;
 import org.eclipse.lemminx.services.extensions.IHoverRequest;
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
 import org.eclipse.lemminx.uriresolver.CacheResourceDownloadingException;
 import org.eclipse.lemminx.utils.MarkupContentFactory;
-import org.eclipse.lemminx.utils.MarkupContentFactory.IMarkupKindSupport;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
@@ -137,7 +137,7 @@ public class ContentModelHoverParticipant extends HoverParticipantAdapter {
 		}
 	}
 
-	private static String getCacheWarningHover(CacheResourceDownloadingException e, IMarkupKindSupport support) {
+	private static String getCacheWarningHover(CacheResourceDownloadingException e, ISharedSettingsRequest support) {
 		// Here cache is enabled and some XML Schema, DTD, etc are loading
 		MarkupContent content = MarkupContentFactory.createMarkupContent(
 				"Cannot process " + (e.isDTD() ? "DTD" : "XML Schema") + " hover: " + e.getMessage(),

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
@@ -19,9 +19,9 @@ import java.util.List;
 import org.eclipse.lemminx.commons.SnippetsBuilder;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.utils.MarkupContentFactory;
-import org.eclipse.lemminx.utils.MarkupContentFactory.IMarkupKindSupport;
 import org.eclipse.lemminx.utils.XMLBuilder;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
@@ -274,8 +274,8 @@ public class XMLGenerator {
 	 * @param support
 	 * @return a markup content for element documentation and null otherwise.
 	 */
-	public static MarkupContent createMarkupContent(CMElementDeclaration cmElement, IMarkupKindSupport support) {
-		String documentation = XMLGenerator.generateDocumentation(cmElement.getDocumentation(),
+	public static MarkupContent createMarkupContent(CMElementDeclaration cmElement, ISharedSettingsRequest support) {
+		String documentation = XMLGenerator.generateDocumentation(cmElement.getDocumentation(support),
 				cmElement.getDocumentURI(), support.canSupportMarkupKind(MarkupKind.MARKDOWN));
 		if (documentation != null) {
 			return MarkupContentFactory.createMarkupContent(documentation, MarkupKind.MARKDOWN, support);
@@ -286,17 +286,17 @@ public class XMLGenerator {
 	/**
 	 * Returns a markup content for attribute name documentation and null otherwise.
 	 * 
-	 * @param cmAttribute
-	 * @param ownerElement
-	 * @param support
+	 * @param cmAttribute  the attribute declaration
+	 * @param ownerElement the owner element declaration
+	 * @param request      the request
 	 * @return a markup content for attribute name documentation and null otherwise.
 	 */
 	public static MarkupContent createMarkupContent(CMAttributeDeclaration cmAttribute,
-			CMElementDeclaration ownerElement, IMarkupKindSupport support) {
-		String documentation = XMLGenerator.generateDocumentation(cmAttribute.getDocumentation(),
-				ownerElement.getDocumentURI(), support.canSupportMarkupKind(MarkupKind.MARKDOWN));
+			CMElementDeclaration ownerElement, ISharedSettingsRequest request) {
+		String documentation = XMLGenerator.generateDocumentation(cmAttribute.getDocumentation(request),
+				ownerElement.getDocumentURI(), request.canSupportMarkupKind(MarkupKind.MARKDOWN));
 		if (documentation != null) {
-			return MarkupContentFactory.createMarkupContent(documentation, MarkupKind.MARKDOWN, support);
+			return MarkupContentFactory.createMarkupContent(documentation, MarkupKind.MARKDOWN, request);
 		}
 		return null;
 	}
@@ -313,8 +313,8 @@ public class XMLGenerator {
 	 *         otherwise.
 	 */
 	public static MarkupContent createMarkupContent(CMAttributeDeclaration cmAttribute, String attributeValue,
-			CMElementDeclaration ownerElement, IMarkupKindSupport support) {
-		String documentation = XMLGenerator.generateDocumentation(cmAttribute.getValueDocumentation(attributeValue),
+			CMElementDeclaration ownerElement, ISharedSettingsRequest support) {
+		String documentation = XMLGenerator.generateDocumentation(cmAttribute.getValueDocumentation(attributeValue, support),
 				ownerElement.getDocumentURI(), support.canSupportMarkupKind(MarkupKind.MARKDOWN));
 		if (documentation != null) {
 			return MarkupContentFactory.createMarkupContent(documentation, MarkupKind.MARKDOWN, support);
@@ -332,7 +332,7 @@ public class XMLGenerator {
 	 * @return a markup content for element text documentation and null otherwise.
 	 */
 	public static MarkupContent createMarkupContent(CMElementDeclaration cmElement, String textContent,
-			IMarkupKindSupport support) {
+			ISharedSettingsRequest support) {
 		String documentation = XMLGenerator.generateDocumentation(cmElement.getValueDocumentation(textContent),
 				cmElement.getDocumentURI(), support.canSupportMarkupKind(MarkupKind.MARKDOWN));
 		if (documentation != null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDAttributeDeclaration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import org.apache.xerces.impl.dtd.XMLAttributeDecl;
 import org.apache.xerces.impl.dtd.XMLSimpleType;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
 
 /**
  * DTD attribute declaration.
@@ -53,7 +54,7 @@ public class CMDTDAttributeDeclaration extends XMLAttributeDecl implements CMAtt
 	}
 
 	@Override
-	public String getDocumentation() {
+	public String getDocumentation(ISharedSettingsRequest request) {
 		if (documentation != null) {
 			return documentation;
 		}
@@ -67,7 +68,7 @@ public class CMDTDAttributeDeclaration extends XMLAttributeDecl implements CMAtt
 	}
 
 	@Override
-	public String getValueDocumentation(String value) {
+	public String getValueDocumentation(String value, ISharedSettingsRequest settings) {
 		return null;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
@@ -24,6 +24,8 @@ import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
 import org.eclipse.lemminx.extensions.dtd.contentmodel.CMDTDDocument.DTDElementInfo;
 import org.eclipse.lemminx.extensions.dtd.contentmodel.CMDTDDocument.DTDNodeInfo;
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
+import org.eclipse.lemminx.settings.SharedSettings;
 
 /**
  * DTD element declaration.
@@ -97,7 +99,7 @@ public class CMDTDElementDeclaration extends XMLElementDecl implements CMElement
 	}
 
 	@Override
-	public String getDocumentation() {
+	public String getDocumentation(ISharedSettingsRequest settings) {
 		if (documentation != null) {
 			return documentation;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/HtmlToPlainText.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/HtmlToPlainText.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright © 2009-2017, Jonathan Hedley <jonathan@hedley.net>
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.eclipse.lemminx.extensions.xsd.contentmodel;
+
+import org.jsoup.helper.StringUtil;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+
+/**
+ * HTML to plain-text. Uses jsoup to convert HTML input to lightly-formatted
+ * plain-text. This is a fork of Jsoup's <a href=
+ * "https://github.com/jhy/jsoup/blob/842977c381b8d48bf12719e3f5cf6fd669379957/src/main/java/org/jsoup/examples/HtmlToPlainText.java">HtmlToPlainText</a>
+ *
+ * @author Jonathan Hedley, jonathan@hedley.net
+ */
+public class HtmlToPlainText {
+
+	/**
+	 * Format an Element to plain-text
+	 * @param element the root element to format
+	 * @return formatted text
+	 */
+	public String getPlainText(Element element) {
+		FormattingVisitor formatter = new FormattingVisitor();
+		NodeTraversor traversor = new NodeTraversor(formatter);
+		traversor.traverse(element); // walk the DOM, and call .head() and .tail() for each node
+
+		return formatter.toString();
+	}
+
+	// the formatting rules, implemented in a breadth-first DOM traverse
+	private class FormattingVisitor implements NodeVisitor {
+		private StringBuilder accum = new StringBuilder(); // holds the accumulated text
+		private int listNesting;
+		// hit when the node is first seen
+		@Override
+		public void head(Node node, int depth) {
+			String name = node.nodeName();
+			if (node instanceof TextNode) {
+				append(((TextNode) node).text()); // TextNodes carry all user-readable text in the DOM.
+			} else if (name.equals("ul")) {
+				listNesting++;
+			} else if (name.equals("li")) {
+				append("\n ");
+				for (int i = 1; i < listNesting; i++) {
+					append("  ");
+				}
+				if (listNesting == 1) {
+					append("* ");
+				} else {
+					append("- ");
+				}
+			} else if (name.equals("dt")) {
+				append("  ");
+			} else if (StringUtil.in(name, "p", "h1", "h2", "h3", "h4", "h5", "tr")) {
+				append("\n");
+			}
+		}
+
+		// hit when all of the node's children (if any) have been visited
+		@Override
+		public void tail(Node node, int depth) {
+			String name = node.nodeName();
+			if (StringUtil.in(name, "br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5")) {
+				append("\n");
+			} else if (StringUtil.in(name, "th", "td")) {
+				append(" ");
+			} else if (name.equals("a")) {
+				append(String.format(" <%s>", node.absUrl("href")));
+			} else if (name.equals("ul")) {
+				listNesting--;
+			}
+		}
+
+		// appends text to the string builder with a simple word wrap method
+		private void append(String text) {
+			if (text.equals(" ") &&
+					(accum.length() == 0 || StringUtil.in(accum.substring(accum.length() - 1), " ", "\n")))
+			{
+				return; // don't accumulate long runs of empty spaces
+			}
+			accum.append(text);
+		}
+
+		@Override
+		public String toString() {
+			return accum.toString();
+		}
+	}
+} 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/XSDDocumentation.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/XSDDocumentation.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.xsd.contentmodel;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.xerces.xs.XSObjectList;
+import org.eclipse.lemminx.settings.SchemaDocumentationType;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.jsoup.Jsoup;
+
+/**
+ * XSD documentation
+ * 
+ * Represents documentation coming from an XML schema file
+ */
+public class XSDDocumentation {
+
+	private static final String APPINFO_ELEMENT = "appinfo";
+	private static final String DOCUMENTATION_ELEMENT = "documentation";
+
+	private final String prefix;
+	private final SchemaDocumentationType strategy;
+	private final List<String> documentation;
+	private final List<String> appinfo;
+
+	public XSDDocumentation(XSObjectList annotations, SchemaDocumentationType docStrategy, boolean convertToPlainText) {
+		this(annotations, null, docStrategy, convertToPlainText);
+	}
+
+	public XSDDocumentation(XSObjectList annotations, String value, SchemaDocumentationType docStrategy, boolean convertToPlainText) {
+		List<String> documentation = Collections.emptyList();
+		List<String> appinfo = Collections.emptyList();
+		switch(docStrategy) {
+			case all: {
+				documentation = XSDAnnotationModel.getDocumentation(annotations, value);
+				appinfo = XSDAnnotationModel.getAppInfo(annotations, value);
+				break;
+			}
+			case documentation: {
+				documentation = XSDAnnotationModel.getDocumentation(annotations, value);
+				break;
+			}
+			case appinfo: {
+				appinfo = XSDAnnotationModel.getAppInfo(annotations, value);
+				break;
+			}
+			case none:{
+				break;
+			}
+		}
+
+		if (convertToPlainText) {
+			// convert content to plain text
+			
+			// if the content contains html tags, converting to plaintext
+			// will remove them
+			convertToPlainText(documentation);
+			convertToPlainText(appinfo);
+		}
+
+		this.documentation = documentation;
+		this.appinfo = appinfo;
+		this.strategy = docStrategy;
+		this.prefix = XSDAnnotationModel.getPrefix(annotations, value);
+	}
+	/**
+	 * Returns formatted documentation that displays
+	 * contents of the documentation element (if exists) and the appinfo
+	 * element (if exists).
+	 * 
+	 * The returned documentation will return raw html if
+	 * <code>html</code> is true. Otherwise, the returned documentation
+	 * will be plaintext.
+	 * 
+	 * @param html if true, the return value will contain raw html
+	 * @return formatted documentation that displays
+	 * contents of the documentation element (if exists) and the appinfo
+	 * element (if exists)
+	 */
+	public String getFormattedDocumentation(boolean html) {
+		StringBuilder result = new StringBuilder();
+		boolean prependTitles = prependTitleCheck();
+		result.append(getFormatted(prefix, DOCUMENTATION_ELEMENT, documentation, prependTitles, html));
+		result.append(getFormatted(prefix, APPINFO_ELEMENT, appinfo, prependTitles, html));
+		return result.toString().trim();
+	}
+
+	/**
+	 * Returns true if documentation title (ie, xs:documentation, xs:appinfo)
+	 * should be preprended to the documentation
+	 * 
+	 * @return true if documentation title (ie, xs:documentation, xs:appinfo)
+	 * should be preprended to the documentation
+	 */
+	private boolean prependTitleCheck() {
+		return this.documentation.size() > 0 && this.appinfo.size() > 0
+				&& strategy == SchemaDocumentationType.all;
+	}
+
+	private static void convertToPlainText(List<String> list) {
+		HtmlToPlainText formatter = new HtmlToPlainText();
+		for (int i = 0; i < list.size(); i++) {
+			String curr = list.get(i);
+			list.set(i, formatter.getPlainText(Jsoup.parse(curr)));
+		}
+	}
+
+	private static String getFormatted(String prefix, String elementName, List<String> content,
+			boolean prependTitles, boolean html) {
+		StringBuilder result = new StringBuilder();
+		if (prependTitles) {
+			result.append(applyPrefix(prefix, elementName, html));
+		}
+		for (String doc: content) {
+			if (html) {
+				result.append("<p>");
+			}
+			result.append(doc);
+			if (html) {
+				result.append("</p>");
+			} else {
+				result.append(System.lineSeparator());
+				result.append(System.lineSeparator());
+			}
+		}
+		return result.toString();
+	}
+
+	private static String applyPrefix(String prefix, String documentation, boolean html) {
+		StringBuilder result = new StringBuilder();
+		if (html) {
+			result.append("<p><b>");
+		}
+		if (!StringUtils.isEmpty(prefix)) {
+			result.append(prefix).append(':');
+		}
+		result.append(documentation);
+		if (html) {
+			result.append("</b>");
+		}
+		result.append(":");
+		if (html) {
+			result.append("</p>");
+		} else {
+			result.append(System.lineSeparator());
+			result.append(System.lineSeparator());
+		}
+		return result.toString();
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/HoverRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/HoverRequest.java
@@ -18,6 +18,7 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.services.extensions.IHoverRequest;
 import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
+import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -28,13 +29,13 @@ import org.eclipse.lsp4j.Range;
  */
 class HoverRequest extends AbstractPositionRequest implements IHoverRequest {
 
-	private final XMLHoverSettings settings;
+	private final SharedSettings settings;
 
 	private Range tagRange;
 
 	private boolean open;
 
-	public HoverRequest(DOMDocument xmlDocument, Position position, XMLHoverSettings settings,
+	public HoverRequest(DOMDocument xmlDocument, Position position, SharedSettings settings,
 			XMLExtensionsRegistry extensionsRegistry) throws BadLocationException {
 		super(xmlDocument, position, extensionsRegistry);
 		this.settings = settings;
@@ -72,9 +73,14 @@ class HoverRequest extends AbstractPositionRequest implements IHoverRequest {
 
 	@Override
 	public boolean canSupportMarkupKind(String kind) {
-		return settings != null && settings.getCapabilities() != null
-				&& settings.getCapabilities().getContentFormat() != null
-				&& settings.getCapabilities().getContentFormat().contains(kind);
+		XMLHoverSettings hoverSettings = settings.getHoverSettings();
+		return settings != null && hoverSettings.getCapabilities() != null
+				&& hoverSettings.getCapabilities().getContentFormat() != null
+				&& hoverSettings.getCapabilities().getContentFormat().contains(kind);
+	}
 
+	@Override
+	public SharedSettings getSharedSettings() {
+		return settings;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLHover.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLHover.java
@@ -28,7 +28,7 @@ import org.eclipse.lemminx.dom.parser.TokenType;
 import org.eclipse.lemminx.dom.parser.XMLScanner;
 import org.eclipse.lemminx.services.extensions.IHoverParticipant;
 import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
+import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.utils.MarkupContentFactory;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
@@ -49,7 +49,7 @@ class XMLHover {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public Hover doHover(DOMDocument xmlDocument, Position position, XMLHoverSettings settings,
+	public Hover doHover(DOMDocument xmlDocument, Position position, SharedSettings settings,
 			CancelChecker cancelChecker) {
 		HoverRequest hoverRequest = null;
 		try {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
@@ -139,13 +139,13 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 		return completions.doComplete(xmlDocument, position, settings, cancelChecker);
 	}
 
-	public Hover doHover(DOMDocument xmlDocument, Position position, XMLHoverSettings settings) {
-		return doHover(xmlDocument, position, settings, NULL_CHECKER);
+	public Hover doHover(DOMDocument xmlDocument, Position position, SharedSettings sharedSettings) {
+		return doHover(xmlDocument, position, sharedSettings, NULL_CHECKER);
 	}
 
-	public Hover doHover(DOMDocument xmlDocument, Position position, XMLHoverSettings settings,
+	public Hover doHover(DOMDocument xmlDocument, Position position, SharedSettings sharedSettings,
 			CancelChecker cancelChecker) {
-		return hover.doHover(xmlDocument, position, settings, cancelChecker);
+		return hover.doHover(xmlDocument, position, sharedSettings, cancelChecker);
 	}
 
 	public List<Diagnostic> doDiagnostics(DOMDocument xmlDocument, CancelChecker monitor,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ICompletionRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ICompletionRequest.java
@@ -14,8 +14,6 @@ package org.eclipse.lemminx.services.extensions;
 
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.utils.XMLGenerator;
-import org.eclipse.lemminx.settings.SharedSettings;
-import org.eclipse.lemminx.utils.MarkupContentFactory.IMarkupKindSupport;
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Range;
 
@@ -23,11 +21,9 @@ import org.eclipse.lsp4j.Range;
  * Completion request API.
  *
  */
-public interface ICompletionRequest extends IPositionRequest, IMarkupKindSupport {
+public interface ICompletionRequest extends IPositionRequest, ISharedSettingsRequest {
 
 	Range getReplaceRange();
-
-	SharedSettings getSharedSettings();
 
 	XMLGenerator getXMLGenerator() throws BadLocationException;
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/IHoverRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/IHoverRequest.java
@@ -12,14 +12,13 @@
  */
 package org.eclipse.lemminx.services.extensions;
 
-import org.eclipse.lemminx.utils.MarkupContentFactory.IMarkupKindSupport;
 import org.eclipse.lsp4j.Range;
 
 /**
  * Hover request API.
  *
  */
-public interface IHoverRequest extends IPositionRequest, IMarkupKindSupport {
+public interface IHoverRequest extends IPositionRequest, ISharedSettingsRequest {
 
 	Range getTagRange();
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ISharedSettingsRequest.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ISharedSettingsRequest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.services.extensions;
+
+import org.eclipse.lemminx.settings.SharedSettings;
+
+/**
+ * Shared settings request API
+ */
+public interface ISharedSettingsRequest {
+
+	/**
+	 * Returns <code>true</code> if the client can support the given Markup kind for
+	 * documentation and <code>false</code> otherwise.
+	 * 
+	 * @param kind the markup kind
+	 * @return <code>true</code> if the client can support the given Markup kind for
+	 *         documentation and <code>false</code> otherwise.
+	 */
+	boolean canSupportMarkupKind(String kind);
+
+	/**
+	 * Returns the sharedSettings instance
+	 * 
+	 * @return the sharedSettings instance
+	 */
+	SharedSettings getSharedSettings();
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SchemaDocumentationType.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SchemaDocumentationType.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.settings;
+
+/**
+ * SchemaDocumentationType enum
+ * 
+ * Defines enums managing the which XSD element content to display
+ * as documentation
+ * 
+ * {@link SchemaDocumentationType#documentation} XSD documentation element
+ * {@link SchemaDocumentationType#appinfo} XSD appinfo element
+ * {@link SchemaDocumentationType#all} XSD documentation and appinfo elements
+ * {@link SchemaDocumentationType#none} none
+ */
+public enum SchemaDocumentationType {
+	documentation,
+	appinfo,
+	all,
+	none
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLPreferences.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLPreferences.java
@@ -18,11 +18,16 @@ package org.eclipse.lemminx.settings;
 public class XMLPreferences {
 	
 	public static final QuoteStyle DEFAULT_QUOTE_STYLE = QuoteStyle.doubleQuotes;
+	
+	public static final SchemaDocumentationType DEFAULT_SCHEMA_DOCUMENTATION_TYPE = SchemaDocumentationType.all;
 
 	private QuoteStyle quoteStyle;
 
+	private SchemaDocumentationType showSchemaDocumentationType;
+
 	public XMLPreferences() {
 		this.quoteStyle = DEFAULT_QUOTE_STYLE;
+		this.showSchemaDocumentationType = DEFAULT_SCHEMA_DOCUMENTATION_TYPE;
 	}
 
 	/**
@@ -66,7 +71,30 @@ public class XMLPreferences {
 		return this.quoteStyle;
 	}
 
+	/**
+	 * Returns the showSchemaDocumentationType
+	 */
+	public SchemaDocumentationType getShowSchemaDocumentationType() {
+		return this.showSchemaDocumentationType;
+	}
+
+	/**
+	 * Sets the showSchemaDocumentationType
+	 * 
+	 * @param showSchemaDocumentationType
+	 */
+	public void setShowSchemaDocumentationType(SchemaDocumentationType showSchemaDocumentationType) {
+		this.showSchemaDocumentationType = showSchemaDocumentationType;
+	}
+
+	/**
+	 * Merges the contents of <code>newPreferences</code> to the current
+	 * <code>XMLPreferences</code> instance
+	 * 
+	 * @param newPreferences
+	 */
 	public void merge(XMLPreferences newPreferences) {
 		this.setQuoteStyle(newPreferences.getQuoteStyle());
+		this.setShowSchemaDocumentationType(newPreferences.getShowSchemaDocumentationType());
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/MarkupContentFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.utils;
 
 import java.util.List;
 
+import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 
@@ -24,19 +25,6 @@ import org.eclipse.lsp4j.MarkupKind;
  */
 public class MarkupContentFactory {
 
-	public static interface IMarkupKindSupport {
-
-		/**
-		 * Returns <code>true</code> if the client can support the given Markup kind for
-		 * documentation and <code>false</code> otherwise.
-		 * 
-		 * @param kind the markup kind
-		 * @return <code>true</code> if the client can support the given Markup kind for
-		 *         documentation and <code>false</code> otherwise.
-		 */
-		boolean canSupportMarkupKind(String kind);
-	}
-
 	/**
 	 * Create the markup content according the given markup kind and the capability
 	 * of the client.
@@ -46,7 +34,7 @@ public class MarkupContentFactory {
 	 * @return the markup content according the given markup kind and the capability
 	 *         of the client.
 	 */
-	public static MarkupContent createMarkupContent(String value, String preferredKind, IMarkupKindSupport support) {
+	public static MarkupContent createMarkupContent(String value, String preferredKind, ISharedSettingsRequest support) {
 		if (value == null) {
 			return null;
 		}
@@ -71,7 +59,7 @@ public class MarkupContentFactory {
 	 * @return the markup content according the given markup kind and the capability
 	 *         of the client.
 	 */
-	public static MarkupContent creatMarkupContent(List<String> values, IMarkupKindSupport markupKindSupport) {
+	public static MarkupContent creatMarkupContent(List<String> values, ISharedSettingsRequest markupKindSupport) {
 		String kind = getKind(markupKindSupport);
 		if (values.size() == 1) {
 			return new MarkupContent(kind, values.get(0));
@@ -89,7 +77,7 @@ public class MarkupContentFactory {
 	 * @return the result of values aggregation according the given markup kind
 	 *         support.
 	 */
-	public static String aggregateContent(List<String> values, IMarkupKindSupport markupKindSupport) {
+	public static String aggregateContent(List<String> values, ISharedSettingsRequest markupKindSupport) {
 		if (values.size() == 1) {
 			return values.get(0);
 		}
@@ -97,7 +85,7 @@ public class MarkupContentFactory {
 		return aggregateContent(values, kind);
 	}
 
-	private static String getKind(IMarkupKindSupport request) {
+	private static String getKind(ISharedSettingsRequest request) {
 		return request.canSupportMarkupKind(MarkupKind.MARKDOWN) ? MarkupKind.MARKDOWN : MarkupKind.PLAINTEXT;
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -583,7 +583,25 @@ public class XMLAssert {
 	}
 
 	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
+			String fileURI, String expectedHoverLabel, Range expectedHoverRange, SharedSettings sharedSettings) throws BadLocationException {
+		ContentModelSettings settings = new ContentModelSettings();
+		settings.setUseCache(false);
+		assertHover(xmlLanguageService, value, catalogPath, fileURI, expectedHoverLabel, expectedHoverRange, settings, sharedSettings);
+	}
+
+	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			String fileURI, String expectedHoverLabel, Range expectedHoverRange, ContentModelSettings settings)
+			throws BadLocationException {
+		SharedSettings sharedSettings = new SharedSettings();
+		HoverCapabilities capabilities = new HoverCapabilities(Arrays.asList(MarkupKind.MARKDOWN), false);
+		sharedSettings.getHoverSettings().setCapabilities(capabilities);
+		assertHover(xmlLanguageService, value, catalogPath, fileURI,
+				expectedHoverLabel, expectedHoverRange, settings, sharedSettings);
+	}
+
+	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
+			String fileURI, String expectedHoverLabel, Range expectedHoverRange, ContentModelSettings settings,
+			SharedSettings sharedSettings)
 			throws BadLocationException {
 		int offset = value.indexOf("|");
 		value = value.substring(0, offset) + value.substring(offset + 1);
@@ -599,10 +617,7 @@ public class XMLAssert {
 		}
 		xmlLanguageService.doSave(new SettingsSaveContext(settings));
 
-		XMLHoverSettings hoverSettings = new XMLHoverSettings();
-		HoverCapabilities capabilities = new HoverCapabilities(Arrays.asList(MarkupKind.MARKDOWN), false);
-		hoverSettings.setCapabilities(capabilities);
-		Hover hover = xmlLanguageService.doHover(htmlDoc, position, hoverSettings);
+		Hover hover = xmlLanguageService.doHover(htmlDoc, position, sharedSettings);
 		if (expectedHoverLabel == null) {
 			assertNull(hover);
 		} else {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -1134,8 +1134,12 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 				"	<|" + //
 				"</project>";
 		testCompletionFor(xml, c("groupId", te(3, 1, 3, 2, "<groupId></groupId>"), "<groupId",
-				"A universally unique identifier for a project. It is normal to use a fully-qualified package name to distinguish it from other projects with a similar name "
-						+ "(eg. <code>org.apache.maven</code>)." + //
+				"3.0.0+" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + //
+						"A universally unique identifier for a project. It is normal to use " + //
+						"a fully-qualified package name to distinguish it from other projects with a similar name " + // 
+						"(eg. org.apache.maven)." + //
 						System.lineSeparator() + //
 						System.lineSeparator() + //
 						"Source: maven-4.0.0.xsd",
@@ -1153,8 +1157,12 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 
 		String mavenFileURI = getXMLSchemaFileURI("maven-4.0.0.xsd");
 		testCompletionMarkdownSupportFor(xml, c("groupId", te(3, 1, 3, 2, "<groupId></groupId>"), "<groupId",
-				"A universally unique identifier for a project. It is normal to use a fully-qualified package name to distinguish it from other projects with a similar name "
-						+ "(eg. `org.apache.maven`)." + //
+				"3.0.0+" + //
+						System.lineSeparator() + //
+						System.lineSeparator() + //
+						"A universally unique identifier for a project. It is normal to use " + //
+						"a fully-qualified package name to distinguish it from other projects with a similar name " + // 
+						"(eg. `org.apache.maven`)." + //
 						System.lineSeparator() + //
 						System.lineSeparator() + //
 						"Source: [maven-4.0.0.xsd](" + mavenFileURI + ")",

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
@@ -1,0 +1,338 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel;
+
+import java.util.Arrays;
+
+import org.apache.xerces.impl.XMLEntityManager;
+import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.settings.SchemaDocumentationType;
+import org.eclipse.lsp4j.HoverCapabilities;
+import org.eclipse.lsp4j.MarkupKind;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * XML hover tests with XML Schema.
+ *
+ */
+public class XMLSchemaHoverDocumentationTypeTest {
+
+	private static final String schemaName = "docAppinfo.xsd";
+	private static final String schemaPath = "src/test/resources/" + schemaName;
+	private static final String docPrefix = "**xs:documentation**:" + System.lineSeparator() + System.lineSeparator();
+	private static final String appinfoPrefix = "**xs:appinfo**:" + System.lineSeparator() + System.lineSeparator();
+	private static String source;
+	private static String plainTextDocPrefix = "xs:documentation:" + System.lineSeparator() + System.lineSeparator();
+	private static String plainTextAppinfoPrefix = "xs:appinfo:" + System.lineSeparator() + System.lineSeparator();
+	private static String plainTextSource;
+
+	@BeforeAll
+	public static void setup() throws MalformedURIException {
+		source = "Source: [" + schemaName + "](" + getXMLSchemaFileURI(schemaName) + ")";
+		plainTextSource = "Source: " + schemaName;
+	}
+
+	@Test
+	public void testHoverAttributeNameDoc() throws BadLocationException, MalformedURIException {
+		assertAttributeNameDocHover("attribute name documentation", SchemaDocumentationType.documentation, true);
+		assertAttributeNameDocHover(null, SchemaDocumentationType.appinfo, true);
+		assertAttributeNameDocHover("attribute name documentation", SchemaDocumentationType.all, true);
+		assertAttributeNameDocHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverAttributeNameAppinfo() throws BadLocationException, MalformedURIException {
+		assertAttributeNameAppinfoHover(null, SchemaDocumentationType.documentation, true);
+		assertAttributeNameAppinfoHover("attribute name appinfo", SchemaDocumentationType.appinfo, true);
+		assertAttributeNameAppinfoHover("attribute name appinfo", SchemaDocumentationType.all, true);
+		assertAttributeNameAppinfoHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverAttributeNameBoth() throws BadLocationException, MalformedURIException {
+		assertAttributeNameBothHover("attribute name documentation", SchemaDocumentationType.documentation, true);
+		assertAttributeNameBothHover("attribute name appinfo", SchemaDocumentationType.appinfo, true);
+		assertAttributeNameBothHover(
+				docPrefix + "attribute name documentation" +
+				System.lineSeparator() + System.lineSeparator() +
+				appinfoPrefix + "attribute name appinfo", SchemaDocumentationType.all, true);
+		assertAttributeNameBothHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverAttributeValueDoc() throws BadLocationException, MalformedURIException {
+		assertAttributeValueDocHover("attribute value documentation", SchemaDocumentationType.documentation, true);
+		assertAttributeValueDocHover(null, SchemaDocumentationType.appinfo, true);
+		assertAttributeValueDocHover("attribute value documentation", SchemaDocumentationType.all, true);
+		assertAttributeValueDocHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverAttributeValueAppinfo() throws BadLocationException, MalformedURIException {
+		assertAttributeValueAppinfoHover(null, SchemaDocumentationType.documentation, true);
+		assertAttributeValueAppinfoHover("attribute value appinfo", SchemaDocumentationType.appinfo, true);
+		assertAttributeValueAppinfoHover("attribute value appinfo", SchemaDocumentationType.all, true);
+		assertAttributeValueAppinfoHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverAttributeValueBoth() throws BadLocationException, MalformedURIException {
+		assertAttributeValueBothHover("attribute value documentation", SchemaDocumentationType.documentation, true);
+		assertAttributeValueBothHover("attribute value appinfo", SchemaDocumentationType.appinfo, true);
+		assertAttributeValueBothHover(
+				docPrefix + "attribute value documentation" +
+				System.lineSeparator() + System.lineSeparator() +
+				appinfoPrefix + "attribute value appinfo", SchemaDocumentationType.all, true);
+		assertAttributeValueBothHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverElementDoc() throws BadLocationException, MalformedURIException {
+		assertElementDocHover("element documentation", SchemaDocumentationType.documentation, true);
+		assertElementDocHover(null, SchemaDocumentationType.appinfo, true);
+		assertElementDocHover("element documentation", SchemaDocumentationType.all, true);
+		assertElementDocHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverElementAppinfo() throws BadLocationException, MalformedURIException {
+		assertElementAppinfoHover(null, SchemaDocumentationType.documentation, true);
+		assertElementAppinfoHover("element appinfo", SchemaDocumentationType.appinfo, true);
+		assertElementAppinfoHover("element appinfo", SchemaDocumentationType.all, true);
+		assertElementAppinfoHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverElementBoth() throws BadLocationException, MalformedURIException {
+		assertElementBothHover("element documentation", SchemaDocumentationType.documentation, true);
+		assertElementBothHover("element appinfo", SchemaDocumentationType.appinfo, true);
+		assertElementBothHover(
+				docPrefix + "element documentation" +
+				System.lineSeparator() + System.lineSeparator() +
+				appinfoPrefix + "element appinfo", SchemaDocumentationType.all, true);
+		assertElementBothHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverElementBothPlainText() throws BadLocationException, MalformedURIException {
+		assertElementBothHover("element documentation", SchemaDocumentationType.documentation, false);
+		assertElementBothHover("element appinfo", SchemaDocumentationType.appinfo, false);
+		assertElementBothHover(
+				plainTextDocPrefix + "element documentation" +
+				System.lineSeparator() + System.lineSeparator() +
+				plainTextAppinfoPrefix + "element appinfo", SchemaDocumentationType.all, false);
+		assertElementBothHover(null, SchemaDocumentationType.none, false);
+	};
+
+
+	@Test
+	public void testHoverMultipleBoth() throws BadLocationException, MalformedURIException {
+		String documentation =
+				"first element documentation" + System.lineSeparator() + System.lineSeparator() +
+				"second element documentation" + System.lineSeparator() + System.lineSeparator() +
+				"third element documentation";
+		
+		String appinfo =
+				"first element appinfo" + System.lineSeparator() + System.lineSeparator() +
+				"second element appinfo" + System.lineSeparator() + System.lineSeparator() +
+				"third element appinfo";
+		
+		assertElementMultipleBothHover(documentation, SchemaDocumentationType.documentation, true);
+		assertElementMultipleBothHover(appinfo, SchemaDocumentationType.appinfo, true);
+		assertElementMultipleBothHover(
+				docPrefix + documentation +
+				System.lineSeparator() + System.lineSeparator() +
+				appinfoPrefix + appinfo, SchemaDocumentationType.all, true);
+		assertElementMultipleBothHover(null, SchemaDocumentationType.none, true);
+	};
+
+	@Test
+	public void testHoverMultipleBothPlainText() throws BadLocationException, MalformedURIException {
+		String documentation =
+				"first element documentation" + System.lineSeparator() +System.lineSeparator() +
+				"second element documentation" + System.lineSeparator() +System.lineSeparator() +
+				"third element documentation";
+		
+		String appinfo =
+				"first element appinfo" + System.lineSeparator() +System.lineSeparator() +
+				"second element appinfo" + System.lineSeparator() +System.lineSeparator() +
+				"third element appinfo";
+		
+		assertElementMultipleBothHover(documentation, SchemaDocumentationType.documentation, false);
+		assertElementMultipleBothHover(appinfo, SchemaDocumentationType.appinfo, false);
+		assertElementMultipleBothHover(
+				plainTextDocPrefix + documentation +
+				System.lineSeparator() + System.lineSeparator() +
+				plainTextAppinfoPrefix + appinfo, SchemaDocumentationType.all, false);
+		assertElementMultipleBothHover(null, SchemaDocumentationType.none, false);
+	};
+
+	private void assertAttributeNameDocHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	attribu|teNameOnlyDocumentation=\"onlyDocumentation\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertAttributeValueDocHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	attributeNameOnlyDocumentation=\"o|nlyDocumentation\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertAttributeNameAppinfoHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	a|ttributeNameOnlyAppinfo=\"onlyAppinfo\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertAttributeValueAppinfoHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	attributeNameOnlyAppinfo=\"o|nlyAppinfo\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertAttributeNameBothHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	a|ttributeNameBoth=\"bothDocumentationAndAppinfo\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertAttributeValueBothHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	attributeNameBoth=\"b|othDocumentationAndAppinfo\">\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertElementDocHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	<e|lementOnlyDocumentation></elementOnlyDocumentation>\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertElementAppinfoHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml = 
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	<e|lementOnlyAppinfo></elementOnlyAppinfo>\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertElementBothHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml =
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	<e|lementBoth></elementBoth>\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertElementMultipleBothHover(String expected, SchemaDocumentationType docSource,
+			boolean markdownSupported) throws BadLocationException {
+		String xml =
+				"<root\n" +
+				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				"	<e|lementMultipleBoth></elementMultipleBoth>\n" +
+				"</root>\n";
+		assertHover(xml, expected, docSource, markdownSupported);
+	}
+
+	private void assertHover(String xml, String expected, SchemaDocumentationType docSource, boolean markdownSupported) throws BadLocationException {
+		String currSource = markdownSupported ? source : plainTextSource;
+		
+		if (expected != null) {
+			StringBuilder content = new StringBuilder(expected);
+			content.append(System.lineSeparator());
+			content.append(System.lineSeparator());
+			content.append(currSource);
+			expected = content.toString();
+		} else {
+			expected = currSource;
+		}
+
+		XMLAssert.assertHover(new XMLLanguageService(), xml, null, schemaPath,
+				expected, null, createSharedSettings(docSource, markdownSupported));
+	}
+
+	private SharedSettings createSharedSettings(SchemaDocumentationType docSource, boolean markdownSupported) {
+		SharedSettings settings = new SharedSettings();
+		if (markdownSupported) {
+			HoverCapabilities capabilities = new HoverCapabilities(Arrays.asList(MarkupKind.MARKDOWN), false);
+			settings.getHoverSettings().setCapabilities(capabilities);
+		}
+		settings.getPreferences()
+				.setShowSchemaDocumentationType(docSource);
+		return settings;
+	}
+
+	private static String getXMLSchemaFileURI(String schemaURI) throws MalformedURIException {
+		return XMLEntityManager.expandSystemId("xsd/" + schemaURI, "src/test/resources/test.xml", true).replace("///",
+				"/");
+	}
+
+	
+}

--- a/org.eclipse.lemminx/src/test/resources/xml-model/grammar.xml
+++ b/org.eclipse.lemminx/src/test/resources/xml-model/grammar.xml
@@ -1,4 +1,4 @@
-<?xml-model href="grammar.dtd" ?>
+<?xml-model href="../grammar.dtd" ?>
 <?xml-model href="grammar.xsd" ?>
 <grammar>
 	<from-xsd></from-xsd>	

--- a/org.eclipse.lemminx/src/test/resources/xsd/docAppinfo.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/docAppinfo.xsd
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema elementFormDefault='qualified' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+
+    <xs:simpleType name='attributeValue'>
+        <xs:restriction base='xs:string'>
+            <xs:enumeration value='onlyDocumentation'>
+                <xs:annotation>
+                    <xs:documentation>attribute value documentation</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value='onlyAppinfo'>
+                <xs:annotation>
+                    <xs:appinfo>attribute value appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value='bothDocumentationAndAppinfo'>
+                <xs:annotation>
+                    <xs:documentation>attribute value documentation</xs:documentation>
+                    <xs:appinfo>attribute value appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name='root'>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name='elementOnlyDocumentation'>
+                    <xs:annotation>
+                        <xs:documentation>element documentation</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name='elementOnlyAppinfo'>
+                    <xs:annotation>
+                        <xs:appinfo>element appinfo</xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name='elementBoth'>
+                    <xs:annotation>
+                        <xs:documentation>element documentation</xs:documentation>
+                        <xs:appinfo>element appinfo</xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name='elementMultipleDocuentation'>
+                    <xs:annotation>
+                        <xs:documentation>first element documentation</xs:documentation>
+                        <xs:documentation>second element documentation</xs:documentation>
+                        <xs:documentation>third element documentation</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name='elementMultipleAppinfo'>
+                    <xs:annotation>
+                        <xs:appinfo>first element appinfo</xs:appinfo>
+                        <xs:appinfo>second element appinfo</xs:appinfo>
+                        <xs:appinfo>third element appinfo</xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name='elementMultipleBoth'>
+                    <xs:annotation>
+                        <xs:documentation>first element documentation</xs:documentation>
+                        <xs:documentation>second element documentation</xs:documentation>
+                        <xs:documentation>third element documentation</xs:documentation>
+                        <xs:appinfo>first element appinfo</xs:appinfo>
+                        <xs:appinfo>second element appinfo</xs:appinfo>
+                        <xs:appinfo>third element appinfo</xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+
+            <xs:attribute name='attributeNameOnlyDocumentation' type='attributeValue' use='required'>
+                <xs:annotation>
+                    <xs:documentation>attribute name documentation</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name='attributeNameOnlyAppinfo' type='attributeValue' use='required'>
+                <xs:annotation>
+                    <xs:appinfo>attribute name appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name='attributeNameBoth' type='attributeValue' use='required'>
+                <xs:annotation>
+                    <xs:documentation>attribute name documentation</xs:documentation>
+                    <xs:appinfo>attribute name appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
Fixes #630 

This PR is accompanied by https://github.com/redhat-developer/vscode-xml/pull/260

Tests must be written.

Demo:

xml:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<root
attributeNameOnlyDocumentation='onlyDocumentation'
attributeNameOnlyAppinfo='onlyAppinfo'
attributeNameBoth='bothDocumentationAndAppinfo'
xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
xsi:noNamespaceSchemaLocation="test.xsd">
<elementOnlyDocumentation></elementOnlyDocumentation>
<elementOnlyAppinfo></elementOnlyAppinfo>
<elementBoth></elementBoth>
</root>
```

xsd:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<aa:schema xmlns:aa="http://www.w3.org/2001/XMLSchema">

  <aa:simpleType name="attributeValue">
    <aa:restriction base="aa:string">
      <aa:enumeration value="onlyDocumentation">
        <aa:annotation>
          <aa:documentation>attribute value documentation</aa:documentation>
        </aa:annotation>
      </aa:enumeration>
      <aa:enumeration value="onlyAppinfo">
        <aa:annotation>
          <aa:documentation>attribute value appinfo</aa:documentation>
        </aa:annotation>
      </aa:enumeration>
      <aa:enumeration value="bothDocumentationAndAppinfo">
        <aa:annotation>
          <aa:documentation>attribute value documentation</aa:documentation>
          <aa:appinfo>attribute value appinfo</aa:appinfo>
        </aa:annotation>
      </aa:enumeration>
    </aa:restriction>
  </aa:simpleType>

<aa:element name="root">
  <aa:complexType>
    <aa:sequence>
      <aa:element name="elementOnlyDocumentation">
        <aa:annotation>
          <aa:documentation>element only documentation element only documentation element only documentation element only documentation</aa:documentation>
        </aa:annotation>
      </aa:element>
      <aa:element name="elementOnlyAppinfo">
        <aa:annotation>
          <aa:appinfo>element only app info element only app info element only app info element only app info element only app info</aa:appinfo>
        </aa:annotation>
      </aa:element>
      <aa:element name="elementBoth">
        <aa:annotation>
          <aa:documentation>element only documentation element only documentation element only documentation element only documentation</aa:documentation>
          <aa:appinfo>element only app info element only app info element only app info element only app info element only app info</aa:appinfo>
        </aa:annotation>
      </aa:element>
    </aa:sequence>
   
    <aa:attribute name="attributeNameOnlyDocumentation" type="attributeValue" use="required">
      <aa:annotation>
        <aa:documentation>attribute name documentation</aa:documentation>
      </aa:annotation>
    </aa:attribute>
    <aa:attribute name="attributeNameOnlyAppinfo" type="attributeValue" use="required">
      <aa:annotation>
        <aa:appinfo>attribute name appinfo</aa:appinfo>
      </aa:annotation>
    </aa:attribute>
    <aa:attribute name="attributeNameBoth" type="attributeValue" use="required">
      <aa:annotation>
        <aa:documentation>attribute name documentation</aa:documentation>
        <aa:appinfo>attribute name appinfo</aa:appinfo>
      </aa:annotation>
    </aa:attribute>
  </aa:complexType>
</aa:element>

</aa:schema>
```
![demo gif](https://raw.githubusercontent.com/xorye/gifs/master/pr/hover_completion.gif?token=AE3CR5IYZEGXIQQE6TN5GR26Y2I74)


Signed-off-by: David Kwon <dakwon@redhat.com>