### PR TITLE
XMLExtensionRegistry: capture initial settings if it's absent

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/FileContentGeneratorPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/generators/FileContentGeneratorPlugin.java
@@ -25,9 +25,11 @@ public class FileContentGeneratorPlugin implements IXMLExtension {
 
 	@Override
 	public void start(InitializeParams params, XMLExtensionsRegistry registry) {
-		IXMLFullFormatter formatter = (IXMLFullFormatter) registry;
-		FileContentGeneratorManager manager = new FileContentGeneratorManager(formatter);
-		registry.registerComponent(manager);
+		if (registry instanceof IXMLFullFormatter) {
+			IXMLFullFormatter formatter = (IXMLFullFormatter) registry;
+			FileContentGeneratorManager manager = new FileContentGeneratorManager(formatter);
+			registry.registerComponent(manager);
+		}
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/XMLExtensionsRegistry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/XMLExtensionsRegistry.java
@@ -27,6 +27,7 @@ import org.eclipse.lemminx.services.extensions.codelens.ICodeLensParticipant;
 import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.format.IFormatterParticipant;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
+import org.eclipse.lemminx.services.extensions.save.ISaveContext.SaveContextType;
 import org.eclipse.lemminx.uriresolver.URIResolverExtensionManager;
 import org.eclipse.lsp4j.InitializeParams;
 
@@ -110,7 +111,10 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 	public void doSave(ISaveContext saveContext) {
 		if (initialized) {
 			extensions.stream().forEach(extension -> extension.doSave(saveContext));
-		} else {
+		} else if (this.initialSaveContext == null || (saveContext != null && saveContext.getType() == SaveContextType.SETTINGS)) {
+			// capture initial configuration iff:
+			// 1. the saveContext is for configuration, not document save
+			// 2. we haven't captured settings before
 			this.initialSaveContext = saveContext;
 		}
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDoSaveTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDoSaveTest.java
@@ -1,0 +1,101 @@
+/**
+ *  Copyright (c) 2020 Yatao Li.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Yatao Li <yatao.li@live.com> - initial API and implementation
+ */
+package org.eclipse.lemminx.services.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Predicate;
+
+import org.eclipse.lemminx.XMLAssert.SettingsSaveContext;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.extensions.IXMLExtension;
+import org.eclipse.lemminx.services.extensions.XMLExtensionsRegistry;
+import org.eclipse.lemminx.services.extensions.save.ISaveContext;
+import org.eclipse.lsp4j.InitializeParams;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Ensures that {@code XMLExtensionsRegistry.doSave()} correctly captures the
+ * initial LS configuration, and the configuration is correctly forwarded to
+ * {@code IXMLExtension.doSave()} for registered extensions.
+ */
+public class ExtensionRegistryDoSaveTest {
+	
+	class RegistryTestExtension implements IXMLExtension {
+		
+		private ISaveContext context = null;
+		
+		@Override
+		public void start(InitializeParams params, XMLExtensionsRegistry registry) {
+		}
+
+		@Override
+		public void stop(XMLExtensionsRegistry registry) {
+		}
+		
+		@Override
+		public void doSave(ISaveContext context) {
+			this.context = context;
+		}
+
+		public ISaveContext getContext() {
+			return context;
+		}
+	}
+	
+	private static class SaveFileContext implements ISaveContext {
+		@Override
+		public DOMDocument getDocument(String uri) {
+			return null;
+		}
+
+		@Override
+		public void collectDocumentToValidate(Predicate<DOMDocument> validateDocumentPredicate) {
+		}
+
+		@Override
+		public SaveContextType getType() {
+			return SaveContextType.DOCUMENT;
+		}
+
+		@Override
+		public String getUri() {
+			return null;
+		}
+
+		@Override
+		public Object getSettings() {
+			return null;
+		}
+	}
+
+	@Test
+	public void initialConfiguration() {
+		XMLExtensionsRegistry registry = new XMLExtensionsRegistry();
+		ISaveContext settingsSaveContext = new SettingsSaveContext(new JsonObject());
+		// initial config passed in during server startup.
+		registry.doSave(settingsSaveContext);
+		// then another event comes in from the client
+		registry.doSave(new SaveFileContext());
+		// extension registration is triggered
+		registry.initializeIfNeeded();
+		RegistryTestExtension extension = new RegistryTestExtension();
+		registry.registerExtension(extension);
+		// examine that the extension properly receives the initial config
+		assertEquals(settingsSaveContext, extension.getContext());
+	}
+}


### PR DESCRIPTION
See: https://github.com/fannheyward/coc-xml/issues/9

Symptom is, `xml.fileAssociations` doesn't work with `coc.nvim`.

Pasting my comment in that issue:

------------------

Observations from my debug run:

The file associations successfully made it into `XMLLanguageServer.updateSettings`. Around line 184,
```java
		ContentModelSettings cmSettings = ContentModelSettings
				.getContentModelXMLSettings(initializationOptionsSettings);
```
I can see the file association rules in cmSettings. However, it's not used to populate the `XMLFileAssociationResolverExtension` settings.

The only path to `XMLFileAssociationResolverExtension.setFileAssociations` is through `XMLTextDocumentService.doSave` ->  `ContentModelPlugin.doSave` -> `ContentModelManager.setFileAssociations`:

```java
	public void doSave(ISaveContext saveContext) {
		if (initialized) {
			extensions.stream().forEach(extension -> extension.doSave(saveContext));
		} else {
			this.initialSaveContext = saveContext;
		}
	}
```

```java
		Object initializationOptionsSettings = saveContext.getSettings();
		cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
```

unfortunately, `coc.nvim` emits `didSave` event too fast, and `XMLTextDocumentService.doSave` is called twice before the extensions are registered... And the actual initial save context is lost.