### PR TITLE
Doclink for catalog entries with 'catalog' attr

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogCatalogEntry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogCatalogEntry.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.catalog;
+
+import java.nio.file.Paths;
+
+import org.eclipse.lemminx.dom.DOMAttr;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMRange;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * Represents a catalog entry that uses the "catalog" attribute to reference an external document
+ */
+public class CatalogCatalogEntry extends CatalogEntry {
+
+	public CatalogCatalogEntry(@NonNull String baseURI, DOMElement entryElement) {
+		super(baseURI, entryElement);
+	}
+
+	@Override
+	public DOMRange getLinkRange() {
+		DOMAttr catalogAttr = CatalogUtils.getCatalogEntryCatalog(getEntryElement());
+		if (catalogAttr == null) {
+			return null;
+		}
+		return catalogAttr.getNodeAttrValue();
+	}
+
+	@Override
+	public String getResolvedURI() {
+		DOMAttr catalogAttr = CatalogUtils.getCatalogEntryCatalog(getEntryElement());
+		if (catalogAttr == null) {
+			return null;
+		}
+		String lastSegment = catalogAttr.getValue();
+		if (StringUtils.isBlank(lastSegment)) {
+			return null;
+		}
+		return Paths.get(getBaseURI(), lastSegment).toString();
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogEntry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogEntry.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.catalog;
+
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMRange;
+
+/**
+ * Represents a catalog entry that references an external document
+ */
+public abstract class CatalogEntry {
+
+	private final String baseURI;
+	private final DOMElement entryElement;
+
+	/**
+	 *
+	 * @param baseURI      <catalog>'s xml:base + <group>'s xml:base (if in a
+	 *                     <group>)
+	 * @param entryElement the element that corresponds with this catalog entry
+	 */
+	protected CatalogEntry(String baseURI, DOMElement entryElement) {
+		this.baseURI = baseURI;
+		this.entryElement = entryElement;
+	}
+
+	/**
+	 * Returns the base URI for this catalog entry
+	 *
+	 * @return the base URI for this catalog entry
+	 */
+	public String getBaseURI() {
+		return baseURI;
+	}
+
+	/**
+	 * Returns the element that corresponds with this catalog entry
+	 *
+	 * @return the element that corresponds with this catalog entry
+	 */
+	protected DOMElement getEntryElement() {
+		return entryElement;
+	}
+
+	/**
+	 * Returns the range in the document where the link to an external document is,
+	 * or null if this catalog entry does not refer to an external document
+	 *
+	 * @return the range in the document where the link to an external document is
+	 */
+	public abstract DOMRange getLinkRange();
+
+	/**
+	 * Returns the URI for the document that this catalog entry references, or null
+	 * if this catalog entry does not refer to an external document
+	 *
+	 * @return the URI for the document that this catalog entry references
+	 */
+	public abstract String getResolvedURI();
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/CatalogUtils.java
@@ -10,17 +10,19 @@
 
 package org.eclipse.lemminx.extensions.catalog;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.utils.DOMUtils;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
  * Utility functions for working with XML catalog documents
@@ -30,30 +32,39 @@ public class CatalogUtils {
 	/**
 	 * The catalog entries that have a 'uri' attribute
 	 */
-	private static final Collection<String> CATALOG_NAMES = Arrays.asList("public", "system", "uri", "systemSuffix",
+	private static final Collection<String> HAS_URI_ATTRIBUTE = Arrays.asList("public", "system", "uri", "systemSuffix",
 			"uriSuffix");
+
+	/**
+	 * The catalog entries that have a 'catalog' attribute
+	 */
+	private static final Collection<String> HAS_CATALOG_ATTRIBUTE = Arrays.asList("delegatePublic", "delegateSystem",
+			"delegateUri", "nextCatalog");
+
+	private static final String XML_BASE_ATTRIBUTE = "xml:base";
 
 	private static final String CATALOG_ENTITY_NAME = "catalog";
 
+	private static final String GROUP_ENTITY_NAME = "group";
+
 	private static final String URI_ATTRIBUTE_NAME = "uri";
 
+	private static final String CATALOG_ATTRIBUTE_NAME = "catalog";
+
 	/**
-	 * Returns a list of all the catalog entries that have the attribute 'uri', or
-	 * an empty list if the document is not a catalog.
+	 * Returns a list of all the catalog entries in the given document, or an empty
+	 * list if the document is not a catalog.
 	 *
-	 * @param document The document to collect the catalog entries from
-	 * @return A list of all the catalog entries that have the attribute 'uri', or
-	 *         an empty list if the document is not a catalog.
+	 * @return a list of all the catalog entries in the given document, or an empty
+	 *         list if the document is not a catalog.
 	 */
-	public static List<DOMElement> getCatalogEntries(DOMDocument document) {
+	public static List<CatalogEntry> getCatalogEntries(DOMDocument document) {
 		if (!DOMUtils.isCatalog(document)) {
 			return Collections.emptyList();
 		}
 		for (DOMNode n : document.getChildren()) {
 			if (CATALOG_ENTITY_NAME.equals(n.getNodeName())) {
-				return n.getChildren().stream().filter(CatalogUtils::isCatalogURIEntry).map((el) -> {
-					return (DOMElement) el;
-				}).collect(Collectors.toList());
+				return collectCatalogEntries((DOMElement) n);
 			}
 		}
 		return Collections.emptyList();
@@ -72,15 +83,114 @@ public class CatalogUtils {
 	}
 
 	/**
-	 * Checks if this node is a catalog entry that is required to have the 'uri'
-	 * attribute
+	 * Returns the catalog attribute node of the given catalog entry or null if
+	 * there is no catalog attribute
 	 *
-	 * @param node The node to check
-	 * @return true if this node is an catalog entry that is required to have the
+	 * @param element The catalog entry to get the catalog attribute of
+	 * @return the catalog attribute node of the given catalog entry or null if
+	 *         there is no catalog attribute
+	 */
+	public static DOMAttr getCatalogEntryCatalog(DOMElement element) {
+		return element.getAttributeNode(CATALOG_ATTRIBUTE_NAME);
+	}
+
+	/**
+	 * Returns true if this element is a catalog entry that is required to have the
+	 * 'uri' attribute and false otherwise
+	 *
+	 * @param element The element to check
+	 * @return true if this element is an catalog entry that is required to have the
 	 *         'uri' attribute and false otherwise
 	 */
-	private static boolean isCatalogURIEntry(DOMNode node) {
-		return node.isElement() && CATALOG_NAMES.contains(node.getNodeName());
+	private static boolean isCatalogEntryWithURI(DOMElement element) {
+		return HAS_URI_ATTRIBUTE.contains(element.getNodeName());
+	}
+
+	/**
+	 * Returns true if this element is a catalog entry that is required to have the
+	 * 'catalog' attribute and false otherwise
+	 *
+	 * @param element The element to check
+	 * @return true if this element is an catalog entry that is required to have the
+	 *         'catalog' attribute and false otherwise
+	 */
+	private static boolean isCatalogEntryWithCatalog(DOMElement element) {
+		return HAS_CATALOG_ATTRIBUTE.contains(element.getNodeName());
+	}
+
+	/**
+	 * Returns true if the given element is a group element and false otherwise
+	 *
+	 * @param element The element to check
+	 * @return true if the given element is a group element and false otherwise
+	 */
+	private static boolean isGroupCatalogEntry(DOMElement element) {
+		return GROUP_ENTITY_NAME.equals(element.getNodeName());
+	}
+
+	/**
+	 * Get a list of all catalog entry elements that are in the given catalog
+	 *
+	 * @param catalog the catalog element to collect the entries for
+	 * @return A list of all the catalog entities in this catalog
+	 */
+	private static List<CatalogEntry> collectCatalogEntries(@NonNull DOMElement catalog) {
+		List<CatalogEntry> entries = new ArrayList<>();
+		String baseURI = catalog.getAttribute(XML_BASE_ATTRIBUTE);
+		baseURI = baseURI == null ? "" : baseURI;
+		for (DOMNode node : catalog.getChildren()) {
+			if (node.isElement()) {
+				DOMElement element = (DOMElement) node;
+				CatalogEntry catalogEntry = createCatalogEntry(baseURI, element);
+				if (catalogEntry != null) {
+					entries.add(catalogEntry);
+				} else if (isGroupCatalogEntry(element)) {
+					entries.addAll(collectGroupEntries(element, baseURI));
+				}
+			}
+		}
+		return entries;
+	}
+
+	/**
+	 * Get a list of all catalog entry elements that are in the given group
+	 *
+	 * @param group   the group element to collect the entries for
+	 * @param baseURI the baseURI of the catalog
+	 * @return A list of all the catalog entities in this group
+	 */
+	private static List<CatalogEntry> collectGroupEntries(DOMElement group, @NonNull String baseURI) {
+		List<CatalogEntry> entries = new ArrayList<>();
+		String groupSegment = group.getAttribute(XML_BASE_ATTRIBUTE);
+		if (groupSegment != null) {
+			baseURI = Paths.get(baseURI, groupSegment).toString();
+		}
+		for (DOMNode node : group.getChildren()) {
+			if (node.isElement()) {
+				DOMElement element = (DOMElement) node;
+				CatalogEntry catalogEntry = createCatalogEntry(baseURI, element);
+				if (catalogEntry != null) {
+					entries.add(catalogEntry);
+				}
+			}
+		}
+		return entries;
+	}
+
+	/**
+	 * Returns a catalog entry for the given element and null if a catalog entry can't be made
+	 *
+	 * @param baseURI the base URI of the catalog entry
+	 * @param element the element to turn into a catalog entry
+	 * @return a catalog entry for the given element and null if a catalog entry can't be made
+	 */
+	private static CatalogEntry createCatalogEntry(@NonNull String baseURI, DOMElement element) {
+		if (isCatalogEntryWithURI(element)) {
+			return new URICatalogEntry(baseURI, element);
+		} else if (isCatalogEntryWithCatalog(element)) {
+			return new CatalogCatalogEntry(baseURI, element);
+		}
+		return null;
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/URICatalogEntry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/catalog/URICatalogEntry.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.catalog;
+
+import java.nio.file.Paths;
+
+import org.eclipse.lemminx.dom.DOMAttr;
+import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.DOMRange;
+import org.eclipse.lemminx.utils.StringUtils;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * Represents a catalog entry that uses the "uri" attribute to reference an external document
+ */
+public class URICatalogEntry extends CatalogEntry {
+
+	public URICatalogEntry(@NonNull String baseURI, DOMElement entryElement) {
+		super(baseURI, entryElement);
+	}
+
+	@Override
+	public DOMRange getLinkRange() {
+		DOMAttr uriAttr = CatalogUtils.getCatalogEntryURI(getEntryElement());
+		if (uriAttr == null) {
+			return null;
+		}
+		return uriAttr.getNodeAttrValue();
+	}
+
+	@Override
+	public String getResolvedURI() {
+		DOMAttr uriAttr = CatalogUtils.getCatalogEntryURI(getEntryElement());
+		if (uriAttr == null) {
+			return null;
+		}
+		String lastSegment = uriAttr.getValue();
+		if (StringUtils.isBlank(lastSegment)) {
+			return null;
+		}
+		return Paths.get(getBaseURI(), lastSegment).toString();
+	}
+
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDocumentLinkTest.java
@@ -102,4 +102,208 @@ public class XMLCatalogDocumentLinkTest {
 				dl(r(1, 39, 1, 54), "src/test/resources/my schema.xsd"));
 	}
 
+	@Test
+	public void testDelegatePublicEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <delegatePublic catalog=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 27, 1, 54), "src/test/resources/catalogs/catalog-public.xml"));
+	}
+
+	@Test
+	public void testDelegateSystemEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <delegateSystem catalog=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 27, 1, 54), "src/test/resources/catalogs/catalog-public.xml"));
+	}
+
+	@Test
+	public void testDelegateUriEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <delegateUri catalog=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 24, 1, 51), "src/test/resources/catalogs/catalog-public.xml"));
+	}
+
+	@Test
+	public void testNextCatalogEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <nextCatalog catalog=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 24, 1, 51), "src/test/resources/catalogs/catalog-public.xml"));
+	}
+
+	@Test
+	public void testCatalogEntryWithoutCatalog() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <public catalog=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testCatalogEntryWithoutURI() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <nextCatalog uri=\"catalogs/catalog-public.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testEmptyNextCatalogEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <nextCatalog catalog=\"\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testBlankNextCatalogEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <nextCatalog catalog=\"    	\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testEmptyPublicCatalogEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <public id=\"http://example.org\" uri=\"\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testBlankPublicCatalogEntry() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <public id=\"http://example.org\" uri=\"    	\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH);
+	}
+
+	@Test
+	public void testCatalogURIEntryWithXMLBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"dtd\">\n" + //
+				"  <public id=\"http://example.org\" uri=\"svg.dtd\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 39, 1, 46), "src/test/resources/dtd/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogURIEntryWithXMLBaseRelativeReference() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"./dtd\">\n" + //
+				"  <public id=\"http://example.org\" uri=\"svg.dtd\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 39, 1, 46), "src/test/resources/dtd/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogURIEntryWithXMLBaseTrailingBackslash() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"dtd/\">\n" + //
+				"  <public id=\"http://example.org\" uri=\"svg.dtd\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 39, 1, 46), "src/test/resources/dtd/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogURIEntryGroupWithBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <group xml:base=\"dtd\">\n" + //
+				"    <public id=\"http://example.org\" uri=\"svg.dtd\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 41, 2, 48), "src/test/resources/dtd/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogURIEntryGroupWithoutBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <group>\n" + //
+				"    <public id=\"http://example.org\" uri=\"dtd/svg.dtd\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 41, 2, 52), "src/test/resources/dtd/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogURIWithCatalogAndGroupBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"abc\">\n" + //
+				"  <group xml:base=\"def\">\n" + //
+				"    <public id=\"http://example.org\" uri=\"svg.dtd\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 41, 2, 48), "src/test/resources/abc/def/svg.dtd"));
+	}
+
+	@Test
+	public void testCatalogCatalogEntryWithXMLBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"catalog\">\n" + //
+				"  <nextCatalog catalog=\"catalog-liferay.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 24, 1, 43), "src/test/resources/catalog/catalog-liferay.xml"));
+	}
+
+	@Test
+	public void testCatalogCatalogEntryWithXMLBaseRelativeReference() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"./catalog\">\n" + //
+				"  <nextCatalog catalog=\"catalog-liferay.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 24, 1, 43), "src/test/resources/catalog/catalog-liferay.xml"));
+	}
+
+	@Test
+	public void testCatalogCatalogEntryWithXMLBaseTrailingBackslash() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"catalog/\">\n" + //
+				"  <nextCatalog catalog=\"catalog-liferay.xml\" />\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(1, 24, 1, 43), "src/test/resources/catalog/catalog-liferay.xml"));
+	}
+
+	@Test
+	public void testCatalogCatalogEntryGroupWithBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <group xml:base=\"catalog\">\n" + //
+				"    <nextCatalog catalog=\"catalog-liferay.xml\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 26, 2, 45), "src/test/resources/catalog/catalog-liferay.xml"));
+	}
+
+	@Test
+	public void testCatalogCatalogEntryGroupWithoutBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\n" + //
+				"  <group>\n" + //
+				"    <nextCatalog catalog=\"catalog/catalog-liferay.xml\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 26, 2, 53), "src/test/resources/catalog/catalog-liferay.xml"));
+	}
+
+	@Test
+	public void testCatalogCatalogWithCatalogAndGroupBase() {
+		String xml = "<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" xml:base=\"abc\">\n" + //
+				"  <group xml:base=\"def\">\n" + //
+				"    <nextCatalog catalog=\"catalog.xml\" />\n" + //
+				"  </group>\n" + //
+				"</catalog>";
+		testDocumentLinkFor(xml, CATALOG_PATH, //
+				dl(r(2, 26, 2, 37), "src/test/resources/abc/def/catalog.xml"));
+	}
+
 }


### PR DESCRIPTION
Any of the catalog entry elements that have the 'catalog' attribute to refer to another catalog are now doclinks.

Closes #845

Signed-off-by: David Thompson <davthomp@redhat.com>