### PR TITLE
Prevent formatting when invalid content exists inside tags

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMNode.java
@@ -64,6 +64,7 @@ public abstract class DOMNode implements Node, DOMRange {
 
 	private XMLNamedNodeMap<DOMAttr> attributeNodes;
 	private XMLNodeList<DOMNode> children;
+	private boolean containsUnknownContent = false;
 
 	final int start; // |<root> </root>
 	int end; // <root> </root>|
@@ -759,7 +760,7 @@ public abstract class DOMNode implements Node, DOMRange {
 	 */
 	@Override
 	public String getTextContent() throws DOMException {
-		return getNodeValue();
+		return getOwnerDocument().getText().substring(start, end);
 	}
 
 	@Override
@@ -841,6 +842,26 @@ public abstract class DOMNode implements Node, DOMRange {
 	@Override
 	public Object setUserData(String arg0, Object arg1, UserDataHandler arg2) {
 		return null;
+	}
+
+	/**
+	 * Returns true if this DOMNode contains unknown content and
+	 * false otherwise
+	 * 
+	 * @return true if this DOMNode contains unknown content and
+	 * false otherwise
+	 */
+	public boolean isContainsUnknownContent() {
+		return containsUnknownContent;
+	}
+
+	/**
+	 * Set containsMalformedContent
+	 *
+	 * @param containsMalformedContent
+	 */
+	public void setContainsUnknownContent(boolean containsUnknownContent) {
+		this.containsUnknownContent = containsUnknownContent;
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -96,6 +96,10 @@ public class DOMParser {
 			}
 			switch (token) {
 			case StartTagOpen: {
+				if (curr instanceof DOMProcessingInstruction) {
+					// Processing instruction should not have child elements
+					curr.setContainsUnknownContent(true);
+				}
 				if(!curr.isClosed() && curr.parent != null) {
 					//The next node's parent (curr) is not closed at this point
 					//so the node's parent (curr) will have its end position updated
@@ -235,6 +239,8 @@ public class DOMParser {
 				String value = scanner.getTokenText();
 				if (curr.hasAttributes() && attr != null) {
 					attr.setValue(value, scanner.getTokenOffset(), scanner.getTokenOffset() + value.length());
+				} else {
+					curr.setContainsUnknownContent(true);
 				}
 				pendingAttribute = null;
 				attr = null;
@@ -649,6 +655,9 @@ public class DOMParser {
 				break;
 			}
 
+			case Unknown: {
+				curr.setContainsUnknownContent(true);
+			}
 			default:
 			}
 			token = scanner.scan();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
@@ -246,8 +246,9 @@ public class XMLScanner implements Scanner {
 			stream.advanceUntilCharsOrNewTag(_QMA, _RAN); // ?>
 			if (stream.peekChar() == _LAN) {
 				state = ScannerState.WithinContent; // TODO: check if EOF causes issues
+				return internalScan();
 			}
-			return internalScan();
+			return finishToken(offset, TokenType.Unknown);
 
 		case WithinPI:
 			if (stream.skipWhitespace()) {
@@ -334,11 +335,11 @@ public class XMLScanner implements Scanner {
 				state = ScannerState.WithinContent;
 				return finishToken(offset, TokenType.EndTagClose);
 			}
-			if (stream.advanceUntilChar(_LAN)) { // <
+			if (stream.peekChar() == _LAN) { // <
 				state = ScannerState.WithinContent;
 				return internalScan();
 			}
-			return finishToken(offset, TokenType.Whitespace);
+			return finishToken(offset, TokenType.Unknown);
 
 		case AfterOpeningStartTag:
 			if (hasNextElementName()) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -246,7 +246,7 @@ public class XMLBuilder {
 	 * <code>delimiter</code>
 	 * 
 	 * @param text                the proposed text to add
-	 * @param isWhitespaceContent whether or not the text contains whitespace content
+	 * @param isWhitespaceContent whether or not the text contains only whitespace content
 	 * @param hasSiblings         whether or not the corresponding text node has siblings
 	 * @param delimiter           line delimiter
 	 * @return this XMLBuilder with <code>text</code> added depending on

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2217,6 +2217,132 @@ public class XMLFormatterTest {
 		format(content, expected, settings);
 	}
 
+	@Test
+	public void testFormatLoneQuoteProlog() throws BadLocationException {
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?\">\n" + //
+				"<foo><bar></bar></foo>";
+		String expected = content;
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteProlog2() throws BadLocationException {
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"\"?>\n" + //
+				"<foo><bar></bar></foo>";
+		String expected = content;
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatPrologMissingClosingTag() throws BadLocationException {
+		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?\n" + //
+				"<foo><bar></bar></foo>";
+		String expected = content;
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTag() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<fo\"o><bar></bar></foo>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<fo\"o attr=\"value\"><bar></bar></foo>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr2() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<foo attr=\"value\" \"><bar></bar></foo>";
+		String expected = content;
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr3() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(false);
+		String content = "<foo at\"tr=\"value\"><bar></bar></foo>";
+		String expected = "<foo at\"tr=\" value\"><bar></bar></foo>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testFormatLoneQuoteStartTagWithAttr4() throws BadLocationException {
+		String content = "<foo>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"  <ba\'r></bar>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"</foo>";
+		String expected = "<foo>\n" + //
+				"  <foobar>\n" + //
+				"    <foobar2></foobar2>\n" + //
+				"  </foobar>\n" + //
+				"  <ba\'r></bar>\n" + //
+				"  <foobar><foobar2></foobar2></foobar>\n" + //
+				"</foo>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteEndTagWithAttr() throws BadLocationException {
+		String content = "<foo>\n" + //
+				"<bar></b\'ar>\n" + //
+				"  text content\n" + //
+				"  <foobar  ></foobar>\n" + //
+				"</foo>";
+		
+		String expected = "<foo>\n" + //
+				"  <bar>\n" + //
+				"    </b\'ar>\n" + //
+				"  text content\n" + //
+				"  <foobar  ></foobar>\n" + //
+				"</foo>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteEndTagWithAttr2() throws BadLocationException {
+		String content = "<foo>\n" + //
+				"<bar></bar\">\n" + //
+				"  text content\n" + //
+				"  <foobar  ></foobar>\n" + //
+				"</foo>";
+		
+		String expected = "<foo>\n" + //
+				"  <bar></bar\">\n" + //
+				"  text content\n" + //
+				"  <foobar  ></foobar>\n" + //
+				"</foo>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testFormatLoneQuoteEndTagWithAttr3() throws BadLocationException {
+		String content = "<foo>\n" +
+				"<foo></foo\"bar>\n" +
+				"  text content\n" +
+				"  <bar></bar>\n" +
+				"</foo>";
+		
+		String expected = "<foo>\n" +
+				"  <foo></foo\"bar>\n" +
+				"  text content\n" +
+				"  <bar></bar>\n" +
+				"</foo>";
+		format(content, expected);
+	}
+
 	// ------------ Tests with format empty elements settings
 
 	@Test


### PR DESCRIPTION
Fixes #679 and #675 

In `DOMNode`, his PR introduces a new boolean property: `containsUnknownContent`. The formatter will read this value and will abort formatting when it reaches a `DOMNode` for which `containsUnknownContent` is true.

Content that comes before the element, will still be formatted:
![demo](https://raw.githubusercontent.com/xorye/gifs/e96303da3aed6f276eec9f95e87860c6b1c6c168/pr/format_pr/1.gif?token=AE3CR5NOTYJZKROWXZMEOVC64ZRSE)

The main goal of this PR is to not lose information when formatting.

Signed-off-by: David Kwon <dakwon@redhat.com>