### PR TITLE
Add dummy attribute when parser reaches attribute value when attr==null

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -233,9 +233,11 @@ public class DOMParser {
 
 			case AttributeValue: {
 				String value = scanner.getTokenText();
-				if (curr.hasAttributes() && attr != null) {
-					attr.setValue(value, scanner.getTokenOffset(), scanner.getTokenOffset() + value.length());
+				if (attr == null) {
+					attr = new DOMAttr(null, scanner.getTokenOffset(), scanner.getTokenOffset() + value.length(), curr);
+					curr.setAttributeNode(attr);
 				}
+				attr.setValue(value, scanner.getTokenOffset(), scanner.getTokenOffset() + value.length());
 				pendingAttribute = null;
 				attr = null;
 				curr.end = scanner.getTokenEnd();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/utils/XMLGenerator.java
@@ -174,7 +174,7 @@ public class XMLGenerator {
 			if (attributesSize != 1) {
 				xml.addAttribute(attributeDeclaration.getName(), value, level, true);
 			} else {
-				xml.addSingleAttribute(attributeDeclaration.getName(), value, true);
+				xml.addSingleAttribute(attributeDeclaration.getName(), value, true, true);
 			}
 		}
 		return snippetIndex;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -438,7 +438,7 @@ class XMLFormatter {
 					List<DOMAttr> attributes = element.getAttributeNodes();
 					if (hasSingleAttributeInFullDoc(element)) {
 						DOMAttr singleAttribute = attributes.get(0);
-						xmlBuilder.addSingleAttribute(singleAttribute.getName(), singleAttribute.getOriginalValue());
+						xmlBuilder.addSingleAttribute(singleAttribute.getName(), singleAttribute.getOriginalValue(), false, singleAttribute.hasDelimiter());
 					} else {
 						for (DOMAttr attr : attributes) {
 							xmlBuilder.addAttribute(attr, this.indentLevel);

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -99,10 +99,6 @@ public class XMLBuilder {
 		return this;
 	}
 
-	public XMLBuilder addSingleAttribute(String name, String value) {
-		return addSingleAttribute(name, value, false);
-	}
-
 	/**
 	 * Used when only one attribute is being added to a node.
 	 * 
@@ -110,12 +106,13 @@ public class XMLBuilder {
 	 * 
 	 * @param name               attribute name
 	 * @param value              attribute value
-	 * @param surroundWithQuotes true if quotes should be added around originalValue
+	 * @param surroundWithQuotes true if quotes should be added around value
+	 * @param addDelimiter       true if delimiter should be added
 	 * @return this XML Builder
 	 */
-	public XMLBuilder addSingleAttribute(String name, String value, boolean surroundWithQuotes) {
+	public XMLBuilder addSingleAttribute(String name, String value, boolean surroundWithQuotes, boolean addDelimiter) {
 		appendSpace();
-		addAttributeContents(name, true, value, surroundWithQuotes);
+		addAttributeContents(name, addDelimiter, value, surroundWithQuotes);
 		return this;
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -1709,11 +1709,9 @@ public class XMLFormatterTest {
 
 	@Test
 	public void testAttValueOnlyStartQuote() throws BadLocationException {
-		SharedSettings settings = new SharedSettings();
-		settings.getPreferences().setQuoteStyle(QuoteStyle.singleQuotes);
 		String content = "<a name = \"> </a>";
 		String expected = "<a name=\"> </a>";
-		format(content, expected, settings);
+		format(content, expected);
 	}
 
 	@Test
@@ -2216,6 +2214,76 @@ public class XMLFormatterTest {
 				"   \r\n";
 		format(content, expected, settings);
 	}
+
+	@Test
+	public void testFormatLoneQuoteProlog() throws BadLocationException {
+		String content = "<?xml version=\"1.0\" e\'ncoding=\"UTF-8\"?>\n" + //
+				"<foo><bar></bar></foo>";
+		String expected = "<?xml version=\"1.0\" e\'ncoding=\"UTF-8\"?>\n" + //
+		"<foo><bar></bar></foo>?>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteProlog2() throws BadLocationException {
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\" \"?><foo><bar></bar></foo>";
+		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" \"?><foo><bar></bar></foo>?>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTag() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<fo\"o><bar></bar></foo>";
+		String expected = "<fo \"o><bar></bar></foo>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<fo\"o attr=\"value\"><bar></bar></foo>";
+		String expected = "<fo \"o attr=\" value\"><bar></bar></foo>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr2() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<foo attr=\"value\" \"><bar></bar></foo>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr3() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<foo at\"tr=\"value\"><bar></bar></foo>";
+		String expected = "<foo at\"tr=\" value\"><bar></bar></foo>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr4() throws BadLocationException {
+		String content = "<foo>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"  <ba\'r></bar>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"</foo>";
+		String expected = "<foo>\n" + //
+				"  <foobar>\n" + //
+				"    <foobar2></foobar2>\n" + //
+				"  </foobar>\n" + //
+				"  <ba \'r></bar>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"</foo>";
+		format(content, expected);
+	}
+
 
 	// ------------ Tests with format empty elements settings
 


### PR DESCRIPTION
Fixes #679, but I'm afraid this type of bug can be very complex. This PR does not cover all cases, as I wanted to minimize the changes in DOMParser.

In the case presented in #679, the reason why the content after the quote disappears is because the parser believes that that content is part of an attribute value. But, because there is no attribute name and delimiter, the scanner reads the quote and onwards, until it finds a matching quote.

Known problems in this PR:
Quote after the question mark in the prolog:
![](https://raw.githubusercontent.com/xorye/gifs/master/pr/format_issues/prolog_question_mark.gif?token=AE3CR5NSQZTGOA4JHJHXMJ264KKBA)

Signed-off-by: David Kwon <dakwon@redhat.com>