### PR TITLE
Implement file path completion for DTD systemId

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/general/completion/FilePathCompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/general/completion/FilePathCompletionParticipant.java
@@ -47,14 +47,25 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 	@Override
 	public void onAttributeValue(String valuePrefix,
 			ICompletionRequest request, ICompletionResponse response) throws Exception {
+		addCompletionItems(valuePrefix, request, response);
+	}
+
+	@Override
+	public void onDTDSystemId(String valuePrefix,
+			ICompletionRequest request, ICompletionResponse response) throws Exception {
+		addCompletionItems(valuePrefix, request, response);
+	}
+
+	private void addCompletionItems(String valuePrefix,
+			ICompletionRequest request, ICompletionResponse response) throws Exception {
 
 		DOMDocument xmlDocument = request.getXMLDocument();
 		String text = xmlDocument.getText();
 		Range fullRange = request.getReplaceRange();
-		
+
 		// Get full attribute value range
 		int documentStartOffset = xmlDocument.offsetAt(fullRange.getStart());
-		
+
 		String fullAttributeValue = valuePrefix;
 		if (isEmpty(fullAttributeValue)) {
 			return;
@@ -64,7 +75,7 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 		int completionOffset = request.getOffset(); // offset after the typed character
 		int parsedAttributeStartOffset = StringUtils.getOffsetAfterWhitespace(fullAttributeValue, completionOffset - documentStartOffset) + documentStartOffset; // first character of URI
 		String attributePath = text.substring(parsedAttributeStartOffset, completionOffset);
-	
+
 		Position startValue = xmlDocument.positionAt(parsedAttributeStartOffset);
 		Position endValue = xmlDocument.positionAt(completionOffset);
 		fullRange = new Range(startValue, endValue);
@@ -96,14 +107,14 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 				return;
 			}
 		}
-		
+
 		if(isWindows) {
 			osSpecificAttributePath = convertToWindowsPath(osSpecificAttributePath);
 		}
 		else if("\\".equals(slashInAttribute)) { // Backslash used in Unix
 			osSpecificAttributePath = osSpecificAttributePath.replace("\\", "/");
 		}
-		
+
 		// Get the normalized URI string from the parent directory file if necessary
 		String workingDirectory = null; // The OS specific path for a working directory
 
@@ -129,10 +140,10 @@ public class FilePathCompletionParticipant extends CompletionParticipantAdapter 
 				}
 			}
 		}
-		
+
 		//Try to get a correctly formatted path from the given values
 		Path validAttributeValuePath = getNormalizedPath(workingDirectory, osSpecificAttributePath); 
-		
+
 		if(validAttributeValuePath == null) {
 			return;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/XSISchemaModel.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/XSISchemaModel.java
@@ -167,6 +167,9 @@ public class XSISchemaModel {
 		
 		String actualPrefix = document.getSchemaInstancePrefix();
 		DOMAttr attrAtOffset = nodeAtOffset.findAttrAt(offset);
+		if (attrAtOffset == null) {
+			return;
+		}
 		String attrName = attrAtOffset.getName();
 		
 		if(attrName != null) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/CompletionParticipantAdapter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/CompletionParticipantAdapter.java
@@ -41,4 +41,10 @@ public class CompletionParticipantAdapter implements ICompletionParticipant {
 		// Do nothing
 	}
 
+	@Override
+	public void onDTDSystemId(String valuePrefix, ICompletionRequest request, ICompletionResponse response)
+			throws Exception {
+		// Do nothing
+	}
+
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ICompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/ICompletionParticipant.java
@@ -25,7 +25,29 @@ public interface ICompletionParticipant {
 	void onAttributeName(boolean generateValue, ICompletionRequest request, ICompletionResponse response)
 			throws Exception;
 
+	/**
+	 * Collects and stores attribute value completion items within the provided completion
+	 * response <code>response</code>
+	 * 
+	 * @param valuePrefix the attribute value before the offset in which completion was invoked
+	 * @param request     the completion request
+	 * @param response    the completion response
+	 * @throws Exception
+	 */
 	void onAttributeValue(String valuePrefix, ICompletionRequest request, ICompletionResponse response)
+			throws Exception;
+	
+
+	/**
+	 * Collects and stores systemId completion items within the provided completion
+	 * response <code>response</code>
+	 * 
+	 * @param valuePrefix the systemId value before the offset in which completion was invoked
+	 * @param request     the completion request
+	 * @param response    the completion response
+	 * @throws Exception
+	 */
+	void onDTDSystemId(String valuePrefix, ICompletionRequest request, ICompletionResponse response)
 			throws Exception;
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/general/FilePathCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/general/FilePathCompletionTest.java
@@ -227,6 +227,61 @@ public class FilePathCompletionTest {
 		testCompletionFor(xml, 0);
 	}
 
+	@Test
+	public void testFilePathCompletionDTD() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \"./|\">";
+		CompletionItem[] items = getCompletionItemList("/", 0, 23, 24, "folderA", "folderB", "NestedA");
+		testCompletionFor(xml, items);
+	}
+
+	@Test
+	public void testFilePathCompletionDTDBackSlash() throws BadLocationException {
+	
+		String xml = "<!DOCTYPE foo SYSTEM \".\\|\">";
+		CompletionItem[] items = getCompletionItemList("\\", 0, 23, 24, "folderA", "folderB", "NestedA");
+		testCompletionFor(xml, items);
+	}
+
+	@Test
+	public void testFilePathCompletionDTDFolderA() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \"./folderA/|\">";
+		CompletionItem[] items = getCompletionItemList("/", 0, 31, 32, "xsdA1.xsd", "xsdA2.xsd");
+		testCompletionFor(xml, items);
+	}
+
+	@Test
+	public void testFilePathCompletionDTDFolderABackSlash() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \".\\folderA\\|\">";
+		CompletionItem[] items = getCompletionItemList("\\", 0, 31, 32, "xsdA1.xsd", "xsdA2.xsd");
+		testCompletionFor(xml, items);
+	}
+
+	@Test
+	public void testFilePathCompletionDTDFolderB() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \"folderB/|\">";
+		CompletionItem[] items = getCompletionItemList("/", 0, 29, 30, "xsdB1.xsd", "xmlB1.xml");
+		testCompletionFor(xml, 2, items);
+	}
+
+	@Test
+	public void testFilePathCompletionDTDFolderBBackSlash() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \"folderB\\|\">";
+		CompletionItem[] items = getCompletionItemList("\\", 0, 29, 30, "xsdB1.xsd", "xmlB1.xml");
+		testCompletionFor(xml, 2, items);
+	}
+
+	@Test
+	public void testFilePathNoCompletion() throws BadLocationException {
+		String xml = "<!DOCTYPE foo SYSTEM \"|\">";
+		testCompletionFor(xml, 0);
+	}
+
+	@Test
+	public void testFilePathNoCompletionMissingSystemId() throws BadLocationException {
+		String xml = "<!DOCTYPE foo \"./|\">";
+		testCompletionFor(xml, 0);
+	}
+
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {
 		testCompletionFor(xml, null, expectedItems);
 	}


### PR DESCRIPTION
Fixes #738 

```
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE foo SYSTEM "">
```

![demo](https://raw.githubusercontent.com/xorye/gifs/a7ba5c7d341bb865a6b61998a0a9d89a8e64925c/pr/dtd_filepath_completion.gif?token=AE3CR5PFSD6XS4NGS6V33LK66JL7A)

Signed-off-by: David Kwon <dakwon@redhat.com>