### PR TITLE
Fix Symbols are not computed when ResultLimitExceededException is thrown

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
@@ -89,15 +89,15 @@ class XMLSymbolsProvider {
 		SymbolInformationResult symbols = new SymbolInformationResult(limit);
 		XMLSymbolFilter filter = symbolSettings.getFilterFor(xmlDocument.getDocumentURI());
 
-		// Process symbols participants
-		if (processSymbolsParticipants(xmlDocument, symbols, null, filter, cancelChecker)) {
-			return symbols;
-		}
-
-		// Process default symbol providers
-		boolean isDTD = xmlDocument.isDTD();
-		boolean hasFilterForAttr = filter.hasFilterFor(MatcherType.ATTRIBUTE);
 		try {
+			// Process symbols participants
+			if (processSymbolsParticipants(xmlDocument, symbols, null, filter, cancelChecker)) {
+				return symbols;
+			}
+
+			// Process default symbol providers
+			boolean isDTD = xmlDocument.isDTD();
+			boolean hasFilterForAttr = filter.hasFilterFor(MatcherType.ATTRIBUTE);
 			for (DOMNode node : xmlDocument.getRoots()) {
 				try {
 					findSymbolInformations(node, "", symbols, (node.isDoctype() && isDTD), filter, hasFilterForAttr,
@@ -160,16 +160,16 @@ class XMLSymbolsProvider {
 		DocumentSymbolsResult symbols = new DocumentSymbolsResult(limit);
 		XMLSymbolFilter filter = symbolSettings.getFilterFor(xmlDocument.getDocumentURI());
 
-		// Process symbols participants
-		if (processSymbolsParticipants(xmlDocument, null, symbols, filter, cancelChecker)) {
-			return symbols;
-		}
-
-		// Process default symbol providers
-		boolean isDTD = xmlDocument.isDTD();
-		boolean hasFilterForAttr = filter.hasFilterFor(MatcherType.ATTRIBUTE);
-		List<DOMNode> nodesToIgnore = new ArrayList<>();
 		try {
+			// Process symbols participants
+			if (processSymbolsParticipants(xmlDocument, null, symbols, filter, cancelChecker)) {
+				return symbols;
+			}
+
+			// Process default symbol providers
+			boolean isDTD = xmlDocument.isDTD();
+			boolean hasFilterForAttr = filter.hasFilterFor(MatcherType.ATTRIBUTE);
+			List<DOMNode> nodesToIgnore = new ArrayList<>();
 			xmlDocument.getRoots().forEach(node -> {
 				try {
 					if ((node.isDoctype() && isDTD)) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ReferencedGrammarSymbolsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ReferencedGrammarSymbolsTest.java
@@ -226,6 +226,26 @@ public class ReferencedGrammarSymbolsTest {
 
 	}
 
+	@Test
+	public void withSymbolLimit() throws BadLocationException, MalformedURIException {
+		XMLSymbolSettings settings = new XMLSymbolSettings();
+		settings.setMaxItemsComputed(3);
+
+		String dtdFileURI = getDTDFileURI("src/test/resources/dtd/entities/base.dtd");
+		String xml = "<!DOCTYPE root-element SYSTEM \"dtd/entities/base.dtd\">\r\n" + //
+				"<root-element>\r\n" + //
+				"</root-element>";
+		testDocumentSymbolsFor(xml, "src/test/resources/base.xml", settings, //
+				// Referenced grammar symbols
+				ds("Grammars", SymbolKind.Module, r(0, 0, 0, 1), r(0, 0, 0, 1), null, //
+						Arrays.asList( //
+								ds(dtdFileURI, SymbolKind.File, r(0, 0, 0, 1), r(0, 0, 0, 1), null, //
+										Arrays.asList( //
+												ds("Binding: doctype", SymbolKind.Property, r(0, 30, 0, 53),
+														r(0, 30, 0, 53), null, null))))) //
+		);
+	}
+
 	private static XMLFileAssociation[] createXSDAssociations(String baseSystemId) {
 		XMLFileAssociation format = new XMLFileAssociation();
 		format.setPattern("**/*.Format.ps1xml");


### PR DESCRIPTION
Fix Symbols are not computed when ResultLimitExceededException is thrown

Fixes #928

Signed-off-by: azerr <azerr@redhat.com>