### PR TITLE
Create EntityNotDeclared code action

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitExceededWarnings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/LimitExceededWarnings.java
@@ -113,7 +113,7 @@ public class LimitExceededWarnings {
 					Collections.singletonList("xml.symbols.maxItemsComputed"));
 			ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Info)
 					.withMessage(message).withCommands(Collections.singletonList(command));
-					client.actionableNotification(notification);
+			client.actionableNotification(notification);
 		} else {
 			// the open settings command is not supported by the client, display a simple
 			// message with LSP

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMAttr.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.dom;
 
 import java.util.List;
 
+import org.eclipse.lemminx.utils.StringUtils;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.TypeInfo;
 
@@ -209,52 +210,8 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 
 	public void setValue(String value, int start, int end) {
 		this.originalValue = value;
-		this.quotelessValue = convertToQuotelessValue(value);
+		this.quotelessValue = StringUtils.convertToQuotelessValue(value);
 		this.nodeAttrValue = start != -1 ? new AttrNameOrValue(start, end) : null;
-	}
-
-	/**
-	 * Returns a String of 'value' without surrounding quotes if it had them.
-	 * 
-	 * @param value
-	 * @return
-	 */
-	public static String convertToQuotelessValue(String value) {
-		if (value == null) {
-			return null;
-		}
-		if (value.isEmpty()) {
-			return value;
-		}
-		char quoteValue = value.charAt(0);
-		int start = quoteValue == '\"' || quoteValue == '\'' ? 1 : 0;
-		quoteValue = value.charAt(value.length() - 1);
-		int end = quoteValue == '\"' || quoteValue == '\'' ? value.length() - 1 : value.length();
-		return value.substring(start, end);
-	}
-
-	/**
-	 * Checks if 'value' has matching surrounding quotations.
-	 * 
-	 * @param value
-	 * @return
-	 */
-	public static boolean isQuoted(String value) {
-		if (value == null) {
-			return false;
-		}
-		if (value.isEmpty()) {
-			return false;
-		}
-		char quoteValueStart = value.charAt(0);
-		boolean start = quoteValueStart == '\"' || quoteValueStart == '\'' ? true : false;
-		if (start == false) {
-			return false;
-		}
-		char quoteValueEnd = value.charAt(value.length() - 1);
-		boolean end = (quoteValueEnd == '\"' || quoteValueEnd == '\'') && quoteValueEnd == quoteValueStart ? true
-				: false;
-		return end;
 	}
 
 	public DOMNode getNodeAttrValue() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocumentType.java
@@ -44,7 +44,8 @@ public class DOMDocumentType extends DTDDeclNode implements org.w3c.dom.Document
 		return this;
 	}
 
-	public String getContent() {
+	@Override
+	public String getTextContent() {
 		if (content == null) {
 			content = getOwnerDocument().getText().substring(getStart(), getEnd());
 		}
@@ -208,7 +209,11 @@ public class DOMDocumentType extends DTDDeclNode implements org.w3c.dom.Document
 	 * getStart() to make them relative to 'content'
 	 */
 	public String getSubstring(int start, int end) {
-		return getContent().substring(start - getStart(), end - getStart());
+		String textContent = getTextContent();
+		if (textContent == null) {
+			return null;
+		}
+		return textContent.substring(start - getStart(), end - getStart());
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DTDErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DTDErrorCode.java
@@ -22,6 +22,7 @@ import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.ElementDeclUnterminatedCodeAction;
+import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.EntityNotDeclaredCodeAction;
 import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
@@ -201,5 +202,6 @@ public enum DTDErrorCode implements IXMLErrorCode {
 
 	public static void registerCodeActionParticipants(Map<String, ICodeActionParticipant> codeActions) {
 		codeActions.put(ElementDeclUnterminated.getCode(), new ElementDeclUnterminatedCodeAction());
+		codeActions.put(EntityNotDeclared.getCode(), new EntityNotDeclaredCodeAction());
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/EntityNotDeclaredCodeAction.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.commons.TextDocument;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMDocumentType;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMNode;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.XMLBuilder;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Code action to fix EntityNotDeclaredCodeAction error.
+ * 
+ * Precondition: {@link Diagnostic#getMessage()} should be in this format:
+ * 
+ * "The entity \"ENTITY NAME\" was referenced, but not declared."
+ * 
+ */
+public class EntityNotDeclaredCodeAction implements ICodeActionParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(EntityNotDeclaredCodeAction.class.getName());
+
+	@Override
+	public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+			SharedSettings sharedSettings, IComponentProvider componentProvider) {
+
+		try {
+			String entityName = getEntityName(diagnostic, range, document);
+
+			if (entityName == null) {
+				return;
+			}
+			
+			DOMDocumentType docType = document.getDoctype();
+			if (docType != null) {
+
+				// Case 1: <!DOCTYPE exists
+				// Add <!ENTITY nbsp "entity-value"> in the subset.
+				// If the subset does not exist, add subset too
+				
+				// ie:
+				// <!DOCTYPE article [
+				// <!ELEMENT article (#PCDATA)>
+				// <!ENTITY nbsp "entity-value">
+				// ]>
+				addEntityCodeAction(entityName, diagnostic, document, sharedSettings, codeActions);
+			} else {
+				// Case 2: <!DOCTYPE does not exist
+				// Generate:
+				// <!DOCTYPE article [
+				//     <!ENTITY nbsp "entity-value">
+				// ]>
+				addDoctypeAndEntityCodeAction(entityName, diagnostic, document, sharedSettings, codeActions);
+			}
+		} catch (BadLocationException e) {
+			LOGGER.log(Level.SEVERE, "In EntityNotDeclaredCodeAction the DOMDocument offset(s) is at a BadLocation", e);
+		}
+	}
+
+	/**
+	 * Add a code action that inserts entity declaration to the
+	 * current DOCTYPE's internal subset
+	 * 
+	 * If the internal subset does not exist, the code action
+	 * inserts it as well
+	 * 
+	 * @param entityName  the entity name for the entity declaration
+	 * @param diagnostic  the code action's diagnostic
+	 * @param document    the DOMDocument
+	 * @param settings    the settings
+	 * @param codeActions the list of code actions
+	 * @throws BadLocationException
+	 */
+	private void addEntityCodeAction(String entityName, Diagnostic diagnostic, DOMDocument document,
+			SharedSettings settings, List<CodeAction> codeActions) throws BadLocationException {
+
+		DOMDocumentType docType = document.getDoctype();
+		Position docTypeEnd = document.positionAt(docType.getEnd());
+		Position insertPosition = getEntityInsertPosition(document);
+		String message = "Declare ENTITY " + entityName;
+		String delimiter = document.lineDelimiter(insertPosition.getLine());
+
+		XMLBuilder insertString = new XMLBuilder(settings, null, delimiter);
+
+		boolean hasInternalSubset = docType.getInternalSubset() != null;
+		if (!hasInternalSubset) {
+			String doctypeContent = docType.getTextContent();
+
+			if (!Character.isWhitespace(doctypeContent.charAt(doctypeContent.length() - 2))) {
+				// doctype ends with " >", "\n>", "\r\n>", etc.
+				insertString.startDoctypeInternalSubset();
+			} else {
+				insertString.startUnindentedDoctypeInternalSubset();
+			}
+			
+			if (insertPosition.getLine() > 0) {
+				insertString.linefeed();
+			}
+		} else if (insertPosition.getCharacter() != 0) {
+			insertString.linefeed(); // add the new entity in a new line
+		}
+
+		insertString.indent(1);
+		addEntityDeclaration(entityName, insertString);
+
+		if (docType.getInternalSubset() == null) {
+			insertString.linefeed().endDoctypeInternalSubset();
+		} else if (docTypeEnd.getLine() == insertPosition.getLine()) {
+			insertString.linefeed();
+		}
+
+		CodeAction action = CodeActionFactory.insert(message, insertPosition, insertString.toString(),
+				document.getTextDocument(), diagnostic);
+		codeActions.add(action);
+	}
+
+	/**
+	 * Add a code action that inserts the DOCTYPE declaration containing
+	 * an internal subset with an entity declaration
+	 * 
+	 * @param entityName  the entity name for the entity declaration
+	 * @param diagnostic  the code action's diagnostic
+	 * @param document    the DOMDocument
+	 * @param settings    the settings
+	 * @param codeActions the list of code actions
+	 * @throws BadLocationException
+	 */
+	private void addDoctypeAndEntityCodeAction(String entityName, Diagnostic diagnostic, DOMDocument document,
+			SharedSettings settings, List<CodeAction> codeActions) throws BadLocationException {
+		Position insertPosition = getDoctypeInsertPosition(document);
+
+		String delimiter = document.lineDelimiter(insertPosition.getLine());
+		String message = "Declare DOCTYPE containing ENTITY " + entityName;
+		DOMElement root = document.getDocumentElement();
+		if (root == null) {
+			return;
+		}
+
+		XMLBuilder insertString = new XMLBuilder(settings, null, delimiter);
+		if (insertPosition.getCharacter() > 0) {
+			insertString.linefeed();
+		}
+		insertString.startDoctype().addParameter(root.getTagName())
+				.startDoctypeInternalSubset().linefeed().indent(1);
+
+		addEntityDeclaration(entityName, insertString);
+
+		insertString.linefeed()
+				.endDoctypeInternalSubset().closeStartElement();
+		
+		Position rootStartPosition = document.positionAt(root.getStart());
+		if (insertPosition.getLine() == rootStartPosition.getLine()) {
+			insertString.linefeed();
+		}
+
+		CodeAction action = CodeActionFactory.insert(message, insertPosition, insertString.toString(),
+				document.getTextDocument(), diagnostic);
+		codeActions.add(action);
+	}
+
+	private Position getDoctypeInsertPosition(DOMDocument document) throws BadLocationException {
+		if (!document.hasProlog()) {
+			return new Position(0, 0);
+		}
+		int prologEnd = document.getChildren().get(0).getEnd();
+		return document.positionAt(prologEnd);
+	}
+
+	private Position getEntityInsertPosition(DOMDocument document) throws BadLocationException {
+		TextDocument textDocument = document.getTextDocument();
+		DOMDocumentType docType = document.getDoctype();
+
+		String subset = docType.getInternalSubset();
+		if (subset == null) { // subset ([]) does not exist
+			return textDocument.positionAt(docType.getEnd() - 1);
+		}
+
+		DOMNode lastChild = docType.getLastChild();
+		if (lastChild != null) {
+			return textDocument.positionAt(lastChild.getEnd());
+		}
+
+		// empty subset exists
+		String subsetValue = "[" + subset + "]";
+		int index = docType.getTextContent().indexOf(subsetValue);
+		if (index >= 0) { // if statement should always satisfy
+			index += subsetValue.length() - 1; // index of ]
+			return docType.getOwnerDocument().positionAt(index + docType.getStart());
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns entity name from the error range and error message
+	 * 
+	 * TODO: This code is a workaround until this issue is fixed:
+	 * https://github.com/microsoft/language-server-protocol/issues/887
+	 * 
+	 * @param diagnostic the diagnostic
+	 * @param range      the error range
+	 * @param doc        the DOM document
+	 * @return entity name from the error range and error message.
+	 * @throws BadLocationException
+	 */
+	private String getEntityName(Diagnostic diagnostic, Range range, DOMDocument doc) throws BadLocationException {
+		String name = doc.getText().substring(doc.offsetAt(range.getStart()), doc.offsetAt(range.getEnd()));
+		String removedAmpAndSemiColon = name.substring(1, name.length() - 1);
+		if (diagnostic.getMessage().indexOf("\"" + removedAmpAndSemiColon + "\"") < 0) {
+			return null;
+		}
+		return removedAmpAndSemiColon;
+	}
+
+	private void addEntityDeclaration(String entityName, XMLBuilder builder) {
+		builder.addDeclTagStart("ENTITY").addParameter(entityName)
+				.addParameter("\"entity-value\"").closeStartElement();
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.java
@@ -82,6 +82,9 @@ public class RootElementTypeMustMatchDoctypedeclCodeAction implements ICodeActio
 	 * The provided <code>message</code> must match this format:
 	 * ... root element "<current root name>", must match DOCTYPE ...
 	 * 
+	 * TODO: This code is a workaround until this issue is fixed:
+	 * https://github.com/microsoft/language-server-protocol/issues/887
+	 * 
 	 * @param message the message to extract the root name from
 	 * @return the current root name, extracted from <code>message</code>
 	 */
@@ -105,6 +108,9 @@ public class RootElementTypeMustMatchDoctypedeclCodeAction implements ICodeActio
 	 * 
 	 * The provided <code>message</code> must match this format:
 	 * ... DOCTYPE root "<root name>".
+	 * 
+	 * TODO: This code is a workaround until this issue is fixed:
+	 * https://github.com/microsoft/language-server-protocol/issues/887
 	 * 
 	 * @param message the message to extract the root name from
 	 * @return the DOCTYPE root name, extracted from <code>message</code>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
@@ -25,7 +25,6 @@ import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
 import org.eclipse.lemminx.extensions.dtd.contentmodel.CMDTDDocument.DTDElementInfo;
 import org.eclipse.lemminx.extensions.dtd.contentmodel.CMDTDDocument.DTDNodeInfo;
 import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
-import org.eclipse.lemminx.settings.SharedSettings;
 
 /**
  * DTD element declaration.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
@@ -439,4 +439,47 @@ public class StringUtils {
 		return -1;
 	}
 
+	/**
+	 * Checks if 'value' has matching surrounding quotations.
+	 * 
+	 * @param value
+	 * @return
+	 */
+	public static boolean isQuoted(String value) {
+		if (value == null) {
+			return false;
+		}
+		if (value.isEmpty()) {
+			return false;
+		}
+		char quoteValueStart = value.charAt(0);
+		boolean start = quoteValueStart == '\"' || quoteValueStart == '\'' ? true : false;
+		if (start == false) {
+			return false;
+		}
+		char quoteValueEnd = value.charAt(value.length() - 1);
+		boolean end = (quoteValueEnd == '\"' || quoteValueEnd == '\'') && quoteValueEnd == quoteValueStart ? true
+				: false;
+		return end;
+	}
+
+	/**
+	 * Returns a String of 'value' without surrounding quotes if it had them.
+	 * 
+	 * @param value
+	 * @return
+	 */
+	public static String convertToQuotelessValue(String value) {
+		if (value == null) {
+			return null;
+		}
+		if (value.isEmpty()) {
+			return value;
+		}
+		char quoteValue = value.charAt(0);
+		int start = quoteValue == '\"' || quoteValue == '\'' ? 1 : 0;
+		quoteValue = value.charAt(value.length() - 1);
+		int end = quoteValue == '\"' || quoteValue == '\'' ? value.length() - 1 : value.length();
+		return value.substring(start, end);
+	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
@@ -440,46 +440,39 @@ public class StringUtils {
 	}
 
 	/**
-	 * Checks if 'value' has matching surrounding quotations.
+	 * Returns <code>value</code> without surrounding quotes.
+	 * 
+	 * If <code>value</code> does not have matching surrounding quotes,
+	 * returns <code>value</code>.
 	 * 
 	 * @param value
-	 * @return
+	 * @return <code>value</code> without surrounding quotes.
 	 */
-	public static boolean isQuoted(String value) {
-		if (value == null) {
-			return false;
+	public static String convertToQuotelessValue(String value) {
+		if (value == null || !isQuoted(value)) {
+			return value;
 		}
-		if (value.isEmpty()) {
-			return false;
-		}
-		char quoteValueStart = value.charAt(0);
-		boolean start = quoteValueStart == '\"' || quoteValueStart == '\'' ? true : false;
-		if (start == false) {
-			return false;
-		}
-		char quoteValueEnd = value.charAt(value.length() - 1);
-		boolean end = (quoteValueEnd == '\"' || quoteValueEnd == '\'') && quoteValueEnd == quoteValueStart ? true
-				: false;
-		return end;
+
+		return value.substring(1, value.length() - 1);
 	}
 
 	/**
-	 * Returns a String of 'value' without surrounding quotes if it had them.
+	 * Returns true if <code>value</code> has matching surrounding quotes
+	 * and false otherwise.
 	 * 
 	 * @param value
-	 * @return
+	 * @return true if <code>value</code> has matching surrounding quotes.
 	 */
-	public static String convertToQuotelessValue(String value) {
-		if (value == null) {
-			return null;
+	public static boolean isQuoted(String value) {
+		if (value == null || value.length() < 2) {
+			return false;
 		}
-		if (value.isEmpty()) {
-			return value;
+
+		char quoteValueStart = value.charAt(0);
+		if (quoteValueStart != '\"' && quoteValueStart != '\'') {
+			return false;
 		}
-		char quoteValue = value.charAt(0);
-		int start = quoteValue == '\"' || quoteValue == '\'' ? 1 : 0;
-		quoteValue = value.charAt(value.length() - 1);
-		int end = quoteValue == '\"' || quoteValue == '\'' ? value.length() - 1 : value.length();
-		return value.substring(start, end);
+		char quoteValueEnd = value.charAt(value.length() - 1);
+		return quoteValueEnd == quoteValueStart;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -194,11 +194,11 @@ public class XMLBuilder {
 		if (originalValue != null) {
 			char quote = sharedSettings.getPreferences().getQuotationAsChar();
 
-			if (DOMAttr.isQuoted(originalValue)) {
+			if (StringUtils.isQuoted(originalValue)) {
 				if (sharedSettings.getFormattingSettings().getEnforceQuoteStyle() == EnforceQuoteStyle.preferred &&
 						originalValue.charAt(0) != quote) {
 
-					originalValue = DOMAttr.convertToQuotelessValue(originalValue);
+					originalValue = StringUtils.convertToQuotelessValue(originalValue);
 					xml.append(quote);
 					if (originalValue != null) {
 						xml.append(originalValue);
@@ -361,8 +361,12 @@ public class XMLBuilder {
 	}
 
 	public XMLBuilder addDeclTagStart(DTDDeclNode tag) {
-
 		xml.append("<!" + tag.getDeclType());
+		return this;
+	}
+
+	public XMLBuilder addDeclTagStart(String declTagName) {
+		xml.append("<!" + declTagName);
 		return this;
 	}
 
@@ -372,17 +376,21 @@ public class XMLBuilder {
 	}
 
 	public XMLBuilder addParameter(String parameter) {
-		xml.append(" " + parameter);
-		return this;
+		return addUnindentedParameter(" " + replaceQuotesIfNeeded(parameter));
 	}
 
 	public XMLBuilder addUnindentedParameter(String parameter) {
-		xml.append(parameter);
+		xml.append(replaceQuotesIfNeeded(parameter));
 		return this;
 	}
 
 	public XMLBuilder startDoctypeInternalSubset() {
 		xml.append(" [");
+		return this;
+	}
+
+	public XMLBuilder startUnindentedDoctypeInternalSubset() {
+		xml.append("[");
 		return this;
 	}
 
@@ -410,6 +418,17 @@ public class XMLBuilder {
 			i--;
 		}
 		return i > 0 && (this.xml.charAt(i) == '\r' || this.xml.charAt(i) == '\n');
+	}
+
+	private String replaceQuotesIfNeeded(String str) {
+		if (this.sharedSettings.getFormattingSettings().getEnforceQuoteStyle() != EnforceQuoteStyle.preferred) {
+			return str;
+		}
+		if (StringUtils.isQuoted(str)) {
+			String quote = this.sharedSettings.getPreferences().getQuotationAsString();
+			return quote + StringUtils.convertToQuotelessValue(str) + quote;
+		}
+		return str;
 	}
 
 	private boolean isJoinCommentLines() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -478,7 +478,12 @@ public class XMLAssert {
 
 	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, CodeAction... expected)
 			throws BadLocationException {
-		testCodeActionsFor(xml, diagnostic, null, expected);
+		testCodeActionsFor(xml, diagnostic, (String) null, expected);
+	}
+
+	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, SharedSettings settings, CodeAction... expected)
+			throws BadLocationException {
+		testCodeActionsFor(xml, diagnostic, null, settings, expected);
 	}
 
 	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath, CodeAction... expected)
@@ -487,7 +492,6 @@ public class XMLAssert {
 		settings.getFormattingSettings().setTabSize(4);
 		settings.getFormattingSettings().setInsertSpaces(false);
 		testCodeActionsFor(xml, diagnostic, catalogPath, settings, expected);
-
 	}
 
 	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath,

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -1760,6 +1760,60 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void testUseSingleQuotesLocalDTD() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.preferred);
+		String content = "<!DOCTYPE note SYSTEM \"note.dtd\">";
+		String expected = "<!DOCTYPE note SYSTEM \'note.dtd\'>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testUseSingleQuotesLocalDTDWithSubset() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.preferred);
+		String content = "<!DOCTYPE article [\n" + //
+				"  <!ENTITY AUTHOR \"John Doe\">\n" + //
+				"  <!ENTITY COMPANY \"JD Power Tools, Inc.\">\n" + //
+				"  <!ENTITY EMAIL \"jd@jd-tools.com\">\n" + //
+				"  <!ELEMENT E EMPTY>\n" + //
+				"  <!ATTLIST E WIDTH CDATA \"0\">\n" + //
+				"]>\n" + //
+				"\n" + //
+				"<root attr=\"hello\"></root>";
+		String expected = "<!DOCTYPE article [\n" + //
+				"  <!ENTITY AUTHOR \'John Doe\'>\n" + //
+				"  <!ENTITY COMPANY \'JD Power Tools, Inc.\'>\n" + //
+				"  <!ENTITY EMAIL \'jd@jd-tools.com\'>\n" + //
+				"  <!ELEMENT E EMPTY>\n" + //
+				"  <!ATTLIST E WIDTH CDATA \'0\'>\n" + //
+				"]>\n" + //
+				"\n" + //
+				"<root attr=\'hello\'></root>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testUseSingleQuotesDTDFile() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
+		settings.getFormattingSettings().setEnforceQuoteStyle(EnforceQuoteStyle.preferred);
+		String content = "<!ENTITY AUTHOR \"John Doe\">\n" + //
+				"<!ENTITY COMPANY \"JD Power Tools, Inc.\">\n" + //
+				"<!ENTITY EMAIL \"jd@jd-tools.com\">\n" + //
+				"<!ELEMENT E EMPTY>\n" + //
+				"<!ATTLIST E WIDTH CDATA \"0\">";
+		String expected = "<!ENTITY AUTHOR \'John Doe\'>\n" + //
+				"<!ENTITY COMPANY \'JD Power Tools, Inc.\'>\n" + //
+				"<!ENTITY EMAIL \'jd@jd-tools.com\'>\n" + //
+				"<!ELEMENT E EMPTY>\n" + //
+				"<!ATTLIST E WIDTH CDATA \'0\'>";
+		format(content, expected, settings, "test.dtd");
+	}
+
+	@Test
 	public void testDontFormatQuotesByDefault() throws BadLocationException {
 		SharedSettings settings = new SharedSettings();
 		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);


### PR DESCRIPTION
Fixes #532 

This PR adds a new code action to locally declare an undeclared entity.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<article>
   &nbsp;
</article>
```

Demo:
![demo](https://raw.githubusercontent.com/xorye/gifs/master/pr/entity_not_declared_ca_2.gif?token=AE3CR5J2JHMDBMFLSFLICM2622T52)

The codeaction works whether or not `<!DOCTYPE` is declared or not, and whether the internal subset `[]` exists or not.

Signed-off-by: David Kwon <dakwon@redhat.com>