### PR TITLE
Format comments which have no end comments should not generate end comments

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -413,7 +413,10 @@ class XMLFormatter {
 		private void formatComment(DOMComment comment) {
 			this.xmlBuilder.startComment(comment);
 			this.xmlBuilder.addContentComment(comment.getData());
-			this.xmlBuilder.endComment();
+			if (comment.isClosed()) {
+				// Generate --> only if comment is closed.
+				this.xmlBuilder.endComment();
+			}
 			if (this.indentLevel == 0) {
 				linefeedOnNextWrite = true;
 			}
@@ -428,7 +431,10 @@ class XMLFormatter {
 		private void formatCDATA(DOMCDATASection cdata) {
 			this.xmlBuilder.startCDATA();
 			this.xmlBuilder.addContentCDATA(cdata.getData());
-			this.xmlBuilder.endCDATA();
+			if (cdata.isClosed()) {
+				// Generate ]> only if CDATA is closed.
+				this.xmlBuilder.endCDATA();
+			}
 		}
 
 		/**

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -55,7 +55,7 @@ public class XMLFormatterTest {
 	@Test
 	public void selfClosingTag() throws BadLocationException {
 		String content = "<a></a>";
-		String expected =  content;
+		String expected = content;
 		assertFormat(content, expected);
 	}
 
@@ -92,7 +92,7 @@ public class XMLFormatterTest {
 		String expected = content;
 		assertFormat(content, expected);
 	}
-	
+
 	@Test
 	public void endTagMissing() throws BadLocationException {
 		String content = "<foo>\r\n" + //
@@ -566,6 +566,54 @@ public class XMLFormatterTest {
 				"2222" + lineSeparator() + //
 				"  3333 -->" + lineSeparator() + //
 				"</a>";
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void testCommentNotClosed() throws BadLocationException {
+		String content = "<foo>\r\n" + //
+				"  <!-- \r\n" + //
+				"</foo>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void testCommentWithRange() throws BadLocationException {
+		String content = "<foo>\r\n" + //
+				"  <!-- |<bar>|\r\n" + //
+				"  </bar>\r\n" + //
+				"	-->\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"  <!-- <bar>\r\n" + //
+				"  </bar>\r\n" + //
+				"	-->\r\n" + //
+				"</foo>";
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void testCDATANotClosed() throws BadLocationException {
+		String content = "<foo>\r\n" + //
+				"  <![CDATA[ \r\n" + //
+				"</foo>";
+		String expected = content;
+		assertFormat(content, expected);
+	}
+
+	@Test
+	public void testCDATAWithRange() throws BadLocationException {
+		String content = "<foo>\r\n" + //
+				"  <![CDATA[ |<bar>|\r\n" + // 
+				"  </bar>\r\n" + //
+				"  ]]>\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"  <![CDATA[ <bar>\r\n" + // 
+				"  </bar>\r\n" + //
+				"  ]]>\r\n" + //
+				"</foo>";
 		assertFormat(content, expected);
 	}
 


### PR DESCRIPTION
Format comments which have no end comments should not generate end

Fixes https://github.com/redhat-developer/vscode-xml/issues/347

Signed-off-by: azerr <azerr@redhat.com>