### PR TITLE
Range formatting inserts <null> when formatting inside DOCTYPE element

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -32,7 +32,6 @@ import org.eclipse.lemminx.dom.DOMText;
 import org.eclipse.lemminx.dom.DTDAttlistDecl;
 import org.eclipse.lemminx.dom.DTDDeclNode;
 import org.eclipse.lemminx.dom.DTDDeclParameter;
-import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLFormattingOptions.EmptyElements;
 import org.eclipse.lemminx.utils.XMLBuilder;
@@ -47,7 +46,6 @@ import org.eclipse.lsp4j.TextEdit;
 class XMLFormatter {
 
 	private static final Logger LOGGER = Logger.getLogger(XMLFormatter.class.getName());
-	private final XMLExtensionsRegistry extensionsRegistry;
 
 	private static class XMLFormatterDocument {
 		private final TextDocument textDocument;
@@ -62,6 +60,7 @@ class XMLFormatter {
 		private XMLBuilder xmlBuilder;
 		private int indentLevel;
 		private boolean linefeedOnNextWrite;
+		private boolean withinDTDContent;
 
 		/**
 		 * XML formatter document.
@@ -112,13 +111,17 @@ class XMLFormatter {
 			String fullText = this.textDocument.getText();
 			String rangeText = fullText.substring(this.startOffset, this.endOffset);
 
-			this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, this.textDocument.getUri(), null, false);
+			withinDTDContent = this.fullDomDocument.isWithinInternalDTD(startOffset);
+			String uri = this.textDocument.getUri();
+			if (withinDTDContent) {
+				uri += ".dtd";
+			}
+			this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, uri, null, false);
 
 			if (containsTextWithinStartTag()) {
 				adjustOffsetToStartTag();
 				rangeText = fullText.substring(this.startOffset, this.endOffset);
-				this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, this.textDocument.getUri(), null,
-						false);
+				this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, uri, null, false);
 			}
 
 			this.xmlBuilder = new XMLBuilder(this.sharedSettings, "",
@@ -161,8 +164,8 @@ class XMLFormatter {
 			this.rangeDomDocument = this.fullDomDocument;
 
 			Position startPosition = textDocument.positionAt(startOffset);
-			this.xmlBuilder = new XMLBuilder(this.sharedSettings,
-					"", textDocument.lineDelimiter(startPosition.getLine()));
+			this.xmlBuilder = new XMLBuilder(this.sharedSettings, "",
+					textDocument.lineDelimiter(startPosition.getLine()));
 		}
 
 		private void enlargePositionToGutters(Position start, Position end) throws BadLocationException {
@@ -176,9 +179,10 @@ class XMLFormatter {
 		}
 
 		private int getStartingIndentLevel() throws BadLocationException {
-
+			if (withinDTDContent) {
+				return 1;
+			}
 			DOMNode startNode = this.fullDomDocument.findNodeAt(this.startOffset);
-
 			if (startNode.isOwnerDocument()) {
 				return 0;
 			}
@@ -271,9 +275,9 @@ class XMLFormatter {
 			}
 
 			if (node.getNodeType() != DOMNode.DOCUMENT_NODE) {
-				boolean doLineFeed = !node.getOwnerDocument().isDTD() &&
-						!(node.isComment() && ((DOMComment) node).isCommentSameLineEndTag()) &&
-						(!node.isText() || (!((DOMText) node).isWhitespace() && ((DOMText) node).hasSiblings()));
+				boolean doLineFeed = !node.getOwnerDocument().isDTD()
+						&& !(node.isComment() && ((DOMComment) node).isCommentSameLineEndTag())
+						&& (!node.isText() || (!((DOMText) node).isWhitespace() && ((DOMText) node).hasSiblings()));
 
 				if (this.indentLevel > 0 && doLineFeed) {
 					// add new line + indent
@@ -374,7 +378,7 @@ class XMLFormatter {
 				linefeedOnNextWrite = true;
 
 			} else {
-				formatDTD(documentType, 0, this.endOffset, this.xmlBuilder);
+				formatDTD(documentType, this.indentLevel, this.endOffset, this.xmlBuilder);
 			}
 		}
 
@@ -633,7 +637,8 @@ class XMLFormatter {
 					this.xmlBuilder.trimFinalNewlines();
 				}
 
-				if (this.sharedSettings.getFormattingSettings().isInsertFinalNewline() && !this.xmlBuilder.isLastLineEmptyOrWhitespace()) {
+				if (this.sharedSettings.getFormattingSettings().isInsertFinalNewline()
+						&& !this.xmlBuilder.isLastLineEmptyOrWhitespace()) {
 					this.xmlBuilder.linefeed();
 				}
 			}
@@ -679,10 +684,6 @@ class XMLFormatter {
 		}
 	}
 
-	public XMLFormatter(XMLExtensionsRegistry extensionsRegistry) {
-		this.extensionsRegistry = extensionsRegistry;
-	}
-
 	/**
 	 * Returns a List containing a single TextEdit, containing the newly formatted
 	 * changes of the document.
@@ -692,11 +693,9 @@ class XMLFormatter {
 	 * @param sharedSettings settings containing formatting preferences
 	 * @return List containing a TextEdit with formatting changes
 	 */
-	public List<? extends TextEdit> format(TextDocument textDocument, Range range,
-			SharedSettings sharedSettings) {
+	public List<? extends TextEdit> format(TextDocument textDocument, Range range, SharedSettings sharedSettings) {
 		try {
-			XMLFormatterDocument formatterDocument = new XMLFormatterDocument(textDocument, range,
-					sharedSettings);
+			XMLFormatterDocument formatterDocument = new XMLFormatterDocument(textDocument, range, sharedSettings);
 			return formatterDocument.format();
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "Formatting failed due to BadLocation", e);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLLanguageService.java
@@ -28,7 +28,6 @@ import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLCodeLensSettings;
 import org.eclipse.lemminx.settings.XMLFoldingSettings;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lemminx.settings.XMLSymbolSettings;
 import org.eclipse.lemminx.uriresolver.CacheResourceDownloadingException;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
@@ -84,7 +83,7 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 	private final XMLRename rename;
 
 	public XMLLanguageService() {
-		this.formatter = new XMLFormatter(this);
+		this.formatter = new XMLFormatter();
 		this.highlighting = new XMLHighlighting(this);
 		this.symbolsProvider = new XMLSymbolsProvider(this);
 		this.completions = new XMLCompletions(this);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -284,6 +284,33 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void rangeSelectEntityNoIndent() throws BadLocationException {
+		String content = "<?xml version='1.0' standalone='no'?>\r\n" +  //
+				"<!DOCTYPE root-element [\r\n" + //
+				"|<!ENTITY local \"LOCALLY DECLARED ENTITY\">|\r\n" +  //
+				"]>";		
+		String expected = "<?xml version='1.0' standalone='no'?>\r\n" +  //
+				"<!DOCTYPE root-element [\r\n" + //
+				"  <!ENTITY local \"LOCALLY DECLARED ENTITY\">\r\n" +  //
+				"]>";
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectEntityWithIndent() throws BadLocationException {
+		String content = "<?xml version='1.0' standalone='no'?>\r\n" +  //
+				"<!DOCTYPE root-element [\r\n" + //
+				"  |<!ENTITY local \"LOCALLY DECLARED ENTITY\">|\r\n" +  //
+				"]>";		
+		String expected = "<?xml version='1.0' standalone='no'?>\r\n" +  //
+				"<!DOCTYPE root-element [\r\n" + //
+				"  <!ENTITY local \"LOCALLY DECLARED ENTITY\">\r\n" +  //
+				"]>";
+		format(content, expected);
+	}
+
+	
+	@Test
 	public void testProlog() throws BadLocationException {
 		String content = "<?xml version=   \"1.0\"       encoding=\"UTF-8\"  ?>\r\n";
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
@@ -2470,7 +2497,6 @@ public class XMLFormatterTest {
 		String expected = "<a attr=\"\'\" attr2=\'\"\' />";
 		format(content, expected, settings);
 	}
-
 
 	@Test
 	public void testTemplate() throws BadLocationException {


### PR DESCRIPTION
Range formatting inserts <null> when formatting inside DOCTYPE element

Fixes #682

Signed-off-by: azerr <azerr@redhat.com>