### PR TITLE
Fix documentation "information" typo

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/DataType.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/DataType.java
@@ -78,9 +78,9 @@ public class DataType {
 		doc.append("**");
 		if (!StringUtils.isEmpty(url)) {
 			doc.append(lineSeparator);
-			doc.append("See [documentation](");
+			doc.append("see [documentation](");
 			doc.append(getUrl());
-			doc.append(") for more informations.");
+			doc.append(") for more information.");
 		}
 		return doc.toString();
 	}


### PR DESCRIPTION
Fixes the typo present in documentation ie:

```
<?xml version="1.0" encoding="UTF-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:element name="root" type="">
  </xs:element>
</xs:schema>
```

Before this PR:
![image](https://user-images.githubusercontent.com/20326645/85787966-35dd5b80-b6fa-11ea-9cd5-478e464c2593.png)

After:
![image](https://user-images.githubusercontent.com/20326645/85788475-0aa73c00-b6fb-11ea-90c6-2271e0a69bb8.png)


Signed-off-by: David Kwon <dakwon@redhat.com>