### PR TITLE
Disable XSD validation when xsi:schemaLocation doesn't declare the hint for the document element root.

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.lemminx.extensions.contentmodel;
 
+import java.util.Objects;
+
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationAllFilesCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationFileCommand;
@@ -24,6 +26,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelSymb
 import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelTypeDefinitionParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.participants.diagnostics.ContentModelDiagnosticsParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.services.IXMLDocumentProvider;
 import org.eclipse.lemminx.services.IXMLValidationService;
 import org.eclipse.lemminx.services.extensions.ICodeActionParticipant;
@@ -69,6 +72,8 @@ public class ContentModelPlugin implements IXMLExtension {
 
 	private ContentModelSettings cmSettings;
 
+	private XMLValidationSettings currentValidationSettings;
+
 	public ContentModelPlugin() {
 		completionParticipant = new ContentModelCompletionParticipant();
 		hoverParticipant = new ContentModelHoverParticipant();
@@ -105,6 +110,8 @@ public class ContentModelPlugin implements IXMLExtension {
 		cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
 		if (cmSettings != null) {
 			updateSettings(cmSettings, saveContext);
+		} else {
+			currentValidationSettings = null;
 		}
 	}
 
@@ -144,6 +151,12 @@ public class ContentModelPlugin implements IXMLExtension {
 		// Update symbols
 		boolean showReferencedGrammars = settings.isShowReferencedGrammars();
 		symbolsProviderParticipant.setEnabled(showReferencedGrammars);
+		// Track if validation settings has changed
+		XMLValidationSettings oldValidationSettings = currentValidationSettings;
+		currentValidationSettings = cmSettings.getValidation();
+		if (oldValidationSettings != null && !Objects.equals(oldValidationSettings, currentValidationSettings)) {
+			context.collectDocumentToValidate(d -> true);
+		}
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/XMLValidator.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/diagnostics/XMLValidator.java
@@ -13,7 +13,9 @@
 package org.eclipse.lemminx.extensions.contentmodel.participants.diagnostics;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,15 +23,21 @@ import java.util.concurrent.CancellationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.parsers.SAXParser;
+import org.apache.xerces.util.URI.MalformedURIException;
 import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMDocumentType;
 import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.dom.NoNamespaceSchemaLocation;
+import org.eclipse.lemminx.dom.SchemaLocationHint;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
+import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLSchemaSettings;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.services.extensions.diagnostics.LSPContentHandler;
 import org.eclipse.lemminx.uriresolver.CacheResourceDownloadingException;
@@ -82,19 +90,24 @@ public class XMLValidator {
 			// Add LSP content handler to stop XML parsing if monitor is canceled.
 			parser.setContentHandler(new LSPContentHandler(monitor));
 
-			boolean hasSchemaGrammar = document.hasSchemaLocation() || document.hasNoNamespaceSchemaLocation()
+			// warn if XML document is not bound to a grammar according the settings
+			warnNoGrammar(document, diagnostics, validationSettings);
+			// Update external grammar location (file association)
+			updateExternalGrammarLocation(document, parser);
+
+			boolean hasSchemaLocation = document.hasSchemaLocation();
+			boolean hasNoNamespaceSchemaLocation = document.hasNoNamespaceSchemaLocation();
+			boolean hasSchemaGrammar = hasSchemaLocation || hasNoNamespaceSchemaLocation
 					|| hasExternalSchemaGrammar(document);
+			boolean schemaValidationEnabled = (hasSchemaGrammar
+					&& isSchemaValidationEnabled(document, validationSettings)
+					|| (hasNoNamespaceSchemaLocation
+							&& isNoNamespaceSchemaValidationEnabled(document, validationSettings)));
+			parser.setFeature("http://apache.org/xml/features/validation/schema", schemaValidationEnabled); //$NON-NLS-1$
+
 			boolean hasGrammar = document.hasDTD() || hasSchemaGrammar || document.hasExternalGrammar();
-			// If diagnostics for Schema preference is enabled
-			if ((validationSettings == null) || validationSettings.isSchema()) {
-
-				updateExternalGrammarLocation(document, parser);
-				parser.setFeature("http://apache.org/xml/features/validation/schema", hasSchemaGrammar); //$NON-NLS-1$
-
-				// warn if XML document is not bound to a grammar according the settings
-				warnNoGrammar(document, diagnostics, validationSettings);
-			} else {
-				hasGrammar = false; // validation for Schema was disabled
+			if (hasSchemaGrammar && !schemaValidationEnabled) {
+				hasGrammar = false;
 			}
 			parser.setFeature("http://xml.org/sax/features/validation", hasGrammar); //$NON-NLS-1$
 
@@ -111,6 +124,125 @@ public class XMLValidator {
 		} finally {
 			reporterForXML.endReport();
 			reporterForGrammar.endReport();
+		}
+	}
+
+	private static boolean isSchemaValidationEnabled(DOMDocument document, XMLValidationSettings validationSettings) {
+		if (validationSettings == null) {
+			return true;
+		}
+		SchemaEnabled enabled = SchemaEnabled.always;
+		XMLSchemaSettings schemaSettings = validationSettings.getSchema();
+		if (schemaSettings != null && schemaSettings.getEnabled() != null) {
+			enabled = schemaSettings.getEnabled();
+		}
+		switch (enabled) {
+		case always:
+			return true;
+		case never:
+			return false;
+		case onValidSchema:
+			return isValidSchemaLocation(document);
+		default:
+			return true;
+		}
+	}
+
+	/**
+	 * Returns true if the given DOM document declares a xsi:schemaLocation hint for
+	 * the document root element is valid and false otherwise.
+	 * 
+	 * The xsi:schemaLocation is valid if:
+	 * 
+	 * <ul>
+	 * <li>xsi:schemaLocation defines an URI for the namespace of the document
+	 * element.</li>
+	 * <li>the URI can be opened</li>
+	 * </ul>
+	 * 
+	 * @param document the DOM document.
+	 * @return true if the given DOM document declares a xsi:schemaLocation hint for
+	 *         the document root element is valid and false otherwise.
+	 */
+	private static boolean isValidSchemaLocation(DOMDocument document) {
+		if (!document.hasSchemaLocation()) {
+			return false;
+		}
+		String namespaceURI = document.getNamespaceURI();
+		SchemaLocationHint hint = document.getSchemaLocation().getLocationHint(namespaceURI);
+		if (hint == null) {
+			return false;
+		}
+		String location = hint.getHint();
+		return isValidLocation(document.getDocumentURI(), location);
+	}
+
+	private static boolean isNoNamespaceSchemaValidationEnabled(DOMDocument document,
+			XMLValidationSettings validationSettings) {
+		if (validationSettings == null) {
+			return true;
+		}
+		SchemaEnabled enabled = SchemaEnabled.always;
+		XMLSchemaSettings schemaSettings = validationSettings.getSchema();
+		if (schemaSettings != null && schemaSettings.getEnabled() != null) {
+			enabled = schemaSettings.getEnabled();
+		}
+		switch (enabled) {
+		case always:
+			return true;
+		case never:
+			return false;
+		case onValidSchema:
+			return isValidNoNamespaceSchemaLocation(document);
+		default:
+			return true;
+		}
+	}
+
+	/**
+	 * Returns true if the given DOM document declares a
+	 * xsi:noNamespaceSchemaLocation which is valid and false otherwise.
+	 * 
+	 * The xsi:noNamespaceSchemaLocation is valid if:
+	 * 
+	 * <ul>
+	 * <li>xsi:noNamespaceSchemaLocation defines an URI.</li>
+	 * <li>the URI can be opened</li>
+	 * </ul>
+	 * 
+	 * @param document the DOM document.
+	 * @return true if the given DOM document declares a xsi:schemaLocation hint for
+	 *         the document root element is valid and false otherwise.
+	 */
+	private static boolean isValidNoNamespaceSchemaLocation(DOMDocument document) {
+		NoNamespaceSchemaLocation noNamespaceSchemaLocation = document.getNoNamespaceSchemaLocation();
+		if (noNamespaceSchemaLocation == null) {
+			return false;
+		}
+		String location = noNamespaceSchemaLocation.getLocation();
+		return isValidLocation(document.getDocumentURI(), location);
+	}
+
+	private static boolean isValidLocation(String documentURI, String location) {
+		String resolvedLocation = getResolvedLocation(documentURI, location);
+		if (resolvedLocation == null) {
+			return false;
+		}
+		try (InputStream is = new URL(resolvedLocation).openStream()) {
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private static String getResolvedLocation(String documentURI, String location) {
+		if (StringUtils.isBlank(location)) {
+			return null;
+		}
+		try {
+			return XMLEntityManager.expandSystemId(location, documentURI, false);
+		} catch (MalformedURIException e) {
+			return location;
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/SchemaEnabled.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/SchemaEnabled.java
@@ -1,0 +1,17 @@
+/**
+ *  Copyright (c) 2021 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.extensions.contentmodel.settings;
+
+public enum SchemaEnabled {
+	always, never, onValidSchema;
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLSchemaSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLSchemaSettings.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright (c) 2021 Red Hat Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lemminx.extensions.contentmodel.settings;
+
+/**
+ * XML Schema settings.
+ *
+ */
+public class XMLSchemaSettings {
+
+	public XMLSchemaSettings() {
+		setEnabled(SchemaEnabled.always);
+	}
+
+	private SchemaEnabled enabled;
+
+	public void setEnabled(SchemaEnabled enabled) {
+		this.enabled = enabled;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((enabled == null) ? 0 : enabled.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		XMLSchemaSettings other = (XMLSchemaSettings) obj;
+		if (enabled != other.enabled)
+			return false;
+		return true;
+	}
+
+	public SchemaEnabled getEnabled() {
+		return enabled;
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
@@ -20,7 +20,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
  */
 public class XMLValidationSettings {
 
-	private Boolean schema;
+	private XMLSchemaSettings schema;
 
 	private Boolean enabled;
 
@@ -31,7 +31,7 @@ public class XMLValidationSettings {
 	/**
 	 * This severity preference to mark the root element of XML document which is
 	 * not bound to a XML Schema/DTD.
-	 * 
+	 *
 	 * Values are {ignore, hint, info, warning, error}
 	 */
 	private String noGrammar;
@@ -40,7 +40,6 @@ public class XMLValidationSettings {
 
 	public XMLValidationSettings() {
 		// set defaults
-		setSchema(true);
 		setEnabled(true);
 		setDisallowDocTypeDecl(false);
 		setResolveExternalEntities(false);
@@ -61,16 +60,18 @@ public class XMLValidationSettings {
 	}
 
 	/**
-	 * @return the schema
+	 * Returns the XML Schema validation settings.
+	 *
+	 * @return the XML Schema validation settings.
 	 */
-	public boolean isSchema() {
+	public XMLSchemaSettings getSchema() {
 		return schema;
 	}
 
 	/**
 	 * @param schema the schema to set
 	 */
-	public void setSchema(boolean schema) {
+	public void setSchema(XMLSchemaSettings schema) {
 		this.schema = schema;
 	}
 
@@ -85,7 +86,7 @@ public class XMLValidationSettings {
 	/**
 	 * Returns true if a fatal error is thrown if the incoming document contains a
 	 * DOCTYPE declaration and false otherwise.
-	 * 
+	 *
 	 * @return true if a fatal error is thrown if the incoming document contains a
 	 *         DOCTYPE declaration and false otherwise.
 	 */
@@ -96,7 +97,7 @@ public class XMLValidationSettings {
 	/**
 	 * Set true if a fatal error is thrown if the incoming document contains a
 	 * DOCTYPE declaration and false otherwise.
-	 * 
+	 *
 	 * @param disallowDocTypeDecl disallow DOCTYPE declaration.
 	 */
 	public void setDisallowDocTypeDecl(boolean disallowDocTypeDecl) {
@@ -105,7 +106,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Returns true if external entities must be resolved and false otherwise.
-	 * 
+	 *
 	 * @return true if external entities must be resolved and false otherwise.
 	 */
 	public boolean isResolveExternalEntities() {
@@ -114,7 +115,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set true if external entities must be resolved and false otherwise.
-	 * 
+	 *
 	 * @param resolveExternalEntities resolve extrenal entities
 	 */
 	public void setResolveExternalEntities(boolean resolveExternalEntities) {
@@ -124,7 +125,7 @@ public class XMLValidationSettings {
 	/**
 	 * Returns the <code>noGrammar</code> severity according the given settings and
 	 * {@link DiagnosticSeverity#Hint} otherwise.
-	 * 
+	 *
 	 * @param validationSettings the validation settings
 	 * @return the <code>noGrammar</code> severity according the given settings and
 	 *         {@link DiagnosticSeverity#Hint} otherwise.
@@ -165,6 +166,49 @@ public class XMLValidationSettings {
 	public boolean isRelatedInformation() {
 		return publishDiagnostics != null && publishDiagnostics.getRelatedInformation() != null
 				&& publishDiagnostics.getRelatedInformation();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (disallowDocTypeDecl ? 1231 : 1237);
+		result = prime * result + ((enabled == null) ? 0 : enabled.hashCode());
+		result = prime * result + ((noGrammar == null) ? 0 : noGrammar.hashCode());
+		result = prime * result + (resolveExternalEntities ? 1231 : 1237);
+		result = prime * result + ((schema == null) ? 0 : schema.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		XMLValidationSettings other = (XMLValidationSettings) obj;
+		if (disallowDocTypeDecl != other.disallowDocTypeDecl)
+			return false;
+		if (enabled == null) {
+			if (other.enabled != null)
+				return false;
+		} else if (!enabled.equals(other.enabled))
+			return false;
+		if (noGrammar == null) {
+			if (other.noGrammar != null)
+				return false;
+		} else if (!noGrammar.equals(other.noGrammar))
+			return false;
+		if (resolveExternalEntities != other.resolveExternalEntities)
+			return false;
+		if (schema == null) {
+			if (other.schema != null)
+				return false;
+		} else if (!schema.equals(other.schema))
+			return false;
+		return true;
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -286,6 +286,17 @@
 		}]
 	},
 	{
+		"name": "org.eclipse.lemminx.extensions.contentmodel.settings.XMLSchemaSettings",
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
+		"name": "org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled",
+		"allDeclaredFields": true
+	},
+	{
 		"name": "org.eclipse.lemminx.settings.XMLSymbolExpressionFilter",
 		"allDeclaredFields": true,
 		"methods": [{

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -41,6 +41,8 @@ import org.eclipse.lemminx.customservice.AutoCloseTagResponse;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMParser;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLSchemaSettings;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.extensions.generators.FileContentGeneratorManager;
 import org.eclipse.lemminx.extensions.generators.FileContentGeneratorSettings;
@@ -441,7 +443,7 @@ public class XMLAssert {
 		return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter));
 	}
 
-	public static ContentModelSettings getContentModelSettings(boolean isEnabled, boolean isSchema) {
+	public static ContentModelSettings getContentModelSettings(boolean isEnabled, SchemaEnabled schemaEnabled) {
 		ContentModelSettings settings = new ContentModelSettings();
 		settings.setUseCache(false);
 		XMLValidationSettings problems = new XMLValidationSettings();
@@ -449,7 +451,9 @@ public class XMLAssert {
 		settings.setValidation(problems);
 		XMLValidationSettings diagnostics = new XMLValidationSettings();
 		diagnostics.setEnabled(isEnabled);
-		diagnostics.setSchema(isSchema);
+		XMLSchemaSettings schemaSettings = new XMLSchemaSettings();
+		schemaSettings.setEnabled(schemaEnabled);
+		diagnostics.setSchema(schemaSettings);
 		settings.setValidation(diagnostics);
 		return settings;
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.XMLAssert.te;
 import static org.eclipse.lemminx.XMLAssert.teOp;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
+import static org.eclipse.lemminx.XMLAssert.testDiagnosticsFor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,6 +32,7 @@ import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.eclipse.lemminx.settings.EnforceQuoteStyle;
@@ -74,7 +76,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</beans>";
 		Diagnostic d = d(3, 2, 3, 15, XMLSchemaErrorCode.cvc_complex_type_2_3,
 				"Element \'bean\' cannot contain text content.\nThe content type is defined as element-only.\n\nCode:");
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 2, 3, 15, "")));
 	}
 
@@ -89,7 +91,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</beans>";
 		Diagnostic d = d(3, 3, 3, 11, XMLSchemaErrorCode.cvc_complex_type_4,
 				"Attribute:\n - name\nis required in element:\n - property\n\nCode:");
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 11, 3, 11, " name=\"\"")));
 	}
 
@@ -126,7 +128,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</project>";
 
 		String message = "Invalid element name:\n - XXX\n\nOne of the following is expected:\n - modelVersion\n - parent\n - groupId\n - artifactId\n - version\n - packaging\n - name\n - description\n - url\n - inceptionYear\n - organization\n - licenses\n - developers\n - contributors\n - mailingLists\n - prerequisites\n - modules\n - scm\n - issueManagement\n - ciManagement\n - distributionManagement\n - properties\n - dependencyManagement\n - dependencies\n - repositories\n - pluginRepositories\n - build\n - reports\n - reporting\n - profiles\n\nError indicated by:\n {http://maven.apache.org/POM/4.0.0}\nwith code:";
-		testDiagnosticsFor(xml, d(3, 2, 3, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_a, message));
+		testDiagnosticsWithCatalogFor(xml, d(3, 2, 3, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_a, message));
 	}
 
 	@Test
@@ -152,7 +154,7 @@ public class XMLSchemaDiagnosticsTest {
 				"		</description>\r\n" + //
 				"	</bean>\r\n" + //
 				"</beans>";
-		testDiagnosticsFor(xml, d(4, 4, 4, 8, XMLSchemaErrorCode.cvc_complex_type_2_4_d));
+		testDiagnosticsWithCatalogFor(xml, d(4, 4, 4, 8, XMLSchemaErrorCode.cvc_complex_type_2_4_d));
 	}
 
 	@Test
@@ -177,7 +179,7 @@ public class XMLSchemaDiagnosticsTest {
 				+ //
 				"<modelVersion XXXX=\"\" ></modelVersion>" + "</project>";
 		Diagnostic d = d(3, 14, 3, 21, XMLSchemaErrorCode.cvc_type_3_1_1);
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 14, 3, 21, "")));
 	}
 
@@ -190,7 +192,7 @@ public class XMLSchemaDiagnosticsTest {
 				"	</bean>              \r\n" + //
 				"</beans>";
 		Diagnostic d = d(2, 7, 2, 11, XMLSchemaErrorCode.cvc_complex_type_3_2_2);
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(2, 7, 2, 14, "")));
 	}
 
@@ -201,7 +203,7 @@ public class XMLSchemaDiagnosticsTest {
 				+ //
 				"	<bean autowire=\"ERROR\" />\r\n" + // <- error
 				"</beans>";
-		testDiagnosticsFor(xml, d(2, 16, 2, 23, XMLSchemaErrorCode.cvc_enumeration_valid),
+		testDiagnosticsWithCatalogFor(xml, d(2, 16, 2, 23, XMLSchemaErrorCode.cvc_enumeration_valid),
 				d(2, 16, 2, 23, XMLSchemaErrorCode.cvc_attribute_3));
 	}
 
@@ -352,7 +354,8 @@ public class XMLSchemaDiagnosticsTest {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<dresssize xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
 				" xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/dressSize.xsd\"></dresssize>";
-		testDiagnosticsFor(xml, d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_datatype_valid_1_2_3),
+		testDiagnosticsFor(xml, //
+				d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_datatype_valid_1_2_3),
 				d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_type_3_1_3));
 	}
 
@@ -376,7 +379,8 @@ public class XMLSchemaDiagnosticsTest {
 				"		</focus>\r\n" + //
 				"	</member>\r\n" + //
 				"</team>";
-		testDiagnosticsFor(xml, d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_maxlength_valid),
+		testDiagnosticsFor(xml, //
+				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_maxlength_valid),
 				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_attribute_3));
 
 	}
@@ -392,7 +396,7 @@ public class XMLSchemaDiagnosticsTest {
 				"	<alias name=\"\" alias=\"\" >XXXX</alias>\r\n" + // <- error
 				"</beans>";
 		Diagnostic d = d(5, 26, 5, 30, XMLSchemaErrorCode.cvc_complex_type_2_1);
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(5, 25, 5, 38, "/>")));
 	}
 
@@ -416,15 +420,16 @@ public class XMLSchemaDiagnosticsTest {
 				"	<alias name=\"\" alias=\"\" >\r\n   \r\n</alias>\r\n" + // <- error
 				"</beans>";
 		Diagnostic d = d(5, 26, 7, 0, XMLSchemaErrorCode.cvc_complex_type_2_1);
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(5, 25, 7, 8, "/>")));
 	}
 
 	@Test
 	public void cvc_pattern_valid() throws Exception {
-		String xml = "<Annotation\r\n" + "	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n"
-				+ "	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/pattern.xsd\"\r\n"
-				+ "	Term=\"X\"></Annotation>";
+		String xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/pattern.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
 		Diagnostic patternValid = d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_pattern_valid);
 		Diagnostic cvcAttribute3 = d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_attribute_3);
 		testDiagnosticsFor(xml, patternValid, cvcAttribute3);
@@ -441,7 +446,7 @@ public class XMLSchemaDiagnosticsTest {
 		Diagnostic patternValid = d(6, 17, 6, 37, XMLSchemaErrorCode.cvc_pattern_valid);
 		Diagnostic cvcType313 = d(6, 17, 6, 37, XMLSchemaErrorCode.cvc_type_3_1_3);
 		Diagnostic cvcType24b = d(3, 5, 3, 10, XMLSchemaErrorCode.cvc_complex_type_2_4_b);
-		testDiagnosticsFor(xml, patternValid, cvcType313, cvcType24b);
+		testDiagnosticsWithCatalogFor(xml, patternValid, cvcType313, cvcType24b);
 	}
 
 	/**
@@ -456,7 +461,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</edmx:Edmx>";
 		Diagnostic d = d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_complex_type_2_4_b,
 				"Child elements are missing from element:\n - edmx:Edmx\n\nThe following elements are expected:\n - Reference\n - DataServices\n\nError indicated by\n {http://docs.oasis-open.org/odata/ns/edmx\":Reference, \"http://docs.oasis-open.org/odata/ns/edmx}\nwith code:");
-		testDiagnosticsFor(xml, d);
+		testDiagnosticsWithCatalogFor(xml, d);
 	}
 
 	@Test
@@ -490,7 +495,8 @@ public class XMLSchemaDiagnosticsTest {
 				"  	<payment amount=\"1\" method=\"credit\"/>\r\n" + //
 				"  </payments>\r\n" + //
 				"</invoice>";
-		testDiagnosticsFor(xml, d(4, 3, 4, 9, XMLSchemaErrorCode.cvc_type_3_1_2),
+		testDiagnosticsFor(xml, //
+				d(4, 3, 4, 9, XMLSchemaErrorCode.cvc_type_3_1_2),
 				d(4, 10, 4, 17, XMLSchemaErrorCode.cvc_datatype_valid_1_2_1),
 				d(4, 10, 4, 17, XMLSchemaErrorCode.cvc_type_3_1_3));
 	}
@@ -506,8 +512,11 @@ public class XMLSchemaDiagnosticsTest {
 	@Test
 	public void schema_reference_4_withSchemaLocation() {
 		String xml = "<IODevice xmlns=\"http://www.io-link.com/IODD/2010/10\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n"
-				+ "  xsi:schemaLocation=\"http://www.io-link.com/IODD/2010/10 IODD1.1.xsd\">\r\n" + "	</IODevice>";
-		testDiagnosticsFor(xml, d(1, 58, 1, 69, XMLSchemaErrorCode.schema_reference_4), //
+				+ //
+				"  xsi:schemaLocation=\"http://www.io-link.com/IODD/2010/10 IODD1.1.xsd\">\r\n" + //
+				"	</IODevice>";
+		testDiagnosticsWithCatalogFor(xml, //
+				d(1, 58, 1, 69, XMLSchemaErrorCode.schema_reference_4), //
 				d(0, 1, 0, 9, XMLSchemaErrorCode.cvc_elt_1_a));
 	}
 
@@ -521,7 +530,8 @@ public class XMLSchemaDiagnosticsTest {
 				+ //
 				"<other:other />\n" + //
 				"</root:root>";
-		testDiagnosticsFor(xml, d(4, 92, 4, 101, XMLSchemaErrorCode.schema_reference_4), //
+		testDiagnosticsWithCatalogFor(xml, //
+				d(4, 92, 4, 101, XMLSchemaErrorCode.schema_reference_4), //
 				d(5, 1, 5, 12, XMLSchemaErrorCode.cvc_complex_type_2_4_c));
 	}
 
@@ -550,7 +560,7 @@ public class XMLSchemaDiagnosticsTest {
 				"    </modules>\r\n" + "</project>";
 		Diagnostic diagnostic = d(4, 7, 4, 13, XMLSchemaErrorCode.cvc_complex_type_2_4_a,
 				"Invalid element name:\n - bodule\n\nOne of the following is expected:\n - module\n\nError indicated by:\n {http://maven.apache.org/POM/4.0.0}\nwith code:");
-		testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsWithCatalogFor(xml, diagnostic);
 
 		testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(4, 7, 4, 13, "module"), te(4, 16, 4, 22, "module")));
 	}
@@ -575,7 +585,7 @@ public class XMLSchemaDiagnosticsTest {
 						" - notifiers\n\n" + "Error indicated by:\n" + //
 						" {http://maven.apache.org/POM/4.0.0}\n" + //
 						"with code:");
-		testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsWithCatalogFor(xml, diagnostic);
 		testCodeActionsFor(xml, diagnostic, //
 				ca(diagnostic, te(4, 7, 4, 16, "notifiers"), te(4, 19, 4, 28, "notifiers")), //
 				ca(diagnostic, te(4, 7, 4, 16, "system"), te(4, 19, 4, 28, "system")), //
@@ -601,7 +611,7 @@ public class XMLSchemaDiagnosticsTest {
 						"Error indicated by:\n" + //
 						" {http://foo}\n" + //
 						"with code:");
-		testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsWithCatalogFor(xml, diagnostic);
 	}
 
 	@Test
@@ -618,7 +628,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</beans>";
 		Diagnostic diagnostic = d(6, 5, 6, 16, XMLSchemaErrorCode.cvc_complex_type_2_4_c,
 				"cvc-complex-type.2.4.c: The matching wildcard is strict, but no declaration can be found for element 'camel:beani'.");
-		testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsWithCatalogFor(xml, diagnostic);
 
 		testCodeActionsFor(xml, diagnostic, //
 				ca(diagnostic, te(6, 11, 6, 16, "bean"), te(6, 25, 6, 30, "bean")), //
@@ -648,7 +658,7 @@ public class XMLSchemaDiagnosticsTest {
 				"</int>";
 		Diagnostic diagnostic = d(1, 1, 1, 4, XMLSchemaErrorCode.cvc_complex_type_2_2,
 				"cvc-complex-type.2.2: Element 'int' must have no element [children], and the value must be valid.");
-		testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsWithCatalogFor(xml, diagnostic);
 	}
 
 	@Test
@@ -661,7 +671,7 @@ public class XMLSchemaDiagnosticsTest {
 				"Content of type 'integer' is expected.\n\nThe following content is not a valid type:\n 'Bob'\n\nCode:");
 		Diagnostic diagnostic_cvc_2_2 = d(1, 1, 1, 4, XMLSchemaErrorCode.cvc_complex_type_2_2,
 				"cvc-complex-type.2.2: Element 'int' must have no element [children], and the value must be valid.");
-		testDiagnosticsFor(xml, diagnosticBob, diagnostic_cvc_2_2);
+		testDiagnosticsWithCatalogFor(xml, diagnosticBob, diagnostic_cvc_2_2);
 	}
 
 	@Test
@@ -671,7 +681,7 @@ public class XMLSchemaDiagnosticsTest {
 				"<two-letter-name xmlns=\"BAD_NS\">Io</two-letter-name>";
 		Diagnostic targetNamespace = d(2, 23, 2, 31, XMLSchemaErrorCode.TargetNamespace_1,
 				"TargetNamespace.1: Expecting namespace 'BAD_NS', but the target namespace of the schema document is 'http://two-letter-name'.");
-		testDiagnosticsFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
+		testDiagnosticsWithCatalogFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
 				"cvc-elt.1.a: Cannot find the declaration of element 'two-letter-name'."));
 		testCodeActionsFor(xml, targetNamespace, ca(targetNamespace, te(2, 23, 2, 31, "\"http://two-letter-name\"")));
 	}
@@ -683,7 +693,7 @@ public class XMLSchemaDiagnosticsTest {
 				"<two-letter-name xmlns=\"_\">Io</two-letter-name>";
 		Diagnostic targetNamespace = d(2, 23, 2, 26, XMLSchemaErrorCode.TargetNamespace_1,
 				"TargetNamespace.1: Expecting namespace '_', but the target namespace of the schema document is 'http://two-letter-name'.");
-		testDiagnosticsFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
+		testDiagnosticsWithCatalogFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
 				"cvc-elt.1.a: Cannot find the declaration of element 'two-letter-name'."));
 		testCodeActionsFor(xml, targetNamespace, ca(targetNamespace, te(2, 23, 2, 26, "\"http://two-letter-name\"")));
 	}
@@ -709,7 +719,7 @@ public class XMLSchemaDiagnosticsTest {
 				"<two-letter-name>Io</two-letter-name>";
 		Diagnostic targetNamespace = d(2, 1, 2, 16, XMLSchemaErrorCode.TargetNamespace_2,
 				"TargetNamespace.2: Expecting no namespace, but the schema document has a target namespace of 'http://two-letter-name'.");
-		testDiagnosticsFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
+		testDiagnosticsWithCatalogFor(xml, targetNamespace, d(2, 1, 2, 16, XMLSchemaErrorCode.cvc_elt_1_a,
 				"cvc-elt.1.a: Cannot find the declaration of element 'two-letter-name'."));
 		testCodeActionsFor(xml, targetNamespace,
 				ca(targetNamespace, te(2, 16, 2, 16, " xmlns=\"http://two-letter-name\"")));
@@ -742,7 +752,7 @@ public class XMLSchemaDiagnosticsTest {
 						+ " 3) the root element of the document is not <xsd:schema>.");
 		Diagnostic eltDiagnostic = d(1, 1, 8, XMLSchemaErrorCode.cvc_elt_1_a);
 		eltDiagnostic.setMessage("cvc-elt.1.a: Cannot find the declaration of element 'invoice'.");
-		XMLAssert.testDiagnosticsFor(xml, missingSchemaDiagnostic, eltDiagnostic);
+		testDiagnosticsFor(xml, missingSchemaDiagnostic, eltDiagnostic);
 
 		SharedSettings settings = new SharedSettings();
 		WorkspaceClientCapabilities workspace = new WorkspaceClientCapabilities();
@@ -775,7 +785,7 @@ public class XMLSchemaDiagnosticsTest {
 				+ " 3) the root element of the document is not <xsd:schema>.");
 		Diagnostic eltDiagnostic = d(1, 1, 8, XMLSchemaErrorCode.cvc_elt_1_a);
 		eltDiagnostic.setMessage("cvc-elt.1.a: Cannot find the declaration of element 'invoice'.");
-		XMLAssert.testDiagnosticsFor(xml, missingSchema, eltDiagnostic);
+		testDiagnosticsFor(xml, missingSchema, eltDiagnostic);
 
 		XMLAssert.testCodeActionsFor(xml, missingSchema);
 	}
@@ -788,7 +798,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  <bar>/bar></bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 7, 12, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 7, 3, 12, "")));
 	}
 
@@ -801,7 +811,7 @@ public class XMLSchemaDiagnosticsTest {
 				"barbarbar</bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 7, 12, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 7, 3, 12, "")));
 	}
 
@@ -813,7 +823,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  <bar>    	/bar> 	 	</bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 12, 17, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 12, 3, 17, "")));
 	}
 
@@ -825,7 +835,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  <bar> <![CDATA[ bar ]]> </bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 18, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 18, 3, 21, "")));
 	}
 
@@ -838,7 +848,7 @@ public class XMLSchemaDiagnosticsTest {
 				"   hi ]]> </bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 18, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 18, 3, 21, "")));
 	}
 
@@ -849,7 +859,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/close-tag-type.xsd\">\n" + //
 				"  <bar> <![CDATA[  ]]> </bar>\n" + //
 				"</foo>";
-		XMLAssert.testDiagnosticsFor(xml);
+		testDiagnosticsFor(xml);
 	}
 
 	@Test
@@ -860,7 +870,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  <bar> <![CDATA[  ]]> TextContent </bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 23, 34, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 23, 3, 34, "")));
 	}
 
@@ -872,7 +882,7 @@ public class XMLSchemaDiagnosticsTest {
 				"  <bar /> TextContent <bar></bar>\n" + //
 				"</foo>";
 		Diagnostic diagnostic = d(3, 10, 21, XMLSchemaErrorCode.cvc_complex_type_2_3);
-		XMLAssert.testDiagnosticsFor(xml, diagnostic);
+		testDiagnosticsFor(xml, diagnostic);
 		XMLAssert.testCodeActionsFor(xml, diagnostic, ca(diagnostic, te(3, 10, 3, 21, "")));
 	}
 
@@ -900,13 +910,11 @@ public class XMLSchemaDiagnosticsTest {
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 		// First validation
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 		// Restart the validation to check the validation is working since Xerces cache
 		// the invalid XSD grammar
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 	}
 
@@ -934,13 +942,11 @@ public class XMLSchemaDiagnosticsTest {
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 		// First validation
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 		// Restart the validation to check the validation is working since Xerces cache
 		// the invalid XSD grammar
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 	}
 
@@ -968,13 +974,11 @@ public class XMLSchemaDiagnosticsTest {
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 		// First validation
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 		// Restart the validation to check the validation is working since Xerces cache
 		// the invalid XSD grammar
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD);
 	}
 
@@ -1008,13 +1012,11 @@ public class XMLSchemaDiagnosticsTest {
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 		// First validation
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD1, diagnosticBasedOnXSD2);
 		// Restart the validation to check the validation is working since Xerces cache
 		// the invalid XSD grammar
-		XMLAssert.testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false,
-				settings, //
+		testDiagnosticsFor(xmlLanguageService, xml, null, null, "src/test/resources/test.xml", false, settings, //
 				diagnostic, diagnosticBasedOnXSD1, diagnosticBasedOnXSD2);
 	}
 
@@ -1024,16 +1026,229 @@ public class XMLSchemaDiagnosticsTest {
 				"	<page></page>\r\n" + //
 				"</document>";
 		Diagnostic diagnostic = d(1, 2, 1, 6, XMLSchemaErrorCode.cvc_complex_type_2_4_b);
-		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/include/catalog-include.xml", diagnostic);
+		testDiagnosticsFor(xml, "src/test/resources/catalogs/include/catalog-include.xml", diagnostic);
 	}
 
-	private static void testDiagnosticsFor(String xml, Diagnostic... expected) {
-		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", expected);
+	@Test
+	public void noHintSchemaLocationForRootElement() {
+		// Here the xsi:schemaLocation doens't declare the hint for
+		// http://www.eclipse.org/oomph/setup/1.0 (used in the root element)
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<setup:Configuration \r\n" + //
+				"    xmi:version=\"2.0\"\r\n" + //
+				"    xmlns:xmi=\"http://www.omg.org/XMI\"\r\n" + //
+				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n" + //
+				"    xmlns:setup=\"http://www.eclipse.org/oomph/setup/1.0\"\r\n" + //
+				"    xmlns:setup.p2=\"http://www.eclipse.org/oomph/setup/p2/1.0\"\r\n" + //
+				"    xmlns:workbench=\"http://www.eclipse.org/oomph/setup/workbench/1.0\"\r\n" + //
+				"    xsi:schemaLocation=\"http://www.eclipse.org/oomph/setup/workbench/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Workbench.ecore\"\r\n"
+				+ //
+				"    label=\"Gael Eclipse Installation\"> \r\n" + //
+				"  <installation name=\"com.github.glhez.eclipse.install\" label=\"Gael Eclipse Installation Installation\">\r\n"
+				+ //
+				"    <setupTask xsi:type=\"setup.p2:P2Task\" label=\"Oomph Setup Task\">\r\n" + //
+				"      <requirement name=\"org.eclipse.oomph.setup.feature.group\"/>\r\n" + //
+				"      <repository url=\"${oomph.update.url}\"/>\r\n" + //
+				"    </setupTask>  \r\n" + //
+				"   </installation>\r\n" + //
+				"</setup:Configuration>";
+
+		// always
+		testDiagnosticsFor(xml,
+				d(1, 1, 1, 20, XMLSchemaErrorCode.cvc_elt_1_a,
+						"cvc-elt.1.a: Cannot find the declaration of element 'setup:Configuration'."), //
+				d(11, 67, 11, 67, XMLSchemaErrorCode.cvc_elt_4_2,
+						"cvc-elt.4.2: Cannot resolve 'setup.p2:P2Task' to a type definition for element 'setupTask'."));
+
+		// on schema valid
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.onValidSchema);
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+	}
+
+	@Test
+	public void noNamespaceSchemaLocationEnabledWithAlways() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.always);
+
+		// good XSD location
+		String xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/pattern.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_pattern_valid), //
+				d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_attribute_3));
+
+		// bad XSD location
+		xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"BAD_LOCATION.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(2, 31, 2, 49, XMLSchemaErrorCode.schema_reference_4), //
+				d(0, 1, 0, 11, XMLSchemaErrorCode.cvc_elt_1_a));
+	}
+
+	@Test
+	public void noNamespaceSchemaLocationEnabledWithNever() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.never);
+
+		// good XSD location
+		String xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/pattern.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+
+		// bad XSD location
+		xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"BAD_LOCATION.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+	}
+
+	@Test
+	public void noNamespaceSchemaLocationEnabledWithOnValidSchema() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.onValidSchema);
+
+		// good XSD location
+		String xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/pattern.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_pattern_valid), //
+				d(3, 6, 3, 9, XMLSchemaErrorCode.cvc_attribute_3));
+
+		// bad XSD location
+		xml = "<Annotation\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:noNamespaceSchemaLocation=\"BAD_LOCATION.xsd\"\r\n" + //
+				"	Term=\"X\"></Annotation>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+	}
+
+	@Test
+	public void schemaLocationEnabledWithAlways() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.always);
+
+		// good XSD location and namespace
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_maxlength_valid), //
+				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_attribute_3),
+				d(1, 1, 1, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_b));
+
+		// bad XSD namespace
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"BAD_NAMESPACE\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(1, 1, 1, 5, XMLSchemaErrorCode.cvc_elt_1_a));
+
+		// bad XSD location
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace BAD_LOCATION.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(5, 40, 5, 56, XMLSchemaErrorCode.schema_reference_4), //
+				d(1, 1, 1, 5, XMLSchemaErrorCode.cvc_elt_1_a));
+	}
+
+	@Test
+	public void schemaLocationEnabledWithNever() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.never);
+
+		// good XSD location and namespace
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+
+		// bad XSD namespace
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"BAD_NAMESPACE\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+
+		// bad XSD location
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace BAD_LOCATION.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+	}
+
+	@Test
+	public void schemaLocationEnabledWithOnValidSchema() throws Exception {
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.onValidSchema);
+
+		// good XSD location and namespace
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings, //
+				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_maxlength_valid), //
+				d(2, 10, 2, 29, XMLSchemaErrorCode.cvc_attribute_3),
+				d(1, 1, 1, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_b));
+
+		// bad XSD namespace
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"BAD_NAMESPACE\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace src/test/resources/xsd/team.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+
+		// bad XSD location
+		xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<team\r\n" + //
+				"     name=\"too long a string\"\r\n" + // <- error
+				"     xmlns=\"team_namespace\"\r\n" + //
+				"     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"     xsi:schemaLocation=\"team_namespace BAD_LOCATION.xsd \">\r\n" + //
+				"</team>";
+		testDiagnosticsFor(xml, null, null, null, true, settings);
+	}
+
+	private static void testDiagnosticsWithCatalogFor(String xml, Diagnostic... expected) {
+		testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", expected);
 	}
 
 	private static void testDiagnosticsDisabledValidation(String xml) {
-		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, false);
-		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", null, null, true, settings);
+		ContentModelSettings settings = XMLAssert.getContentModelSettings(true, SchemaEnabled.never);
+		testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", null, null, true, settings);
 	}
 
 	private static String getGrammarFileURI(String grammarURI) throws MalformedURIException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.lemminx.XMLAssert.testDiagnosticsFor;
 
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
+import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
 import org.eclipse.lemminx.settings.EnforceQuoteStyle;
 import org.eclipse.lemminx.settings.QuoteStyle;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -630,7 +631,7 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testOpenQuoteExpectedDisabledPreference() throws Exception {
 		String xml = " <InstdAmt Ccy==\"JPY\">10000000</InstdAmt>";
-		testDiagnosticsFor(xml, null, null, null, true, XMLAssert.getContentModelSettings(false, true)); // validation
+		testDiagnosticsFor(xml, null, null, null, true, XMLAssert.getContentModelSettings(false, SchemaEnabled.always)); // validation
 																											// is
 																											// disabled
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
@@ -29,6 +29,7 @@ import org.eclipse.lemminx.XMLLanguageServer;
 import org.eclipse.lemminx.client.CodeLensKind;
 import org.eclipse.lemminx.client.ExtendedClientCapabilities;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
 import org.eclipse.lemminx.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import org.eclipse.lemminx.utils.FilesUtils;
 import org.eclipse.lsp4j.FormattingOptions;
@@ -53,60 +54,48 @@ public class SettingsTest {
 			f.delete();
 		}
 	}
+
 	// @formatter:off
-	private final String json = 
-	"{\r\n" +
-	"	\"settings\": {\r\n" + //
+	private final String json = "{\r\n" + "	\"settings\": {\r\n" + //
 	// Content model settings
-	"		\"xml\": {\r\n" + 
-	"			\"fileAssociations\": [\r\n" + //
-	"				{\r\n" + //
-	"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\spring-beans-3.0.xsd\",\r\n" + //
-	"					\"pattern\": \"**/test*.xml\"\r\n" + //
-	"				},\r\n" + //
-	"				{\r\n" + //
-	"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\projectDescription.xsd\",\r\n" + //
-	"					\"pattern\": \"projectDescription.xml\"\r\n" + //
-	"				}\r\n" + //
-	"			],\r\n" + //
-	"			\"catalogs\": [\r\n" + //
-	"				\"src\\\\test\\\\resources\\\\catalogs\\\\catalog.xml\"\r\n" + //
-	"			],\r\n" + //
-	"			\"validation\": {\r\n" + //
-	"				\"enabled\": true,\r\n" + //
-	"				\"schema\": false\r\n" + //
-	"			},\r\n" + //
-	// Client (commons) settings
-	"			\"format\": {\r\n" + //
-	"				\"tabSize\": 10,\r\n" + //
-	"				\"insertSpaces\": false,\r\n" + //
-	"				\"splitAttributes\": true,\r\n" + //
-	"				\"joinCDATALines\": true,\r\n" + //
-	"				\"formatComments\": true,\r\n" + //
-	"				\"joinCommentLines\": true,\r\n" + //
-	"				\"preserveAttributeLineBreaks\": true\r\n" + //
-	"			},\r\n" + 
-	"			\"server\": {\r\n" + //
-	"				\"workDir\": \"~/" + testFolder + "/Nested\"\r\n" + //
-	"			},\r\n" + 
-	"			\"symbols\": {\r\n" + //
-	"				\"enabled\": true,\r\n" + //
-	"				\"excluded\": [\"**\\\\*.xsd\", \"**\\\\*.xml\"]\r\n" + //
-	"			}\r\n" + 
-	"		}\r\n" + 
-	"	},\r\n" +
-	"	\"extendedClientCapabilities\": {\r\n" + 
-	"		\"codeLens\": {\r\n" + 
-	"			\"codeLensKind\": {\r\n" + 
-	"				\"valueSet\": [\r\n" + 
-	"					\"references\"\r\n" + 
-	"				]\r\n" + 
-	"			}\r\n" + 
-	"		},\r\n" + 
-	"		actionableNotificationSupport: true,\r\n" + 
-	"		openSettingsCommandSupport: true\r\n" + 
-	"	}" + 
-	"}";
+			"		\"xml\": {\r\n" + "			\"fileAssociations\": [\r\n" + //
+			"				{\r\n" + //
+			"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\spring-beans-3.0.xsd\",\r\n" + //
+			"					\"pattern\": \"**/test*.xml\"\r\n" + //
+			"				},\r\n" + //
+			"				{\r\n" + //
+			"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\projectDescription.xsd\",\r\n" + //
+			"					\"pattern\": \"projectDescription.xml\"\r\n" + //
+			"				}\r\n" + //
+			"			],\r\n" + //
+			"			\"catalogs\": [\r\n" + //
+			"				\"src\\\\test\\\\resources\\\\catalogs\\\\catalog.xml\"\r\n" + //
+			"			],\r\n" + //
+			"			\"validation\": {\r\n" + //
+			"				\"enabled\": true,\r\n" + //
+			"			    \"schema\": {\r\n" + //
+			"				    \"enabled\": \"never\"\r\n" + //
+			"			     }\r\n" + //
+			"			},\r\n" + //
+			// Client (commons) settings
+			"			\"format\": {\r\n" + //
+			"				\"tabSize\": 10,\r\n" + //
+			"				\"insertSpaces\": false,\r\n" + //
+			"				\"splitAttributes\": true,\r\n" + //
+			"				\"joinCDATALines\": true,\r\n" + //
+			"				\"formatComments\": true,\r\n" + //
+			"				\"joinCommentLines\": true,\r\n" + //
+			"				\"preserveAttributeLineBreaks\": true\r\n" + //
+			"			},\r\n" + "			\"server\": {\r\n" + //
+			"				\"workDir\": \"~/" + testFolder + "/Nested\"\r\n" + //
+			"			},\r\n" + "			\"symbols\": {\r\n" + //
+			"				\"enabled\": true,\r\n" + //
+			"				\"excluded\": [\"**\\\\*.xsd\", \"**\\\\*.xml\"]\r\n" + //
+			"			}\r\n" + "		}\r\n" + "	},\r\n" + "	\"extendedClientCapabilities\": {\r\n"
+			+ "		\"codeLens\": {\r\n" + "			\"codeLensKind\": {\r\n" + "				\"valueSet\": [\r\n"
+			+ "					\"references\"\r\n" + "				]\r\n" + "			}\r\n" + "		},\r\n"
+			+ "		actionableNotificationSupport: true,\r\n" + "		openSettingsCommandSupport: true\r\n" + "	}"
+			+ "}";
 	// @formatter:on
 
 	@Test
@@ -120,13 +109,15 @@ public class SettingsTest {
 
 		// Test client commons settings
 		initializationOptionsSettings = AllXMLSettings.getAllXMLSettings(initializationOptionsSettings);
-		XMLGeneralClientSettings settings = XMLGeneralClientSettings.getGeneralXMLSettings(initializationOptionsSettings);
+		XMLGeneralClientSettings settings = XMLGeneralClientSettings
+				.getGeneralXMLSettings(initializationOptionsSettings);
 		assertNotNull(settings);
 		// Server
 		assertEquals("~/" + testFolder + "/Nested", settings.getServer().getWorkDir());
 
 		// Test content model extension settings
-		ContentModelSettings cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
+		ContentModelSettings cmSettings = ContentModelSettings
+				.getContentModelXMLSettings(initializationOptionsSettings);
 		assertNotNull(cmSettings);
 		// Catalog
 		assertNotNull(cmSettings.getCatalogs());
@@ -135,16 +126,19 @@ public class SettingsTest {
 		// File associations
 		assertNotNull(cmSettings.getFileAssociations());
 		assertEquals(2, cmSettings.getFileAssociations().length);
-		assertEquals("src\\test\\resources\\xsd\\spring-beans-3.0.xsd", cmSettings.getFileAssociations()[0].getSystemId());
+		assertEquals("src\\test\\resources\\xsd\\spring-beans-3.0.xsd",
+				cmSettings.getFileAssociations()[0].getSystemId());
 		assertEquals("**/test*.xml", cmSettings.getFileAssociations()[0].getPattern());
 		// Diagnostics
 		assertNotNull(cmSettings.getValidation());
 		assertEquals(true, cmSettings.getValidation().isEnabled());
-		assertEquals(false, cmSettings.getValidation().isSchema());
+		assertNotNull(cmSettings.getValidation().getSchema());
+		assertNotNull(cmSettings.getValidation().getSchema().getEnabled());
+		assertEquals(SchemaEnabled.never, cmSettings.getValidation().getSchema().getEnabled());
 		// Symbols
 		assertNotNull(settings.getSymbols());
 		assertEquals(true, settings.getSymbols().isEnabled());
-		assertArrayEquals(new String[]{"**\\*.xsd", "**\\*.xml"}, settings.getSymbols().getExcluded());
+		assertArrayEquals(new String[] { "**\\*.xsd", "**\\*.xml" }, settings.getSymbols().getExcluded());
 
 	}
 
@@ -177,7 +171,7 @@ public class SettingsTest {
 		// the InitializeParams
 		xmlFormattingOptions.merge(sharedXMLFormattingOptions);
 		assertEquals(10, xmlFormattingOptions.getTabSize());
-		assertTrue(xmlFormattingOptions.isInsertSpaces()); 
+		assertTrue(xmlFormattingOptions.isInsertSpaces());
 		assertTrue(xmlFormattingOptions.isJoinCommentLines());
 	}
 
@@ -216,7 +210,7 @@ public class SettingsTest {
 		} catch (Exception e) {
 			fail();
 		} finally {
-			//Reset static cache path
+			// Reset static cache path
 			FilesUtils.setCachePathSetting(null);
 			System.setProperty("user.home", originalUserHome);
 		}
@@ -224,7 +218,8 @@ public class SettingsTest {
 
 	@Test
 	public void symbolSettingsTest() {
-		//Tests that when the settings are updated the shared settings are also updated correctly
+		// Tests that when the settings are updated the shared settings are also updated
+		// correctly
 
 		InitializeParams params = createInitializeParams(json);
 		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
@@ -233,9 +228,10 @@ public class SettingsTest {
 
 		XMLExcludedSymbolFile xsdFile = new XMLExcludedSymbolFile("**\\*.xsd");
 		XMLExcludedSymbolFile xmlFile = new XMLExcludedSymbolFile("**\\*.xml");
-		XMLExcludedSymbolFile[] expectedExcludedFiles = new XMLExcludedSymbolFile[] {xsdFile, xmlFile};
+		XMLExcludedSymbolFile[] expectedExcludedFiles = new XMLExcludedSymbolFile[] { xsdFile, xmlFile };
 
-		XMLExcludedSymbolFile[] actualExpectedFiles = languageServer.getSettings().getSymbolSettings().getExcludedFiles();
+		XMLExcludedSymbolFile[] actualExpectedFiles = languageServer.getSettings().getSymbolSettings()
+				.getExcludedFiles();
 		assertArrayEquals(expectedExcludedFiles, actualExpectedFiles);
 	}
 
@@ -249,8 +245,7 @@ public class SettingsTest {
 		assertNotNull(clientCapabilities.getCodeLens().getCodeLensKind());
 		assertNotNull(clientCapabilities.getCodeLens().getCodeLensKind().getValueSet());
 		assertEquals(1, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().size());
-		assertEquals(CodeLensKind.References,
-				clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
+		assertEquals(CodeLensKind.References, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
 		assertTrue(clientCapabilities.isActionableNotificationSupport());
 		assertTrue(clientCapabilities.isOpenSettingsCommandSupport());
 	}


### PR DESCRIPTION
Disable XSD validation when xsi:schemaLocation doesn't declare the hint for the document element root.

See #951

Signed-off-by: azerr <azerr@redhat.com>