### PR TITLE
Correct highlight range for `cvc-complex-type.2.2`

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -47,6 +47,7 @@ import org.eclipse.lsp4j.Range;
  */
 public enum XMLSchemaErrorCode implements IXMLErrorCode {
 	cvc_complex_type_2_3("cvc-complex-type.2.3"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-3
+	cvc_complex_type_2_2("cvc-complex-type.2.2"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-2
 	cvc_complex_type_2_1("cvc-complex-type.2.1"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-1
 	cvc_complex_type_2_4_a("cvc-complex-type.2.4.a"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-4-a
 	cvc_complex_type_2_4_b("cvc-complex-type.2.4.b"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-4-b
@@ -128,6 +129,7 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		switch (code) {
 		case cvc_complex_type_2_3:
 			return XMLPositionUtility.selectFirstNonWhitespaceText(offset, document);
+		case cvc_complex_type_2_2:
 		case cvc_complex_type_2_4_a:
 		case cvc_complex_type_2_4_b:
 		case cvc_complex_type_2_4_c:

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -552,6 +552,31 @@ public class XMLSchemaDiagnosticsTest {
 											ca(diagnostic, te(5, 12, 5, 17, "AElement2"), te(5, 28, 5, 33, "AElement2")));
 	}
 
+	@Test
+	public void cvc_complex_type_2_2_withElement() throws Exception {
+		String xml =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+		"<int xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://integer\" xsi:schemaLocation=\"http://integer src/test/resources/xsd/namedInteger.xsd\">\n" + //
+		"    <int>42</int>\n" + //
+		"</int>";
+		Diagnostic diagnostic = d(1, 1, 1, 4, XMLSchemaErrorCode.cvc_complex_type_2_2,
+			"cvc-complex-type.2.2: Element 'int' must have no element [children], and the value must be valid.");
+		testDiagnosticsFor(xml, diagnostic);
+	}
+
+	@Test
+	public void cvc_complex_type_2_2_withText() throws Exception {
+		String xml =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+		"<int xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://integer\" xsi:schemaLocation=\"http://integer src/test/resources/xsd/namedInteger.xsd\">\n" + //
+		"    Bob</int>";
+		Diagnostic diagnosticBob = d(2, 4, 2, 7, XMLSchemaErrorCode.cvc_datatype_valid_1_2_1,
+			"Content of type 'integer' is expected.\n\nThe following content is not a valid type:\n 'Bob'\n\nCode:");
+		Diagnostic diagnostic_cvc_2_2 = d(1, 1, 1, 4, XMLSchemaErrorCode.cvc_complex_type_2_2,
+			"cvc-complex-type.2.2: Element 'int' must have no element [children], and the value must be valid.");
+		testDiagnosticsFor(xml, diagnosticBob, diagnostic_cvc_2_2);
+	}
+
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) {
 		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", expected);
 	}
@@ -563,4 +588,3 @@ public class XMLSchemaDiagnosticsTest {
 
 }
 
-	

--- a/org.eclipse.lemminx/src/test/resources/xsd/namedInteger.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/namedInteger.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="http://integer"
+  xmlns="http://integer"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+
+  <xs:element name="int">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:integer">
+          <xs:attribute name="name" type="xs:string"></xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
The opening tag for the node is now underlined and reports the issue. Fixes #631.

![LemminxIssue631Demo1](https://user-images.githubusercontent.com/22376627/82700874-12c41580-9c3d-11ea-877a-4a32dbd1833e.png)
![LemminxIssue631Demo2](https://user-images.githubusercontent.com/22376627/82700876-13f54280-9c3d-11ea-8753-44ba8dfef521.png)

Signed-off-by: David Thompson <davthomp@redhat.com>