### PR TITLE
Implement trim trailing whitespaces formatting setting

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
@@ -27,6 +27,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 	public static final int DEFAULT_TAB_SIZE = 2;
 	public static final EnforceQuoteStyle DEFAULT_ENFORCE_QUOTE_STYLE = EnforceQuoteStyle.ignore;
 	public static final boolean DEFAULT_PRESERVE_ATTR_LINE_BREAKS = false;
+	public static final boolean DEFAULT_TRIM_TRAILING_SPACES = false;
 
 	// All possible keys
 	private static final String SPLIT_ATTRIBUTES = "splitAttributes";
@@ -38,6 +39,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 	private static final String JOIN_CONTENT_LINES = "joinContentLines";
 	private static final String PRESERVED_NEWLINES = "preservedNewlines";
 	private static final String TRIM_FINAL_NEWLINES = "trimFinalNewlines";
+	private static final String TRIM_TRAILING_WHITESPACE = "trimTrailingWhitespace";
 	private static final String ENFORCE_QUOTE_STYLE = "enforceQuoteStyle";
 	private static final String PRESERVE_ATTR_LINE_BREAKS = "preserveAttributeLineBreaks";
 
@@ -294,6 +296,15 @@ public class XMLFormattingOptions extends FormattingOptions {
 	public boolean isTrimFinalNewlines() {
 		final Boolean value = this.getBoolean(TRIM_FINAL_NEWLINES);
 		return (value == null) ? true: value;
+	}
+
+	public void setTrimTrailingWhitespace(boolean newValue) {
+		this.putBoolean(TRIM_TRAILING_WHITESPACE, newValue);
+	}
+
+	public boolean isTrimTrailingWhitespace() {
+		final Boolean value = this.getBoolean(TRIM_TRAILING_WHITESPACE);
+		return (value == null) ? DEFAULT_TRIM_TRAILING_SPACES: value;
 	}
 
 	public void setEnforceQuoteStyle(EnforceQuoteStyle enforce) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -259,7 +259,7 @@ public class XMLBuilder {
 	 * <code>delimiter</code>
 	 * 
 	 * @param text                the proposed text to add
-	 * @param isWhitespaceContent whether or not the text contains whitespace content
+	 * @param isWhitespaceContent whether or not the text contains only whitespace content
 	 * @param hasSiblings         whether or not the corresponding text node has siblings
 	 * @param delimiter           line delimiter
 	 * @return this XMLBuilder with <code>text</code> added depending on
@@ -273,6 +273,9 @@ public class XMLBuilder {
 				text = StringUtils.normalizeSpace(text);
 			} else if (hasSiblings) {
 				text = text.trim();
+			}
+			if (isTrimTrailingWhitespace()) {
+				text = trimTrailingSpacesEachLine(text);
 			}
 			xml.append(text);
 		} else if (!hasSiblings && isPreserveEmptyContent()) {
@@ -327,13 +330,39 @@ public class XMLBuilder {
 	}
 
 	/**
-	 * Trims the trailing newlines for the current xml StringBuilder
+	 * Trims the trailing newlines for the current XML StringBuilder
 	 */
 	public void trimFinalNewlines() {
 		int i = xml.length() - 1;
 		while (i >= 0 && Character.isWhitespace(xml.charAt(i))) {
 			xml.deleteCharAt(i--);
 		}
+	}
+
+	/**
+	 * Returns <code>str</code> with the trailing spaces from each line
+	 * removed
+	 *
+	 * @param str the String
+	 * @return <code>str</code> with the trailing spaces from each line
+	 * removed
+	 */
+	private static String trimTrailingSpacesEachLine(String str) {
+		StringBuilder sb = new StringBuilder(str);
+		int i = str.length() - 1;
+		boolean removeSpaces = true;
+		while (i >= 0) {
+			char curr = sb.charAt(i);
+			if (curr == '\n' || curr == '\r') {
+				removeSpaces = true;
+			} else if (removeSpaces && Character.isWhitespace(curr)) {
+				sb.deleteCharAt(i);
+			} else {
+				removeSpaces = false;
+			}
+			i--;
+		}
+		return sb.toString();
 	}
 
 	public XMLBuilder startCDATA() {
@@ -470,6 +499,10 @@ public class XMLBuilder {
 
 	private boolean isPreserveEmptyContent() {
 		return sharedSettings.getFormattingSettings().isPreserveEmptyContent();
+	}
+
+	private boolean isTrimTrailingWhitespace() {
+		return sharedSettings.getFormattingSettings().isTrimTrailingWhitespace();
 	}
 
 	private int getPreservedNewlines() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -288,7 +288,7 @@ public class XMLFormatterTest {
 		String content = "<?xml version='1.0' standalone='no'?>\r\n" +  //
 				"<!DOCTYPE root-element [\r\n" + //
 				"|<!ENTITY local \"LOCALLY DECLARED ENTITY\">|\r\n" +  //
-				"]>";		
+				"]>";
 		String expected = "<?xml version='1.0' standalone='no'?>\r\n" +  //
 				"<!DOCTYPE root-element [\r\n" + //
 				"  <!ENTITY local \"LOCALLY DECLARED ENTITY\">\r\n" +  //
@@ -301,7 +301,7 @@ public class XMLFormatterTest {
 		String content = "<?xml version='1.0' standalone='no'?>\r\n" +  //
 				"<!DOCTYPE root-element [\r\n" + //
 				"  |<!ENTITY local \"LOCALLY DECLARED ENTITY\">|\r\n" +  //
-				"]>";		
+				"]>";
 		String expected = "<?xml version='1.0' standalone='no'?>\r\n" +  //
 				"<!DOCTYPE root-element [\r\n" + //
 				"  <!ENTITY local \"LOCALLY DECLARED ENTITY\">\r\n" +  //
@@ -309,7 +309,7 @@ public class XMLFormatterTest {
 		format(content, expected);
 	}
 
-	
+
 	@Test
 	public void testProlog() throws BadLocationException {
 		String content = "<?xml version=   \"1.0\"       encoding=\"UTF-8\"  ?>\r\n";
@@ -2102,6 +2102,57 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void testTrimTrailingWhitespaceText() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+		String content = "<a>   \n" +
+				"text     \n" +
+				"    text text text    \n" +
+				"    text\n" +
+				"</a>   ";
+		String expected = "<a>\n" +
+				"text\n" +
+				"    text text text\n" +
+				"    text\n" +
+				"</a>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testTrimTrailingWhitespaceNewlines() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+		String content = "<a>   \n" +
+				"   \n" +
+				"</a>   ";
+		String expected = "<a></a>";
+		format(content, expected, settings);
+	}
+
+	@Test
+	public void testTrimTrailingWhitespaceTextAndNewlines() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+		String content = "<a>   \n" +
+				"    \n" +
+				"text     \n" +
+				"    text text text    \n" +
+				"   \n" +
+				"    text\n" +
+				"        \n" +
+				"</a>   ";
+		String expected = "<a>\n" +
+				"\n" +
+				"text\n" +
+				"    text text text\n" +
+				"\n" +
+				"    text\n" +
+				"\n" +
+				"</a>";
+		format(content, expected, settings);
+	}
+
+	@Test
 	public void testTrimFinalNewlinesDefault() throws BadLocationException {
 		String content = "<a  ></a>\r\n";
 		String expected = "<a></a>";
@@ -2603,7 +2654,7 @@ public class XMLFormatterTest {
 				"<b attr=\"value\" attr=\"value\"\n" + //
 				"attr=\"value\" attr=\"value\"\n" + //
 				"attr=\"value\" attr=\"value\">\n" + //
-				"</b>\n" + 
+				"</b>\n" +
 				"</a>";
 		String expected = "<a>\n" +
 				"  <b attr=\"value\" attr=\"value\"\n" + //


### PR DESCRIPTION
For https://github.com/redhat-developer/vscode-xml/issues/250

Since trailing whitespaces after elements (ie: `<a>test</a>____`) are already being removed after formatting, this PR focusses on removing the trailing whitespaces within text content.

Demo:
```
<test>
   
text    
   
</test>
```
![demo](https://raw.githubusercontent.com/xorye/gifs/master/pr/250.gif?token=AE3CR5OXTGQYZXKS52TS2SS66IH4W)

Signed-off-by: David Kwon <dakwon@redhat.com>