### PR TITLE
Use CompletableFuture in CacheResourceManagerTest 

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDHoverExtensionsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -75,13 +76,14 @@ public class DTDHoverExtensionsTest {
 			Path cachedFilePath = CacheResourcesManager.getResourceCachePath(httpDTDUri);
 			Files.deleteIfExists(cachedFilePath);
 
-			// Download the DTD by waiting 1 sec
 			CacheResourcesManager cacheResourcesManager = new CacheResourcesManager();
 			try {
 				cacheResourcesManager.getResource(httpDTDUri);
-			} catch (CacheResourceDownloadingException ignored) {
+				fail("Expected file to be downloading");
+			} catch (CacheResourceDownloadingException containsFuture) {
+				// Wait for download to finish
+				containsFuture.getFuture().get(30, TimeUnit.SECONDS);
 			}
-			TimeUnit.MILLISECONDS.sleep(1000);
 			assertTrue(Files.exists(cachedFilePath),
 					"'" + cachedFilePath + "' file should be downloaded in the cache.");
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaPublishDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaPublishDiagnosticsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 import static org.eclipse.lemminx.XMLAssert.pd;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.eclipse.lemminx.AbstractCacheBasedTest;
@@ -139,6 +140,8 @@ public class XMLSchemaPublishDiagnosticsTest extends AbstractCacheBasedTest {
 				" xsi:noNamespaceSchemaLocation=\"http://invoice.xsd\">\r\n" + //
 				"</invoice> \r\n" + //
 				"";
+
+		TimeUnit.SECONDS.sleep(2); // HACK: to make the timing work on slow machines
 
 		String expectedLocation = TEST_WORK_DIRECTORY.resolve("cache/http/invoice.xsd").toString();
 		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, configuration,


### PR DESCRIPTION
Use a CompletableFuture to wait for the download to finish when testing the CacheResourceManager. This should mean different CPU/network conditions don't cause the tests to fail. A generous timeout is given for the downloads.

Fixes #753

Signed-off-by: David Thompson <davthomp@redhat.com>