### PR TITLE
noNamespaceSchemaLocation file missing CodeAction

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -178,9 +178,12 @@ public class XMLTextDocumentService implements TextDocumentService {
 		if (extendedClientCapabilities != null) {
 			// Extended client capabilities
 			sharedSettings.getCodeLensSettings().setCodeLens(extendedClientCapabilities.getCodeLens());
-			sharedSettings.setActionableNotificationSupport(extendedClientCapabilities.isActionableNotificationSupport());
+			sharedSettings
+					.setActionableNotificationSupport(extendedClientCapabilities.isActionableNotificationSupport());
 			sharedSettings.setOpenSettingsCommandSupport(extendedClientCapabilities.isOpenSettingsCommandSupport());
 		}
+		// Workspace settings
+		sharedSettings.getWorkspaceSettings().setCapabilities(capabilities.getWorkspace());
 	}
 
 	@Override
@@ -195,8 +198,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
 		return computeDOMAsync(params.getTextDocument(), (cancelChecker, xmlDocument) -> {
-			return getXMLLanguageService().doHover(xmlDocument, params.getPosition(), sharedSettings,
-					cancelChecker);
+			return getXMLLanguageService().doHover(xmlDocument, params.getPosition(), sharedSettings, cancelChecker);
 		});
 	}
 
@@ -240,8 +242,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 						}) //
 						.collect(Collectors.toList());
 			}
-			SymbolInformationResult result =  getXMLLanguageService()
-					.findSymbolInformations(xmlDocument, symbolSettings, cancelChecker);
+			SymbolInformationResult result = getXMLLanguageService().findSymbolInformations(xmlDocument, symbolSettings,
+					cancelChecker);
 			resultLimitExceeded = result.isResultLimitExceeded();
 			symbols = result.stream() //
 					.map(s -> {
@@ -249,7 +251,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 						return e;
 					}) //
 					.collect(Collectors.toList());
-			
+
 			if (resultLimitExceeded) {
 				// send warning
 				getLimitExceededWarnings().onResultLimitExceeded(xmlDocument.getTextDocument().getUri(),
@@ -560,8 +562,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	public LimitExceededWarnings getLimitExceededWarnings() {
 		if (this.limitExceededWarnings == null) {
-			this.limitExceededWarnings =
-					new LimitExceededWarnings(this.xmlLanguageServer.getLanguageClient(), sharedSettings);
+			this.limitExceededWarnings = new LimitExceededWarnings(this.xmlLanguageServer.getLanguageClient(),
+					sharedSettings);
 		}
 		return this.limitExceededWarnings;
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCodeActionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCodeActionParticipant.java
@@ -35,10 +35,6 @@ public class ContentModelCodeActionParticipant implements ICodeActionParticipant
 
 	public ContentModelCodeActionParticipant() {
 		codeActionParticipants = new HashMap<>();
-		XMLSyntaxErrorCode.registerCodeActionParticipants(codeActionParticipants);
-		DTDErrorCode.registerCodeActionParticipants(codeActionParticipants);
-		XMLSchemaErrorCode.registerCodeActionParticipants(codeActionParticipants);
-		XSDErrorCode.registerCodeActionParticipants(codeActionParticipants);
 	}
 
 	@Override
@@ -47,10 +43,29 @@ public class ContentModelCodeActionParticipant implements ICodeActionParticipant
 		if (diagnostic == null || diagnostic.getCode() == null || !diagnostic.getCode().isLeft()) {
 			return;
 		}
+		registerCodeActionsIfNeeded(sharedSettings);
 		ICodeActionParticipant participant = codeActionParticipants.get(diagnostic.getCode().getLeft());
 		if (participant != null) {
-			participant.doCodeAction(diagnostic, range, document, codeActions, sharedSettings,
-					componentProvider);
+			participant.doCodeAction(diagnostic, range, document, codeActions, sharedSettings, componentProvider);
+		}
+	}
+
+	/**
+	 * Register code action if needed.
+	 * 
+	 * @param sharedSettings the shared settings.
+	 */
+	private void registerCodeActionsIfNeeded(SharedSettings sharedSettings) {
+		if (codeActionParticipants.isEmpty()) {
+			synchronized (codeActionParticipants) {
+				if (!codeActionParticipants.isEmpty()) {
+					return;
+				}
+				XMLSyntaxErrorCode.registerCodeActionParticipants(codeActionParticipants);
+				DTDErrorCode.registerCodeActionParticipants(codeActionParticipants);
+				XMLSchemaErrorCode.registerCodeActionParticipants(codeActionParticipants, sharedSettings);
+				XSDErrorCode.registerCodeActionParticipants(codeActionParticipants);
+			}
 		}
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -35,12 +35,15 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_complex_type_4CodeAction;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_enumeration_validCodeAction;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.cvc_type_3_1_1CodeAction;
+import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.schema_reference_4CodeAction;
 import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
+import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.utils.DOMUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResourceOperationKind;
 
 /**
  * XML Schema error code.
@@ -164,7 +167,7 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		case cvc_pattern_valid: {
 			String value = getString(arguments[0]);
 			Range result = XMLPositionUtility.selectAttributeValueByGivenValueAt(value, offset, document);
-			if(result != null) {
+			if (result != null) {
 				return result;
 			}
 			return XMLPositionUtility.selectTrimmedText(offset, document);
@@ -257,7 +260,8 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		return null;
 	}
 
-	public static void registerCodeActionParticipants(Map<String, ICodeActionParticipant> codeActions) {
+	public static void registerCodeActionParticipants(Map<String, ICodeActionParticipant> codeActions,
+			SharedSettings sharedSettings) {
 		codeActions.put(cvc_complex_type_2_4_a.getCode(), new cvc_complex_type_2_4_aCodeAction());
 		codeActions.put(cvc_complex_type_2_4_c.getCode(), new cvc_complex_type_2_4_aCodeAction());
 		codeActions.put(cvc_complex_type_2_3.getCode(), new cvc_complex_type_2_3CodeAction());
@@ -269,5 +273,9 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		codeActions.put(cvc_complex_type_2_1.getCode(), new cvc_complex_type_2_1CodeAction());
 		codeActions.put(TargetNamespace_1.getCode(), new TargetNamespace_1CodeAction());
 		codeActions.put(TargetNamespace_2.getCode(), new TargetNamespace_2CodeAction());
+		
+		if (sharedSettings.getWorkspaceSettings().isResourceOperationSupported(ResourceOperationKind.Create)) {
+			codeActions.put(schema_reference_4.getCode(), new schema_reference_4CodeAction());
+		}
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/schema_reference_4CodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/schema_reference_4CodeAction.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.lemminx.commons.CodeActionFactory;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
+import org.eclipse.lemminx.services.extensions.IComponentProvider;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Code Action that creates a schema file referenced by
+ * xsi:noNamespaceSchemaLocation if it is missing
+ */
+public class schema_reference_4CodeAction implements ICodeActionParticipant {
+
+	private static final Pattern PATH_FINDING_REGEX = Pattern.compile("[^']+'file:///(.+)',.*");
+
+	@Override
+	public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+			SharedSettings sharedSettings, IComponentProvider componentProvider) {
+
+		String missingFilePath = getPathFromDiagnostic(diagnostic);
+		if (StringUtils.isEmpty(missingFilePath)) {
+			return;
+		}
+		Path p = Paths.get(missingFilePath);
+		if (p.toFile().exists()) {
+			return;
+		}
+
+		// TODO: use the generator
+		String schemaTemplate = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n\n</xs:schema>";
+
+		CodeAction makeSchemaFile = CodeActionFactory.createFile("Generate missing file '" + p.toFile().getName() + "'",
+				"file:///" + missingFilePath, schemaTemplate, diagnostic);
+
+		codeActions.add(makeSchemaFile);
+	}
+
+	/**
+	 * Extract the file to create from the diagnostic. Example diagnostic:
+	 * schema_reference.4: Failed to read schema document
+	 * 'file:///home/dthompson/Documents/TestFiles/potationCoordination.xsd',
+	 * because 1) could not find the document; 2) the document could not be read; 3)
+	 * the root element of the document is not <xsd:schema>.
+	 */
+	private String getPathFromDiagnostic(Diagnostic diagnostic) {
+		Matcher m = PATH_FINDING_REGEX.matcher(diagnostic.getMessage());
+		if (m.find()) {
+			return m.group(1);
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
@@ -26,9 +26,10 @@ public class SharedSettings {
 	private final XMLCodeLensSettings codeLensSettings;
 	private final XMLHoverSettings hoverSettings;
 	private final XMLPreferences preferences;
-
+	private final XMLWorkspaceSettings workspaceSettings;
 	private boolean actionableNotificationSupport;
 	private boolean openSettingsCommandSupport;
+	private boolean createFileResourceOperationSupport;
 
 	public SharedSettings() {
 		this.completionSettings = new XMLCompletionSettings();
@@ -39,8 +40,10 @@ public class SharedSettings {
 		this.codeLensSettings = new XMLCodeLensSettings();
 		this.hoverSettings = new XMLHoverSettings();
 		this.preferences = new XMLPreferences();
+		this.workspaceSettings = new XMLWorkspaceSettings();
 		this.actionableNotificationSupport = false;
 		this.openSettingsCommandSupport = false;
+
 	}
 
 	public SharedSettings(SharedSettings newSettings) {
@@ -87,13 +90,19 @@ public class SharedSettings {
 		return preferences;
 	}
 
+	public XMLWorkspaceSettings getWorkspaceSettings() {
+		return workspaceSettings;
+	}
+
 	/**
-	 * Returns true if the client supports actionable notifications and false otherwise
+	 * Returns true if the client supports actionable notifications and false
+	 * otherwise
 	 * 
 	 * See {@link org.eclipse.lemminx.customservice.ActionableNotification} and
 	 * {@link org.eclipse.lemminx.customservice.XMLLanguageClientAPI}
 	 * 
-	 * @return true if the client supports actionable notifications and false otherwise
+	 * @return true if the client supports actionable notifications and false
+	 *         otherwise
 	 */
 	public boolean isActionableNotificationSupport() {
 		return actionableNotificationSupport;
@@ -109,11 +118,13 @@ public class SharedSettings {
 	}
 
 	/**
-	 * Returns true if the client supports the open settings command and false otherwise
+	 * Returns true if the client supports the open settings command and false
+	 * otherwise
 	 * 
 	 * See {@link org.eclipse.lemminx.client.ClientCommands#OPEN_SETTINGS}
 	 * 
-	 * @return true if the client supports the open settings command and false otherwise
+	 * @return true if the client supports the open settings command and false
+	 *         otherwise
 	 */
 	public boolean isOpenSettingsCommandSupport() {
 		return openSettingsCommandSupport;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLWorkspaceSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLWorkspaceSettings.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.settings;
+
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+
+/**
+ * A wrapper around LSP {@link WorkspaceClientCapabilities}.
+ *
+ */
+public class XMLWorkspaceSettings {
+
+	private WorkspaceClientCapabilities workspace;
+
+	public void setCapabilities(WorkspaceClientCapabilities workspace) {
+		this.workspace = workspace;
+	}
+
+	/**
+	 * Returns true if the client can support the given resource operation kind and
+	 * false otherwise.
+	 * 
+	 * @param kind the resource operation kind.
+	 * @return true if the client can support the given resource operation kind and
+	 *         false otherwise.
+	 */
+	public boolean isResourceOperationSupported(String kind) {
+		return workspace != null && workspace.getWorkspaceEdit() != null
+				&& workspace.getWorkspaceEdit().getResourceOperations() != null
+				&& workspace.getWorkspaceEdit().getResourceOperations().contains(kind);
+	}
+
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -45,7 +45,6 @@ import org.eclipse.lemminx.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lemminx.services.extensions.save.AbstractSaveContext;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLCodeLensSettings;
-import org.eclipse.lemminx.settings.XMLHoverSettings;
 import org.eclipse.lemminx.settings.XMLSymbolSettings;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
@@ -54,6 +53,8 @@ import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.CreateFileOptions;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
@@ -70,6 +71,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceContext;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
@@ -481,8 +483,8 @@ public class XMLAssert {
 		testCodeActionsFor(xml, diagnostic, (String) null, expected);
 	}
 
-	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, SharedSettings settings, CodeAction... expected)
-			throws BadLocationException {
+	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, SharedSettings settings,
+			CodeAction... expected) throws BadLocationException {
 		testCodeActionsFor(xml, diagnostic, null, settings, expected);
 	}
 
@@ -563,11 +565,32 @@ public class XMLAssert {
 		return codeAction;
 	}
 
+	public static CodeAction ca(Diagnostic d, Either<TextDocumentEdit, ResourceOperation>... ops) {
+		CodeAction codeAction = new CodeAction();
+		codeAction.setDiagnostics(Collections.singletonList(d));
+		codeAction.setEdit(new WorkspaceEdit(Arrays.asList(ops)));
+		codeAction.setTitle("");
+		return codeAction;
+	}
+
 	public static TextEdit te(int startLine, int startCharacter, int endLine, int endCharacter, String newText) {
 		TextEdit textEdit = new TextEdit();
 		textEdit.setNewText(newText);
 		textEdit.setRange(r(startLine, startCharacter, endLine, endCharacter));
 		return textEdit;
+	}
+
+	public static Either<TextDocumentEdit, ResourceOperation> createFile(String uri, boolean overwrite) {
+		CreateFileOptions options = new CreateFileOptions();
+		options.setIgnoreIfExists(!overwrite);
+		options.setOverwrite(overwrite);
+		return Either.forRight(new CreateFile(uri, options));
+	}
+
+	public static Either<TextDocumentEdit, ResourceOperation> teOp(String uri, int startLine, int startChar,
+			int endLine, int endChar, String newText) {
+		return Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, 0),
+				Collections.singletonList(te(startLine, startChar, endLine, endChar, newText))));
 	}
 
 	// ------------------- Hover assert
@@ -594,10 +617,12 @@ public class XMLAssert {
 	}
 
 	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
-			String fileURI, String expectedHoverLabel, Range expectedHoverRange, SharedSettings sharedSettings) throws BadLocationException {
+			String fileURI, String expectedHoverLabel, Range expectedHoverRange, SharedSettings sharedSettings)
+			throws BadLocationException {
 		ContentModelSettings settings = new ContentModelSettings();
 		settings.setUseCache(false);
-		assertHover(xmlLanguageService, value, catalogPath, fileURI, expectedHoverLabel, expectedHoverRange, settings, sharedSettings);
+		assertHover(xmlLanguageService, value, catalogPath, fileURI, expectedHoverLabel, expectedHoverRange, settings,
+				sharedSettings);
 	}
 
 	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
@@ -606,14 +631,13 @@ public class XMLAssert {
 		SharedSettings sharedSettings = new SharedSettings();
 		HoverCapabilities capabilities = new HoverCapabilities(Arrays.asList(MarkupKind.MARKDOWN), false);
 		sharedSettings.getHoverSettings().setCapabilities(capabilities);
-		assertHover(xmlLanguageService, value, catalogPath, fileURI,
-				expectedHoverLabel, expectedHoverRange, settings, sharedSettings);
+		assertHover(xmlLanguageService, value, catalogPath, fileURI, expectedHoverLabel, expectedHoverRange, settings,
+				sharedSettings);
 	}
 
 	public static void assertHover(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			String fileURI, String expectedHoverLabel, Range expectedHoverRange, ContentModelSettings settings,
-			SharedSettings sharedSettings)
-			throws BadLocationException {
+			SharedSettings sharedSettings) throws BadLocationException {
 		int offset = value.indexOf("|");
 		value = value.substring(0, offset) + value.substring(offset + 1);
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -13,9 +13,13 @@
 package org.eclipse.lemminx.extensions.contentmodel;
 
 import static org.eclipse.lemminx.XMLAssert.ca;
+import static org.eclipse.lemminx.XMLAssert.createFile;
 import static org.eclipse.lemminx.XMLAssert.d;
 import static org.eclipse.lemminx.XMLAssert.te;
+import static org.eclipse.lemminx.XMLAssert.teOp;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
+
+import java.util.Arrays;
 
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
@@ -24,6 +28,9 @@ import org.eclipse.lemminx.settings.EnforceQuoteStyle;
 import org.eclipse.lemminx.settings.QuoteStyle;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.ResourceOperationKind;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceEditCapabilities;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -643,6 +650,54 @@ public class XMLSchemaDiagnosticsTest {
 		testCodeActionsFor(xml, targetNamespace, settings, ca(targetNamespace, te(2, 16, 2, 16, " xmlns='http://two-letter-name'")));
 	}
 
+	@Test
+	public void localSchemaFileMissingCodeAction() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<invoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"/salad.xsd\">\n" + //
+				"</invoice>";
+		Diagnostic missingSchemaDiagnostic = d(2, 32, 44, XMLSchemaErrorCode.schema_reference_4);
+		missingSchemaDiagnostic.setMessage("schema_reference.4: Failed to read schema document "
+				+ "'file:///salad.xsd',"
+				+ " because 1) could not find the document; 2) the document could not be read;"
+				+ " 3) the root element of the document is not <xsd:schema>.");
+		Diagnostic eltDiagnostic = d(1, 1, 8, XMLSchemaErrorCode.cvc_elt_1_a);
+		eltDiagnostic.setMessage("cvc-elt.1.a: Cannot find the declaration of element 'invoice'.");
+		XMLAssert.testDiagnosticsFor(xml, missingSchemaDiagnostic, eltDiagnostic);
+
+		SharedSettings settings = new SharedSettings();
+		WorkspaceClientCapabilities workspace = new WorkspaceClientCapabilities();
+		WorkspaceEditCapabilities workspaceEdit = new WorkspaceEditCapabilities();
+		workspaceEdit.setResourceOperations(Arrays.asList(ResourceOperationKind.Create));
+		workspace.setWorkspaceEdit(workspaceEdit);
+		settings.getWorkspaceSettings().setCapabilities(workspace);
+
+		XMLAssert.testCodeActionsFor(xml, //
+				missingSchemaDiagnostic, //
+				settings, //
+				ca(missingSchemaDiagnostic,//
+				createFile("file:///salad.xsd", false), // 
+				teOp("file:///salad.xsd", 0, 0, 0, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n\n</xs:schema>")));
+	}
+
+	@Test
+	public void localSchemaFileMissingCodeActionNotSupported() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+				"<invoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"/salad.xsd\">\n" + //
+				"</invoice>";
+		Diagnostic missingSchema = d(2, 32, 44, XMLSchemaErrorCode.schema_reference_4);
+		missingSchema.setMessage("schema_reference.4: Failed to read schema document "
+				+ "'file:///salad.xsd',"
+				+ " because 1) could not find the document; 2) the document could not be read;"
+				+ " 3) the root element of the document is not <xsd:schema>.");
+		Diagnostic eltDiagnostic = d(1, 1, 8, XMLSchemaErrorCode.cvc_elt_1_a);
+		eltDiagnostic.setMessage("cvc-elt.1.a: Cannot find the declaration of element 'invoice'.");
+		XMLAssert.testDiagnosticsFor(xml, missingSchema, eltDiagnostic);
+
+		XMLAssert.testCodeActionsFor(xml, missingSchema);
+	}
+
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) {
 		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", expected);
 	}
@@ -653,4 +708,3 @@ public class XMLSchemaDiagnosticsTest {
 	}
 
 }
-


### PR DESCRIPTION
A CodeAction for the error `schema-reference.4` that
creates the file referenced in
`xsi:noNamespaceSchemaLocation` if its missing.

Closes #691

Signed-off-by: David Thompson <davthomp@redhat.com>