### PR TITLE
Fix line break being incorrectly added when preserveAttrLineBreaks is

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -547,10 +547,10 @@ class XMLFormatter {
 		private void formatAttributes(DOMElement element) throws BadLocationException {
 			List<DOMAttr> attributes = element.getAttributeNodes();
 			boolean isSingleElement = hasSingleAttributeInFullDoc(element);
-			DOMNode prev = element;
+			int prevOffset = element.getStart();
 			for (DOMAttr attr : attributes) {
 				if (this.sharedSettings.getFormattingSettings().isPreserveAttrLineBreaks()
-						&& !isSameLine(prev.getStart(), attr.getNodeAttrName().getStart())) {
+						&& !isSameLine(prevOffset, attr.getStart())) {
 					xmlBuilder.linefeed();
 					xmlBuilder.indent(this.indentLevel + 1);
 					xmlBuilder.addSingleAttribute(attr, false, false);
@@ -559,7 +559,7 @@ class XMLFormatter {
 				} else {
 					xmlBuilder.addAttribute(attr, this.indentLevel);
 				}
-				prev = attr.getNodeAttrName();
+				prevOffset = attr.getEnd();
 			}
 		}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2594,6 +2594,31 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void preserveAttributeLineBreaks5() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setPreserveAttrLineBreaks(true);
+		String content = "<a attr=\"value\" attr=\"value\"\n" + //
+				"  attr=\n" + //
+				"  \"value\" attr=\"value\"></a>";
+		String expected = "<a attr=\"value\" attr=\"value\"\n" + //
+				"  attr=\"value\" attr=\"value\"></a>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void preserveAttributeLineBreaksMissingValue() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setPreserveAttrLineBreaks(true);
+		String content = "<a attr= attr=\"value\"\n" + //
+				"  attr=\n" + //
+				"   attr=\"value\"></a>";
+		String expected = "<a attr= attr=\"value\"\n" + //
+				"  attr=\n" + //
+				"  attr=\"value\"></a>";
+		format(content, expected, settings);
+	}
+
+	@Test
 	public void preserveAttributeLineBreaksCollapseEmptyElement() throws BadLocationException {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setPreserveAttrLineBreaks(true);


### PR DESCRIPTION
While `xml.format.preserveAttributeLineBreaks` is enabled, in this case:
```
<a attr="value" attr="value"
    attr=
    "value" attr="value">
</a>
```

in master, formatting results in:
```
<a attr="value" attr="value"
    attr="value"
    attr="value">
</a>
```

There shouldn't be a newline after the 2nd line.

This PR fixes this problem. As a result, formatting now results in:
```
<a attr="value" attr="value"
    attr="value" attr="value">
</a>
```

Sorry, this should have been caught yesterday

Signed-off-by: David Kwon <dakwon@redhat.com>