### PR TITLE
Invalid location hint in xsi:schemaLocation

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocation.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/SchemaLocation.java
@@ -44,11 +44,10 @@ public class SchemaLocation {
 				break;
 			}
 			DOMNode valNode = attr.getNodeAttrValue();
-			// matcher matches 1 char ahead, but valNode's start is at beginning of "
-			int start = valNode.getStart() + locPairMatcher.start(2);
-			// matcher matches end correctly, but range needs to be one past end
-			// to highlight the end, and one to make up for "
-			int end = valNode.getStart() + locPairMatcher.end(2) + 2;
+			// http://example.org/schema/root |root.xsd http://example.org/schema/bison bison.xsd
+			int start = valNode.getStart() + locPairMatcher.start(2) + 1;
+			// http://example.org/schema/root root.xsd| http://example.org/schema/bison bison.xsd
+			int end = valNode.getStart() + locPairMatcher.end(2) + 1;
 			schemaLocationValuePairs.put(namespaceURI,
 					new SchemaLocationHint(start, end, locationHint, this));
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelDocumentLinkParticipant.java
@@ -55,7 +55,7 @@ public class ContentModelDocumentLinkParticipant implements IDocumentLinkPartici
 				if (location != null) {
 					DOMRange attrValue = noNamespaceSchemaLocation.getAttr().getNodeAttrValue();
 					if (attrValue != null) {
-						links.add(createDocumentLink(attrValue, location));
+						links.add(createDocumentLink(attrValue, location, true));
 					}
 				}
 			} catch (BadLocationException e) {
@@ -70,7 +70,7 @@ public class ContentModelDocumentLinkParticipant implements IDocumentLinkPartici
 				try {
 					DOMRange systemIdRange = docType.getSystemIdNode();
 					if (systemIdRange != null) {
-						links.add(createDocumentLink(systemIdRange, location));
+						links.add(createDocumentLink(systemIdRange, location, true));
 					}
 				} catch (BadLocationException e) {
 					// Do nothing
@@ -85,7 +85,7 @@ public class ContentModelDocumentLinkParticipant implements IDocumentLinkPartici
 				try {
 					DOMRange hrefRange = xmlModel.getHrefNode();
 					if (hrefRange != null) {
-						links.add(createDocumentLink(hrefRange, location));
+						links.add(createDocumentLink(hrefRange, location, true));
 					}
 				} catch (BadLocationException e) {
 					// Do nothing
@@ -101,7 +101,7 @@ public class ContentModelDocumentLinkParticipant implements IDocumentLinkPartici
 				for (SchemaLocationHint schemaLocationHint : schemaLocationHints) {
 					location = getResolvedLocation(document.getDocumentURI(), schemaLocationHint.getHint());
 					if (location != null) {
-						links.add(createDocumentLink(schemaLocationHint, location));
+						links.add(createDocumentLink(schemaLocationHint, location, false));
 					}
 				}
 			} catch (BadLocationException e) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDDocumentLinkParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDDocumentLinkParticipant.java
@@ -59,7 +59,7 @@ public class XSDDocumentLinkParticipant implements IDocumentLinkParticipant {
 						String location = getResolvedLocation(document.getDocumentURI(), schemaLocationAttr.getValue());
 						DOMRange schemaLocationRange = schemaLocationAttr.getNodeAttrValue();
 						try {
-							links.add(createDocumentLink(schemaLocationRange, location));
+							links.add(createDocumentLink(schemaLocationRange, location, true));
 						} catch (BadLocationException e) {
 							LOGGER.log(Level.SEVERE, "Creation of document link failed", e);
 						}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
@@ -983,17 +983,22 @@ public class XMLPositionUtility {
 	}
 
 	/**
-	 * Create document link.
+	 * Create a document link
 	 * 
-	 * @param target
-	 * @param location
-	 * @return
-	 * @throws BadLocationException
+	 * @param target   The range in the document that should be the link
+	 * @param location URI where the link should point
+	 * @param adjust   <code>true</code> means the first and last character of
+	 *                 <code>target</code> will not be a part of the link.
+	 * @return A DocumentLink over the range <code>target</code> that points to
+	 *         <code>location</code>.
+	 * @throws BadLocationException if <code>target</code> is out of the bounds of
+	 *                              the document
 	 */
-	public static DocumentLink createDocumentLink(DOMRange target, String location) throws BadLocationException {
+	public static DocumentLink createDocumentLink(DOMRange target, String location, boolean adjust)
+			throws BadLocationException {
 		DOMDocument document = target.getOwnerDocument();
-		Position start = document.positionAt(target.getStart() + 1);
-		Position end = document.positionAt(target.getEnd() - 1);
+		Position start = document.positionAt(target.getStart() + (adjust ? 1 : 0));
+		Position end = document.positionAt(target.getEnd() - (adjust ? 1 : 0));
 		return new DocumentLink(new Range(start, end), location);
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -488,10 +488,38 @@ public class XMLSchemaDiagnosticsTest {
 	@Test
 	public void schema_reference_4_withSchemaLocation() {
 		String xml = "<IODevice xmlns=\"http://www.io-link.com/IODD/2010/10\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n"
-				+ "			  xsi:schemaLocation=\"http://www.io-link.com/IODD/2010/10 IODD1.1.xsd\">\r\n"
+				+ "  xsi:schemaLocation=\"http://www.io-link.com/IODD/2010/10 IODD1.1.xsd\">\r\n"
 				+ "	</IODevice>";
-		testDiagnosticsFor(xml, d(1, 24, 1, 73, XMLSchemaErrorCode.schema_reference_4), //
+		testDiagnosticsFor(xml, d(1, 58, 1, 69, XMLSchemaErrorCode.schema_reference_4), //
 				d(0, 1, 0, 9, XMLSchemaErrorCode.cvc_elt_1_a));
+	}
+
+	@Test
+	public void schema_reference_4_schemaLocationMultipleOneWrong() {
+		String xml = "<root:root\n" + //
+				"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"xmlns:root=\"http://example.org/schema/root\"\n" + //
+				"xmlns:other=\"http://example.org/schema/other\"\n" + //
+				"xsi:schemaLocation=\"http://example.org/schema/root root.xsd http://example.org/schema/other other.xsd\">\n" + //
+				"<other:other />\n" + //
+				"</root:root>";
+		testDiagnosticsFor(xml, d(4, 92, 4, 101, XMLSchemaErrorCode.schema_reference_4), //
+				d(5, 1, 5, 12, XMLSchemaErrorCode.cvc_complex_type_2_4_c));
+	}
+
+	@Test
+	public void schema_reference_4_schemaLocationMultipleBothWrong() {
+		String xml = "<root:root\n" + //
+				"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"xmlns:root=\"http://example.org/schema/robot\"\n" + //
+				"xmlns:other=\"http://example.org/schema/other\"\n" + //
+				"xsi:schemaLocation=\"http://example.org/schema/robot robot.xsd http://example.org/schema/other other.xsd\">\n" + //
+				"<other:other />\n" + //
+				"</root:root>";
+		testDiagnosticsFor(xml, //
+				d(4, 52, 4, 61, XMLSchemaErrorCode.schema_reference_4), //
+				d(0, 1, 0, 10, XMLSchemaErrorCode.cvc_elt_1_a), //
+				d(4, 94, 4, 103, XMLSchemaErrorCode.schema_reference_4));
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/resources/catalogs/catalog.xml
+++ b/org.eclipse.lemminx/src/test/resources/catalogs/catalog.xml
@@ -33,5 +33,8 @@
 		uri="../xsd/edmx.xsd" />
 	<uri name="http://docs.oasis-open.org/odata/ns/edm"
 		uri="../xsd/edm.xsd" />
+	
+	<uri name="http://example.org/schema/root"
+		uri="../xsd/root.xsd" />
 
 </catalog>

--- a/org.eclipse.lemminx/src/test/resources/xsd/root.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/root.xsd
@@ -1,0 +1,9 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://example.org/schema/root">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
When non-existent schemas are referenced using `xsi:schemaLocation`,
the location hint is now highlighted instead of the entire attribute
value.

Fixes #782

Signed-off-by: David Thompson <davthomp@redhat.com>