### PR TITLE
Don't send invalid catalog notifications for paths with file scheme

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogPlugin.java
@@ -12,21 +12,20 @@
  */
 package org.eclipse.lemminx.extensions.catalog;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.lemminx.client.PathFeature;
 import org.eclipse.lemminx.client.InvalidPathWarner;
+import org.eclipse.lemminx.client.PathFeature;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
 import org.eclipse.lemminx.services.IXMLNotificationService;
 import org.eclipse.lemminx.services.extensions.IDocumentLinkParticipant;
 import org.eclipse.lemminx.services.extensions.IXMLExtension;
 import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
+import org.eclipse.lemminx.utils.FilesUtils;
 import org.eclipse.lsp4j.InitializeParams;
 
 /**
@@ -74,20 +73,14 @@ public class XMLCatalogPlugin implements IXMLExtension {
 			return; // happen when notification service is not available
 		}
 		String[] catalogs = cmSettings.getCatalogs();
-		Set<String> invalidCatalogs = Arrays.stream(catalogs).filter(c -> !isXMLCatalogFileValid(c)).collect(Collectors.toSet());
-
+		Set<String> invalidCatalogs = Arrays.stream(catalogs).filter(c -> {
+			return Files.notExists(FilesUtils.getPath(c));
+		}).collect(Collectors.toSet());
+		
 		if (invalidCatalogs.size() > 0) {
 			this.pathWarner.onInvalidFilePath(invalidCatalogs, PathFeature.CATALOGS);
 		} else {
 			this.pathWarner.evictKey(PathFeature.CATALOGS);
-		}
-	}
-
-	private static boolean isXMLCatalogFileValid(String catalogFile) {
-		try {
-			return new File(new URI(catalogFile).toString()).exists();
-		} catch (URISyntaxException e) {
-			return new File(catalogFile).exists();
 		}
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/uriresolver/XMLCatalogResolverExtension.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/uriresolver/XMLCatalogResolverExtension.java
@@ -12,10 +12,8 @@
  */
 package org.eclipse.lemminx.extensions.contentmodel.uriresolver;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +26,7 @@ import org.apache.xerces.xni.XMLResourceIdentifier;
 import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLInputSource;
 import org.eclipse.lemminx.uriresolver.URIResolverExtension;
+import org.eclipse.lemminx.utils.FilesUtils;
 
 /**
  * XML catalog URI resolver.
@@ -106,9 +105,8 @@ public class XMLCatalogResolverExtension implements URIResolverExtension {
 			for (String catalogPath : catalogs) {
 				// resolve catalog file path with root uri
 				String fullPath = expandSystemId(catalogPath);
-				// check if XML catalog path is valid
-				boolean valid = XMLCatalogResolverExtension.isXMLCatalogFileValid(fullPath);
-				if (valid) {
+				
+				if (Files.exists(FilesUtils.getPath(fullPath))) {
 					xmlCatalogFiles.add(fullPath);
 					LOGGER.info("Adding XML catalog '" + catalogPath + "' with expand system id '" + fullPath
 							+ "' and root URI '" + rootUri + "'.");
@@ -135,20 +133,6 @@ public class XMLCatalogResolverExtension implements URIResolverExtension {
 			return XMLEntityManager.expandSystemId(path, rootUri, false);
 		} catch (MalformedURIException e) {
 			return path;
-		}
-	}
-
-	/**
-	 * Returns true if the XML catalog file exists and false otherwise.
-	 * 
-	 * @param catalogFile catalog file to check.
-	 * @return true if the XML catalog file exists and false otherwise.
-	 */
-	private static boolean isXMLCatalogFileValid(String catalogFile) {
-		try {
-			return new File(new URI(catalogFile).getPath()).exists();
-		} catch (URISyntaxException e) {
-			return new File(catalogFile).exists();
 		}
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/InvalidPathWarnerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/InvalidPathWarnerTest.java
@@ -24,13 +24,9 @@ import org.junit.jupiter.api.Test;
  */
 public class InvalidPathWarnerTest extends AbstractNotifierTest {
 
-	private static final String userDir = System.getProperty("user.dir"); // C:..\..\folderName || /bin/.../java
-		
-	private static final String userDirForwardSlash = userDir.replace("\\", "/");
+	private static final String catalog1 = "catalog.xml";
 
-	private static final String catalog1 = userDir + "/src/test/resources/catalogs/catalog.xml";
-
-	private static final String catalog2 = userDir + "/src/test/resources/catalogs/catalog2.xml";
+	private static final String catalog2 = "catalog2.xml";
 
 	private static final PathFeature TEST_FEATURE = PathFeature.CATALOGS;
 	
@@ -103,25 +99,22 @@ public class InvalidPathWarnerTest extends AbstractNotifierTest {
 
 	@Test
 	public void testSendMessage() {
-		String filePath = userDirForwardSlash + catalog1;
 		setSupportCapabilities(false, false);
-		sendNotification(filePath);
+		sendNotification(catalog1);
 		assertCounts(0, 1);
 	}
 
 	@Test
 	public void testSendMessage2() {
-		String filePath = userDirForwardSlash + catalog1;
 		setSupportCapabilities(true, false);
-		sendNotification(filePath);
+		sendNotification(catalog1);
 		assertCounts(0, 1);
 	}
 
 	@Test
 	public void testSendMessage3() {
-		String filePath = userDirForwardSlash + catalog1;
 		setSupportCapabilities(false, true);
-		sendNotification(filePath);
+		sendNotification(catalog1);
 		assertCounts(0, 1);
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/FilesUtilsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/FilesUtilsTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class FilesUtilsTest {
 
 	@Test
-	public void testFilesCachePathPreference() throws Exception {	
+	public void testFilesCachePathPreference() throws Exception {
 		System.clearProperty(FilesUtils.LEMMINX_WORKDIR_KEY);
 		String newBasePathString = System.getProperty("user.home");
 		String newSubPathString = Paths.get("New", "Sub", "Path").toString();


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/289

The reason why completion from the catalog was working even though there was an error notification was because `XMLCatalogResolverExtension` used `new URI(catalogFile).getPath()` while `XMLCatalogPlugin` used `new URI(catalogFile).toString()`.

I removed `isXMLCatalogFileValid()` from `XMLCatalogResolverExtension` and `XMLCatalogPlugin`, and moved it into a utils class.

Signed-off-by: David Kwon <dakwon@redhat.com>