### PR TITLE
noNamespaceSchemaLocation file missing CodeAction

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -174,6 +174,11 @@ public class XMLTextDocumentService implements TextDocumentService {
 			typeDefinitionLinkSupport = textDocumentClientCapabilities.getTypeDefinition() != null
 					&& textDocumentClientCapabilities.getTypeDefinition().getLinkSupport() != null
 					&& textDocumentClientCapabilities.getTypeDefinition().getLinkSupport();
+			sharedSettings.setOpenSettingsCommandSupport(
+					capabilities.getWorkspace() != null
+					&& capabilities.getWorkspace().getWorkspaceEdit() != null
+					&& capabilities.getWorkspace().getWorkspaceEdit().getResourceOperations() != null
+					&& capabilities.getWorkspace().getWorkspaceEdit().getResourceOperations().contains("create"));
 		}
 		if (extendedClientCapabilities != null) {
 			// Extended client capabilities

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
@@ -20,9 +20,13 @@ import java.util.List;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.CreateFileOptions;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
@@ -116,5 +120,33 @@ public class CodeActionFactory {
 
 		insertContentAction.setEdit(workspaceEdit);
 		return insertContentAction;
+	}
+
+	/**
+	 * Makes a CodeAction to create a file and add content to the file.
+	 * 
+	 * @param title The displayed name of the CodeAction
+	 * @param docURI The file to create
+	 * @param content The text to put into the newly created document.
+	 * @param diagnostic The diagnostic that this CodeAction will fix
+	 */
+	public static CodeAction createFile(String title, String docURI, String content, Diagnostic diagnostic) {
+
+		List<Either<TextDocumentEdit, ResourceOperation>> actionsToTake = new ArrayList<>(2);
+		
+		actionsToTake.add(Either.forRight(new CreateFile(docURI, new CreateFileOptions(false, true))));
+		
+		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(docURI, 0);
+		TextEdit te = new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), content);
+		actionsToTake.add(Either.forLeft(new TextDocumentEdit(identifier, Collections.singletonList(te))));
+		
+		WorkspaceEdit createAndAddContentEdit = new WorkspaceEdit(actionsToTake);
+
+		CodeAction codeAction = new CodeAction(title);
+		codeAction.setEdit(createAndAddContentEdit);
+		codeAction.setDiagnostics(Collections.singletonList(diagnostic));
+		codeAction.setKind(CodeActionKind.QuickFix);
+
+		return codeAction;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -35,6 +35,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_complex_type_4CodeAction;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_enumeration_validCodeAction;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_type_3_1_1CodeAction;
+import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.schema_reference_4CodeAction;
 import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lemminx.utils.DOMUtils;
@@ -269,5 +270,8 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		codeActions.put(cvc_complex_type_2_1.getCode(), new cvc_complex_type_2_1CodeAction());
 		codeActions.put(TargetNamespace_1.getCode(), new TargetNamespace_1CodeAction());
 		codeActions.put(TargetNamespace_2.getCode(), new TargetNamespace_2CodeAction());
+
+		// TODO: check if the client has the correct capabilities to execute this code action
+		codeActions.put(schema_reference_4.getCode(), new schema_reference_4CodeAction());
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/schema_reference_4CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/schema_reference_4CodeAction.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Code Action that creates a schema file referenced by xsi:noNamespaceSchemaLocation if it is missing
+ */
+public class schema_reference_4CodeAction implements ICodeActionParticipant {
+
+	private static final Pattern PATH_FINDING_REGEX = Pattern.compile("[^']+'file://(.+)',.*");
+
+	@Override
+	public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+			SharedSettings sharedSettings, IComponentProvider componentProvider) {
+
+		if (!sharedSettings.isCreateFileResourceOperationSupport()) {
+			return;
+		}
+
+		String missingFilePath = getPathFromDiagnostic(diagnostic);
+		if (StringUtils.isEmpty(missingFilePath)) {
+			return;
+		}
+		Path p = Paths.get(missingFilePath);
+		if (p.toFile().exists()) {
+			return;
+		}
+
+		// TODO: use the generator
+		String schemaTemplate = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n\n</xs:schema>";
+
+		CodeAction makeSchemaFile = CodeActionFactory.createFile(
+				"Generate missing file '" + p.toFile().getName() + "'",
+				missingFilePath,
+				schemaTemplate,
+				diagnostic);
+
+		codeActions.add(makeSchemaFile);
+	}
+
+	/**
+	 * Extract the file to create from the diagnostic. Example diagnostic:
+	 * schema_reference.4: Failed to read schema document
+	 * 'file:///home/dthompson/Documents/TestFiles/potationCoordination.xsd',
+	 * because 1) could not find the document; 2) the document could not be read;
+	 * 3) the root element of the document is not <xsd:schema>.
+	 */
+	private String getPathFromDiagnostic(Diagnostic diagnostic) {
+		Matcher m = PATH_FINDING_REGEX.matcher(diagnostic.getMessage());
+		if (m.find()) {
+			return m.group(1);
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
@@ -29,6 +29,7 @@ public class SharedSettings {
 
 	private boolean actionableNotificationSupport;
 	private boolean openSettingsCommandSupport;
+	private boolean createFileResourceOperationSupport;
 
 	public SharedSettings() {
 		this.completionSettings = new XMLCompletionSettings();
@@ -127,5 +128,28 @@ public class SharedSettings {
 	public void setOpenSettingsCommandSupport(boolean openSettingsCommandSupport) {
 		this.openSettingsCommandSupport = openSettingsCommandSupport;
 	}
+
+	/**
+	 * Returns true if the client supports the CreateFile ResourceOperation,
+	 * and false otherwise.
+	 * 
+	 * @return true if the client supports the CreateFile ResourceOperation,
+	 * false otherwise.
+	 */
+	public boolean isCreateFileResourceOperationSupport() {
+		return createFileResourceOperationSupport;
+	}
+
+	/**
+	 * Sets createFileResourceOperationSupport
+	 * 
+	 * This boolean indicates if the client supports the CreateFile ResourceOepration
+	 * 
+	 * @param createFileResourceOperationSupport The new value of <code>createFileResourceOperationSupport</code>
+	 */
+	public void setCreateFileResourceOperationSupport(boolean createFileResourceOperationSupport) {
+		this.createFileResourceOperationSupport = createFileResourceOperationSupport;
+	}
+
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -54,6 +54,8 @@ import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.CreateFileOptions;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
@@ -70,6 +72,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceContext;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
@@ -563,11 +566,32 @@ public class XMLAssert {
 		return codeAction;
 	}
 
+	public static CodeAction ca(Diagnostic d, Either<TextDocumentEdit, ResourceOperation>... ops) {
+		CodeAction codeAction = new CodeAction();
+		codeAction.setDiagnostics(Collections.singletonList(d));
+		codeAction.setEdit(new WorkspaceEdit(Arrays.asList(ops)));
+		codeAction.setTitle("");
+		return codeAction;
+	}
+
 	public static TextEdit te(int startLine, int startCharacter, int endLine, int endCharacter, String newText) {
 		TextEdit textEdit = new TextEdit();
 		textEdit.setNewText(newText);
 		textEdit.setRange(r(startLine, startCharacter, endLine, endCharacter));
 		return textEdit;
+	}
+
+	public static Either<TextDocumentEdit, ResourceOperation> createFile(String uri, boolean overwrite) {
+		CreateFileOptions options = new CreateFileOptions();
+		options.setIgnoreIfExists(!overwrite);
+		options.setOverwrite(overwrite);
+		return Either.forRight(new CreateFile(uri, options));
+	}
+
+	public static Either<TextDocumentEdit, ResourceOperation> teOp(String uri, int startLine, int startChar,
+			int endLine, int endChar, String newText) {
+		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0),
+				Collections.singletonList(te(startLine, startChar, endLine, endChar, newText))));
 	}
 
 	// ------------------- Hover assert


### PR DESCRIPTION
A CodeAction for the error `schema-reference.4` that creates the file referenced in `xsi:noNamespaceSchemaLocation` if its missing.

Closes #691

Signed-off-by: David Thompson <davthomp@redhat.com>