### PR TITLE
Fix error range for cvc-complex-type-2.3

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLPositionUtility.java
@@ -81,7 +81,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the attribute name range and null otherwise.
-	 * 
+	 *
 	 * @param attr the attribute.
 	 * @return the attribute name range and null otherwise.
 	 */
@@ -100,7 +100,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the attribute value range and null otherwise.
-	 * 
+	 *
 	 * @param attr the attribute.
 	 * @return the attribute value range and null otherwise.
 	 */
@@ -171,7 +171,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the range of the prefix of an attribute name
-	 * 
+	 *
 	 * For example, if attrName = "xsi:example", the range for "xsi" will be
 	 * returned
 	 */
@@ -309,7 +309,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the root start tag (excludes the '<') of the given
 	 * <code>document</code> and null otherwise.
-	 * 
+	 *
 	 * @param document the DOM document.
 	 * @return the range of the root start tag (excludes the '<') of the given
 	 *         <code>document</code> and null otherwise.
@@ -328,9 +328,9 @@ public class XMLPositionUtility {
 	/**
 	 * Finds the root element of the given document and returns the attribute value
 	 * <code>Range</code> for the attribute <code>attrName</code>.
-	 * 
+	 *
 	 * If <code>attrName</code> is not declared then null is returned.
-	 * 
+	 *
 	 * @param attrName The name of the attribute to find the range of the value for
 	 * @param document The document to use the root element of
 	 * @return The range in <code>document</code> where the declared value of
@@ -363,7 +363,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the start tag name (excludes the '<') of the given
 	 * <code>element</code> and null otherwise.
-	 * 
+	 *
 	 * @param element the DOM element
 	 * @return the range of the start tag of the given <code>element</code> and null
 	 *         otherwise.
@@ -375,7 +375,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of a tag's local name. If the tag does not have a prefix,
 	 * implying it doesn't have a local name, it will return null.
-	 * 
+	 *
 	 * @param element
 	 * @return
 	 */
@@ -386,10 +386,10 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the start tag name (excludes the '<') of the given
 	 * <code>element</code> and null otherwise.
-	 * 
+	 *
 	 * If suffixOnly is true then it will try to return the range of the
 	 * localName/suffix. Else it will return null.
-	 * 
+	 *
 	 * @param element    the DOM element
 	 * @param suffixOnly select the suffix portion, only when a prefix exists
 	 * @return the range of the start tag of the given <code>element</code> and null
@@ -450,7 +450,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the end tag of the given <code>element</code> name and
 	 * null otherwise.
-	 * 
+	 *
 	 * @param element the DOM element
 	 * @return the range of the end tag of the given <code>element</code> and null
 	 *         otherwise.
@@ -462,7 +462,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the end tag of the given LOCAL <code>element</code> name
 	 * and null otherwise.
-	 * 
+	 *
 	 * @param element the DOM element
 	 * @return the range of the end tag of the given <code>element</code> and null
 	 *         otherwise.
@@ -474,7 +474,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the end tag of the given <code>element</code> and null
 	 * otherwise.
-	 * 
+	 *
 	 * @param element the DOM element
 	 * @return the range of the end tag of the given <code>element</code> and null
 	 *         otherwise.
@@ -502,7 +502,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the entity reference in a text node (ex : &amp;) and
 	 * null otherwise.
-	 * 
+	 *
 	 * @param offset   the offset
 	 * @param document the document
 	 * @return the range of the entity reference in a text node (ex : &amp;) and
@@ -515,7 +515,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range of the entity reference in a text node (ex : &amp;) and
 	 * null otherwise.
-	 * 
+	 *
 	 * @param offset            the offset
 	 * @param document          the document
 	 * @param endsWithSemicolon true if the entity reference must end with ';' and
@@ -547,7 +547,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the start offset of the entity reference (ex : &am|p;) from the left
 	 * of the given offset and -1 if no entity reference.
-	 * 
+	 *
 	 * @param text   the XML content.
 	 * @param offset the offset.
 	 * @return the start offset of the entity reference (ex : &am|p;) from the left
@@ -582,7 +582,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the end offset of the entity reference (ex : &am|p;) from the right
 	 * of the given offset and -1 if no entity reference.
-	 * 
+	 *
 	 * @param text   the XML content.
 	 * @param offset the offset.
 	 * @return the end offset of the entity reference (ex : &am|p;) from the right
@@ -605,12 +605,13 @@ public class XMLPositionUtility {
 		DOMNode element = document.findNodeAt(offset);
 		if (element != null) {
 			for (DOMNode node : element.getChildren()) {
-				if (node.isCharacterData() && ((DOMCharacterData) node).hasMultiLine()) {
-					String content = ((DOMCharacterData) node).getData();
-					int start = node.getStart();
+				if (node.isCharacterData()) {
+					DOMCharacterData data = (DOMCharacterData) node;
+					int start = data.getStartContent();
 					Integer end = null;
-					for (int i = 0; i < content.length(); i++) {
-						char c = content.charAt(i);
+					String text = document.getText();
+					for (int i = start; i < data.getEndContent(); i++) {
+						char c = text.charAt(i);
 						if (end == null) {
 							if (Character.isWhitespace(c)) {
 								start++;
@@ -637,7 +638,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the text content range and null otherwise.
-	 * 
+	 *
 	 * @param text the DOM text node..
 	 * @return the text content range and null otherwise.
 	 */
@@ -670,17 +671,17 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the range covering the trimmed text belonging to the node located at
 	 * offset.
-	 * 
+	 *
 	 * This method assumes that the node located at offset only contains text.
-	 * 
+	 *
 	 * For example, if the node located at offset is:
-	 * 
+	 *
 	 * <a> hello
-	 * 
+	 *
 	 * </a>
-	 * 
+	 *
 	 * the returned range will cover only "hello".
-	 * 
+	 *
 	 * @param offset
 	 * @param document
 	 * @return range covering the trimmed text belonging to the node located at
@@ -731,7 +732,7 @@ public class XMLPositionUtility {
 	/**
 	 * Will give the range for the last VALID DTD Decl parameter at 'offset'. An
 	 * unrecognized Parameter is not considered VALID,
-	 * 
+	 *
 	 * eg: "<!ELEMENT elementName (content) UNRECOGNIZED_CONTENT" will give the
 	 * range of 1 character length, after '(content)'
 	 */
@@ -768,7 +769,7 @@ public class XMLPositionUtility {
 	/**
 	 * Will give the range for the last VALID DTD Decl parameter at 'offset'. An
 	 * unrecognized Parameter is not considered VALID,
-	 * 
+	 *
 	 * eg: <!ELEMENT elementName (content) UNRECOGNIZED_CONTENT will give the range
 	 * 1 character after '(content)'
 	 */
@@ -799,7 +800,7 @@ public class XMLPositionUtility {
 	/**
 	 * Will give the range for the last DTD Decl parameter at 'offset'. An
 	 * unrecognized Parameter is considered as well.
-	 * 
+	 *
 	 * eg: <!ELEMENT elementName (content) UNRECOGNIZED_CONTENT will give the range
 	 * 1 character after '(content)'
 	 */
@@ -848,7 +849,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the range for the given <code>node</code>.
-	 * 
+	 *
 	 * @param node the node
 	 * @return the range for the given <code>node</code>.
 	 */
@@ -868,7 +869,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the location link for the given <code>origin</code> and
 	 * <code>target</code> nodes.
-	 * 
+	 *
 	 * @param origin the origin node.
 	 * @param target the target node.
 	 * @return the location link for the given <code>origin</code> and
@@ -887,7 +888,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the location link for the given <code>origin</code> and
 	 * <code>target</code> nodes.
-	 * 
+	 *
 	 * @param origin the origin node.
 	 * @param target the target node.
 	 * @return the location link for the given <code>origin</code> and
@@ -903,7 +904,7 @@ public class XMLPositionUtility {
 	/**
 	 * Returns the location link for the given <code>origin</code> and
 	 * <code>target</code> nodes.
-	 * 
+	 *
 	 * @param origin the origin node.
 	 * @param target the target node.
 	 * @return the location link for the given <code>origin</code> and
@@ -917,7 +918,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the location for the given <code>target</code> node.
-	 * 
+	 *
 	 * @param target the target node.
 	 * @return the location for the given <code>target</code> node.
 	 */
@@ -929,7 +930,7 @@ public class XMLPositionUtility {
 
 	/**
 	 * Create a document link
-	 * 
+	 *
 	 * @param target   The range in the document that should be the link
 	 * @param location URI where the link should point
 	 * @param adjust   <code>true</code> means the first and last character of
@@ -949,10 +950,10 @@ public class XMLPositionUtility {
 
 	/**
 	 * Returns the range covering the first child of the node located at offset.
-	 * 
+	 *
 	 * Returns null if node is not a DOMElement, or if a node does not exist at
 	 * offset.
-	 * 
+	 *
 	 * @param offset
 	 * @param document
 	 * @return range covering the first child of the node located at offset

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 import java.util.Arrays;
 
 import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
 import org.eclipse.lemminx.settings.EnforceQuoteStyle;
@@ -572,7 +573,7 @@ public class XMLSchemaDiagnosticsTest {
 	}
 
 	/**
-	 * 
+	 *
 	 * @throws Exception
 	 * @see https://github.com/eclipse/lemminx/issues/856
 	 */
@@ -767,6 +768,102 @@ public class XMLSchemaDiagnosticsTest {
 		XMLAssert.testDiagnosticsFor(xml, missingSchema, eltDiagnostic);
 
 		XMLAssert.testCodeActionsFor(xml, missingSchema);
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_singleLine() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar>/bar></bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 7, 12, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 7, 3, 12, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_multiLine() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar>/bar>\n" + //
+				"barbarbar</bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 7, 12, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 7, 3, 12, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_singleLineSpaces() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar>    	/bar> 	 	</bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 12, 17, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 12, 3, 17, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_singleLineCData() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar> <![CDATA[ bar ]]> </bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 18, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 18, 3, 21, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_multiLineCData() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar> <![CDATA[ bar\n" + //
+				"   hi ]]> </bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 18, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 18, 3, 21, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_blankCData() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar> <![CDATA[  ]]> </bar>\n" + //
+				"</foo>";
+		XMLAssert.testDiagnosticsFor(xml);
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_blankCDataWithTextAfter() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar> <![CDATA[  ]]> TextContent </bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 23, 34, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 23, 3, 34, "")));
+	}
+
+	@Test
+	public void cvc_complex_type_2_3_elementBeforeText() throws BadLocationException {
+		String xml = "<foo\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
+				"  <bar /> TextContent <bar></bar>\n" + //
+				"</foo>";
+		Diagnostic diagnostic = d(3, 10, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 10, 3, 21, "")));
 	}
 
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) {

--- a/org.eclipse.lemminx/src/test/resources/xsd/close-tag-type.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/close-tag-type.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="bar" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="foo" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bar">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="bar" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="foo" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Now handles text nodes that are only take up one line, as well as `<![CDATA[]]>`.

Closes #885

Signed-off-by: David Thompson <davthomp@redhat.com>
