### PR TITLE
Added document links for xsi:schemaLocation

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMDocument.java
@@ -335,7 +335,7 @@ public class DOMDocument extends DOMNode implements Document {
 		if (attr == null) {
 			return null;
 		}
-		return new SchemaLocation(root.getOwnerDocument().getDocumentURI(), attr);
+		return new SchemaLocation(attr);
 	}
 
 	private static NoNamespaceSchemaLocation createNoNamespaceSchemaLocation(DOMNode root,

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocationHint.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocationHint.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2020 Red Hat Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.dom;
+
+/**
+ * Represents one of the location hints provided in an xsi:schemaLocation
+ * attribute.
+ */
+public class SchemaLocationHint implements DOMRange {
+
+	private final int start, end;
+
+	private final String hint;
+
+	private final SchemaLocation parent;
+
+	/**
+	 * Create a new SchemaLocationHint object that represents one of the location
+	 * hints given in the parent <code>SchemaLocation</code>.
+	 *
+	 * @param start  The offset from the beginning of the document where this
+	 *               location hint starts
+	 * @param end    The offset from the beginning of the document where this
+	 *               location hint ends
+	 * @param hint   The hint to the location of a schema (A URI that points to a
+	 *               schema)
+	 * @param parent The <code>SchemaLocation</code> in which this hint was given
+	 */
+	public SchemaLocationHint(int start, int end, String hint, SchemaLocation parent) {
+		this.start = start;
+		this.end = end;
+		this.hint = hint;
+		this.parent = parent;
+	}
+
+	/**
+	 * Returns the location hint that this SchemaLocationHint represents
+	 *
+	 * @return The location hint, a URI to a schema, as a String
+	 */
+	public String getHint() {
+		return this.hint;
+	}
+
+	/**
+	 * Returns the offset from the beginning of the document where this location
+	 * hint starts
+	 * 
+	 * @return The offset from the beginning of the document where this location
+	 *         hint starts
+	 */
+	@Override
+	public int getStart() {
+		return this.start;
+	}
+
+	/**
+	 * Returns the offset from the beginning of the document where this location
+	 * hint ends
+	 * 
+	 * @return The offset from the beginning of the document where this location
+	 *         hint ends
+	 */
+	@Override
+	public int getEnd() {
+		return this.end;
+	}
+
+	@Override
+	public DOMDocument getOwnerDocument() {
+		return parent.getAttr().getOwnerDocument();
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelDocumentLinkParticipant.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.contentmodel.participants;
 
 import static org.eclipse.lemminx.utils.XMLPositionUtility.createDocumentLink;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.xerces.impl.XMLEntityManager;
@@ -23,18 +24,21 @@ import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMDocumentType;
 import org.eclipse.lemminx.dom.DOMRange;
 import org.eclipse.lemminx.dom.NoNamespaceSchemaLocation;
+import org.eclipse.lemminx.dom.SchemaLocation;
+import org.eclipse.lemminx.dom.SchemaLocationHint;
 import org.eclipse.lemminx.dom.XMLModel;
 import org.eclipse.lemminx.services.extensions.IDocumentLinkParticipant;
 import org.eclipse.lsp4j.DocumentLink;
 
 /**
  * Document link for :
- * 
+ *
  * <ul>
  * <li>XML Schema xsi:noNamespaceSchemaLocation</li>
  * <li>DTD SYSTEM (ex : <!DOCTYPE root-element SYSTEM "./extended.dtd" )</li>
+ * <li>XML Schema xsi:schemaLocation</li>
  * </ul>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -88,11 +92,27 @@ public class ContentModelDocumentLinkParticipant implements IDocumentLinkPartici
 				}
 			}
 		}
+		// Doc link for xsi:schemaLocation
+		SchemaLocation schemaLocation = document.getSchemaLocation();
+		if (schemaLocation != null) {
+			try {
+				Collection<SchemaLocationHint> schemaLocationHints = schemaLocation.getSchemaLocationHints();
+				String location;
+				for (SchemaLocationHint schemaLocationHint : schemaLocationHints) {
+					location = getResolvedLocation(document.getDocumentURI(), schemaLocationHint.getHint());
+					if (location != null) {
+						links.add(createDocumentLink(schemaLocationHint, location));
+					}
+				}
+			} catch (BadLocationException e) {
+				// Do nothing
+			}
+		}
 	}
 
 	/**
 	 * Returns the expanded system location
-	 * 
+	 *
 	 * @return the expanded system location
 	 */
 	private static String getResolvedLocation(String documentURI, String location) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDocumentLinkTest.java
@@ -35,4 +35,83 @@ public class XMLSchemaDocumentLinkTest {
 		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/Format.xml",
 				dl(r(1, 100, 1, 114), "src/test/resources/xsd/Format.xsd"));
 	}
+
+	@Test
+	public void singleSchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
+				"<Configuration xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://example.org/schema/format xsd/Format.xsd\">\r\n"
+				+ //
+				"  <ViewDefinitions>\r\n" + //
+				"    <View>";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/Format.xml",
+				dl(r(1, 122, 1, 136), "src/test/resources/xsd/Format.xsd"));
+	}
+
+	@Test
+	public void manySchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<beans xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //
+				"       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"       xmlns:camel=\"http://camel.apache.org/schema/spring\"\r\n" + //
+				"       xmlns:cxf=\"http://camel.apache.org/schema/cxf\"\r\n" + //
+				"       xsi:schemaLocation=\"http://www.example.org/schema/beans xsd/spring-beans.xsd http://www.example.org/schema/spring xsd/camel-spring.xsd http://www.example.org/schema/salad xsd/salad.xsd\">\r\n";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/beans-and-salad.xml",
+				dl(r(5, 63, 5, 83), "src/test/resources/xsd/spring-beans.xsd"),
+				dl(r(5, 178, 5, 191), "src/test/resources/xsd/salad.xsd"),
+				dl(r(5, 121, 5, 141), "src/test/resources/xsd/camel-spring.xsd")
+				);
+	}
+
+	@Test
+	public void lineBreakManySchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<beans xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //
+				"       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"       xmlns:camel=\"http://camel.apache.org/schema/spring\"\r\n" + //
+				"       xmlns:cxf=\"http://camel.apache.org/schema/cxf\"\r\n" + //
+				"       xsi:schemaLocation=\"\r\n" + //
+				"         http://www.example.org/schema/beans xsd/spring-beans.xsd\r\n" + //
+				"         http://www.example.org/schema/spring xsd/camel-spring.xsd\r\n" + //
+				"         http://www.example.org/schema/salad xsd/salad.xsd\">\r\n";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/beans-and-salad.xml",
+				dl(r(6, 45, 6, 65), "src/test/resources/xsd/spring-beans.xsd"),
+				dl(r(8, 45, 8, 58), "src/test/resources/xsd/salad.xsd"),
+				dl(r(7, 46, 7, 66), "src/test/resources/xsd/camel-spring.xsd"));
+	}
+
+	@Test
+	public void blankSchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+		"<beans xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //
+		"       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+		"       xmlns:camel=\"http://camel.apache.org/schema/spring\"\r\n" + //
+		"       xmlns:cxf=\"http://camel.apache.org/schema/cxf\"\r\n" + //
+		"       xsi:schemaLocation=\"\" />";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/xsd/bean.xml");
+
+	}
+
+	@Test
+	public void incompleteSchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
+				"<Configuration xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://example.org/schema/format\">\r\n"
+				+ //
+				"  <ViewDefinitions>\r\n" + //
+				"    <View>";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/Format.xml");
+	}
+
+	@Test
+	public void secondTokenIsIncompleteSchemaLocation() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+		"<beans xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //
+		"       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+		"       xmlns:camel=\"http://camel.apache.org/schema/spring\"\r\n" + //
+		"       xmlns:cxf=\"http://camel.apache.org/schema/cxf\"\r\n" + //
+		"       xsi:schemaLocation=\"\r\n" + //
+		"         http://www.example.org/schema/beans xsd/spring-beans.xsd\r\n" + //
+		"         http://www.example.org/schema/spring\" />\r\n";
+		XMLAssert.testDocumentLinkFor(xml, "src/test/resources/beans-and-salad.xml",
+				dl(r(6, 45, 6, 65), "src/test/resources/xsd/spring-beans.xsd"));
+	}
 }


### PR DESCRIPTION
Every second token for the value of xsi:schemaLocation is turned into a
document link to the referenced schema file.

Closes #666

Signed-off-by: David Thompson <davthomp@redhat.com>