### PR TITLE
Add new formatting setting `xml.format.splitAttributesIndentSize`

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
@@ -17,7 +17,7 @@ import org.eclipse.lsp4j.FormattingOptions;
 /**
  * This class is the root of all formatting settings. It is necessary to update
  * this class for any new additions.
- * 
+ *
  * All defaults should be set here to eventually be overridden if needed.
  */
 public class XMLFormattingOptions extends FormattingOptions {
@@ -28,6 +28,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 	public static final EnforceQuoteStyle DEFAULT_ENFORCE_QUOTE_STYLE = EnforceQuoteStyle.ignore;
 	public static final boolean DEFAULT_PRESERVE_ATTR_LINE_BREAKS = false;
 	public static final boolean DEFAULT_TRIM_TRAILING_SPACES = false;
+	public static final int DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE = 2;
 
 	// All possible keys
 	private static final String SPLIT_ATTRIBUTES = "splitAttributes";
@@ -43,51 +44,52 @@ public class XMLFormattingOptions extends FormattingOptions {
 	private static final String ENFORCE_QUOTE_STYLE = "enforceQuoteStyle";
 	private static final String PRESERVE_ATTR_LINE_BREAKS = "preserveAttributeLineBreaks";
 	private static final String PRESERVE_EMPTY_CONTENT = "preserveEmptyContent";
+	private static final String SPLIT_ATTRIBUTES_INDENT_SIZE = "splitAttributesIndentSize";
 
 	/**
 	 * Options for formatting empty elements.
-	 * 
+	 *
 	 * <ul>
 	 * <li>{@link #expand} : expand empty elements. With this option the following
 	 * XML:
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * <example />
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * will be formatted to :
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * <example><example>
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * </li>
 	 * <li>{@link #collapse} : collapse empty elements. With this option the
 	 * following XML:
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * <example></example>
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * will be formatted to :
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * <example />
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * </li>
 	 * <li>{@link #ignore} : keeps the original XML content for empty elements.
 	 * </li>
 	 * </ul>
-	 * 
+	 *
 	 */
 	public static enum EmptyElements {
 		expand, collapse, ignore;
@@ -125,6 +127,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 		this.setPreserveEmptyContent(false);
 		this.setPreservedNewlines(DEFAULT_PRESERVER_NEW_LINES);
 		this.setEmptyElement(EmptyElements.ignore);
+		this.setSplitAttributesIndentSize(DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE);
 	}
 
 	public XMLFormattingOptions(int tabSize, boolean insertSpaces, boolean initializeDefaultSettings) {
@@ -284,7 +287,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 
 	/**
 	 * Returns the value of trimFinalNewlines.
-	 * 
+	 *
 	 * If the trimFinalNewlines does not exist, defaults to true.
 	 */
 	@Override
@@ -309,13 +312,13 @@ public class XMLFormattingOptions extends FormattingOptions {
 	public EnforceQuoteStyle getEnforceQuoteStyle() {
 		String value = this.getString(XMLFormattingOptions.ENFORCE_QUOTE_STYLE);
 		EnforceQuoteStyle enforceStyle = null;
-		
+
 		try {
 			enforceStyle = value == null ? null : EnforceQuoteStyle.valueOf(value);
 		} catch (IllegalArgumentException e) {
 			return DEFAULT_ENFORCE_QUOTE_STYLE;
 		}
-		
+
 		return enforceStyle == null ? DEFAULT_ENFORCE_QUOTE_STYLE : enforceStyle;
 	}
 
@@ -328,7 +331,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 
 	/**
 	 * Returns the value of preserveAttrLineBreaks
-	 * 
+	 *
 	 * @return the value of preserveAttrLineBreaks
 	 */
 	public boolean isPreserveAttrLineBreaks() {
@@ -343,6 +346,25 @@ public class XMLFormattingOptions extends FormattingOptions {
 		} else {
 			return XMLFormattingOptions.DEFAULT_PRESERVE_ATTR_LINE_BREAKS;
 		}
+	}
+
+	/**
+	 * Sets the value of splitAttributesIndentSize
+	 *
+	 * @param splitAttributesIndentSize the new value for splitAttributesIndentSize
+	 */
+	public void setSplitAttributesIndentSize(int splitAttributesIndentSize) {
+		this.putNumber(SPLIT_ATTRIBUTES_INDENT_SIZE, Integer.valueOf(splitAttributesIndentSize));
+	}
+
+	/**
+	 * Returns the value of splitAttributesIndentSize or zero if it was set to a negative value
+	 *
+	 * @return the value of splitAttributesIndentSize or zero if it was set to a negative value
+	 */
+	public int getSplitAttributesIndentSize() {
+		int splitAttributesIndentSize = getNumber(SPLIT_ATTRIBUTES_INDENT_SIZE).intValue();
+		return splitAttributesIndentSize < 0 ? 0 : splitAttributesIndentSize;
 	}
 
 	public XMLFormattingOptions merge(FormattingOptions formattingOptions) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -35,7 +35,6 @@ public class XMLBuilder {
 	private final String lineDelimiter;
 	private final StringBuilder xml;
 	private final String whitespacesIndent;
-	private final int splitAttributesIndent = 2;
 
 	private final Collection<IFormatterParticipant> formatterParticipants;
 
@@ -174,7 +173,7 @@ public class XMLBuilder {
 	public XMLBuilder addAttribute(String name, String value, int level, boolean surroundWithQuotes) {
 		if (isSplitAttributes()) {
 			linefeed();
-			indent(level + splitAttributesIndent);
+			indent(level + sharedSettings.getFormattingSettings().getSplitAttributesIndentSize());
 		} else {
 			appendSpace();
 		}
@@ -190,7 +189,7 @@ public class XMLBuilder {
 	private XMLBuilder addAttribute(DOMAttr attr, int level, boolean surroundWithQuotes) {
 		if (isSplitAttributes()) {
 			linefeed();
-			indent(level + splitAttributesIndent);
+			indent(level + sharedSettings.getFormattingSettings().getSplitAttributesIndentSize());
 		} else {
 			appendSpace();
 		}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -605,12 +605,12 @@ public class XMLFormatterTest {
 	@Test
 	public void testCDATAWithRange() throws BadLocationException {
 		String content = "<foo>\r\n" + //
-				"  <![CDATA[ |<bar>|\r\n" + // 
+				"  <![CDATA[ |<bar>|\r\n" + //
 				"  </bar>\r\n" + //
 				"  ]]>\r\n" + //
 				"</foo>";
 		String expected = "<foo>\r\n" + //
-				"  <![CDATA[ <bar>\r\n" + // 
+				"  <![CDATA[ <bar>\r\n" + //
 				"  </bar>\r\n" + //
 				"  ]]>\r\n" + //
 				"</foo>";
@@ -2847,6 +2847,61 @@ public class XMLFormatterTest {
 				"  a4=\"123456789\" a5=\"123456789\" a6=\"123456789\"\n" + //
 				"  a7=\"123456789\" a8=\"123456789\" a9=\"123456789\"\n" + //
 				"></a>";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void splitAttributesIndentSize0() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(0);
+
+		String content = "<root a='a' b='b' c='c'/>\n";
+		String expected = "<root\n" + //
+				"a='a'\n" + //
+				"b='b'\n" + //
+				"c='c' />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void splitAttributesIndentSizeNegative() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(-1);
+
+		String content = "<root a='a' b='b' c='c'/>\n";
+		String expected = "<root\n" + //
+				"a='a'\n" + //
+				"b='b'\n" + //
+				"c='c' />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void splitAttributesIndentSize1() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(1);
+
+		String content = "<root a='a' b='b' c='c'/>\n";
+		String expected = "<root\n" + //
+				"  a='a'\n" + //
+				"  b='b'\n" + //
+				"  c='c' />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void splitAttributesIndentSizeDefault() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+
+		String content = "<root a='a' b='b' c='c'/>\n";
+		String expected = "<root\n" + //
+				"    a='a'\n" + //
+				"    b='b'\n" + //
+				"    c='c' />";
 		assertFormat(content, expected, settings);
 	}
 


### PR DESCRIPTION
Add a new setting which controls the level of indentation of attributes with respect to their parent element when `xml.format.splitAttributes` is enabled.

Based off of a comment by Cong Wang (@I322871) on the vscode-xml Gitter

Signed-off-by: David Thompson <davthomp@redhat.com>
