### PR TITLE
Fixed error range for SemicolonRequiredInReference

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -31,6 +31,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.Root
 import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
+import org.eclipse.lemminx.utils.XMLPositionUtility.EntityReferenceRange;
 import org.eclipse.lsp4j.Range;
 
 /**
@@ -55,7 +56,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	the_element_type_lmsg("the-element-type-lmsg"), EqRequiredInXMLDecl, IllegalQName, InvalidCommentStart,
 	LessthanInAttValue, MarkupEntityMismatch, MarkupNotRecognizedInContent, NameRequiredInReference, OpenQuoteExpected,
 	PITargetRequired, PseudoAttrNameExpected, QuoteRequiredInXMLDecl, RootElementTypeMustMatchDoctypedecl,
-	SDDeclInvalid, SpaceRequiredBeforeEncodingInXMLDecl, SpaceRequiredBeforeStandalone, SpaceRequiredInPI,
+	SDDeclInvalid, SemicolonRequiredInReference, SpaceRequiredBeforeEncodingInXMLDecl, SpaceRequiredBeforeStandalone, SpaceRequiredInPI,
 	VersionInfoRequired, VersionNotSupported, XMLDeclUnterminated, CustomETag, PrematureEOF, DoctypeNotAllowed, NoMorePseudoAttributes;
 
 	private final String code;
@@ -166,6 +167,10 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 		case ETagRequired: {
 			String tag = getString(arguments[0]);
 			return XMLPositionUtility.selectChildEndTag(tag, offset, document);
+		}
+		case SemicolonRequiredInReference: {
+			EntityReferenceRange range = XMLPositionUtility.selectEntityReference(offset + 1, document, false);
+			return range != null ? range.getRange() : null;
 		}
 		case ContentIllegalInProlog: {
 			int startOffset = offset + 1;

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -492,4 +492,39 @@ public class XMLSyntaxDiagnosticsTest {
 		String xml = "<?xml version=\"5000.0\"encoding=\"UTF-8\"?>";
 		testDiagnosticsFor(xml, d(0, 14, 0, 22, XMLSyntaxErrorCode.VersionNotSupported));
 	}
+
+	@Test
+	public void testEntitySemicolonRequiredInReference() throws Exception {
+		String xml = "<!DOCTYPE root [\n" + //
+				"    <!ELEMENT root (#PCDATA)>\n" + //
+				"    <!ENTITY mdash \"&#x2014;\">\n" + //
+				"]>\n" + //
+				"<root>\n" + //
+				"    &mdash \n" + //
+				"</root>";
+		testDiagnosticsFor(xml, d(5, 4, 5, 10, XMLSyntaxErrorCode.SemicolonRequiredInReference));
+	}
+
+	@Test
+	public void testEntitySemicolonRequiredInReferenceOddSpacing() throws Exception {
+		String xml = "<!DOCTYPE root [\n" + //
+				"    <!ELEMENT root (#PCDATA)>\n" + //
+				"    <!ENTITY mdash \"&#x2014;\">\n" + //
+				"]>\n" + //
+				"<root>\n" + //
+				"    &mdash</root>";
+		testDiagnosticsFor(xml, d(5, 4, 5, 10, XMLSyntaxErrorCode.SemicolonRequiredInReference));
+	}
+
+	@Test
+	public void testEntitySemicolonRequiredInReferenceShortName() throws Exception {
+		String xml = "<!DOCTYPE root [\n" + //
+				"    <!ELEMENT root (#PCDATA)>\n" + //
+				"    <!ENTITY m \"&#x2014;\">\n" + //
+				"]>\n" + //
+				"<root>\n" + //
+				"    &m \n" + //
+				"</root>";
+		testDiagnosticsFor(xml, d(5, 4, 5, 6, XMLSyntaxErrorCode.SemicolonRequiredInReference));
+	}
 }


### PR DESCRIPTION
The error range now goes from the start of the ampersand to
the end of the entity name.

![SemicolonRequiredInReference](https://user-images.githubusercontent.com/22376627/83278837-312c9280-a1a2-11ea-86ca-5cfbda1b09a6.png)

Fixes #664

Signed-off-by: David Thompson <davthomp@redhat.com>