### PR TITLE
Improve schema generation from an xml doc whose name is also an extension

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeAction.java
@@ -131,8 +131,12 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 	 * 
 	 * @return the unique grammar URI file.
 	 */
-	private static String getGrammarURI(String documentURI, String fileExtension) {
+	static String getGrammarURI(String documentURI, String fileExtension) {
 		int index = documentURI.lastIndexOf('.');
+		if (index > 1 && documentURI.charAt(index - 1) == '/') {
+			// case with file which starts with '.' (ex .project, .classpath).
+			index = -1;
+		}
 		String grammarWithoutExtension = index != -1 ? documentURI.substring(0, index) : documentURI;
 		String grammarURI = grammarWithoutExtension + "." + fileExtension;
 		int i = 1;
@@ -146,7 +150,7 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 		return grammarURI;
 	}
 
-	private static String getFileName(String schemaURI) {
+	static String getFileName(String schemaURI) {
 		return new File(schemaURI).getName();
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeActionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeActionTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Generate grammar URI tests.
+ *
+ */
+public class NoGrammarConstraintsCodeActionTest {
+
+	@Test
+	public void generateGrammarURI() {
+		String actual = NoGrammarConstraintsCodeAction.getGrammarURI("file:///C:/test.xml", "xsd");
+		assertEquals("file:///C:/test.xsd", actual);
+	}
+
+	@Test
+	public void generateGrammarURIWithDot() {
+		String actual = NoGrammarConstraintsCodeAction.getGrammarURI("file:///C:/.project", "xsd");
+		assertEquals("file:///C:/.project.xsd", actual);
+	}
+
+}


### PR DESCRIPTION
Improve schema generation from an xml doc whose name is also an extension

Fixes #805

Signed-off-by: azerr <azerr@redhat.com>