### PR TITLE
Preserve trailing whitespace of text content

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -754,6 +754,10 @@ class XMLFormatter {
 			// check if format range reaches the end of the document
 			if (this.endOffset == this.textDocument.getText().length()) {
 
+				if (this.sharedSettings.getFormattingSettings().isTrimTrailingWhitespace()) {
+					this.xmlBuilder.trimFinalWhitespace();
+				}
+
 				if (this.sharedSettings.getFormattingSettings().isTrimFinalNewlines()) {
 					this.xmlBuilder.trimFinalNewlines();
 				}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/StringUtils.java
@@ -65,7 +65,7 @@ public class StringUtils {
 
 	/**
 	 * Checks if a string is null or consists of only whitespace characters.
-	 * 
+	 *
 	 * @param value The string to check
 	 * @return <code>true</code> if any of the below hold, and false otherwise:
 	 * <ul>
@@ -81,7 +81,7 @@ public class StringUtils {
 	/**
 	 * Normalizes the whitespace characters of a given string and applies it to the
 	 * given string builder.
-	 * 
+	 *
 	 * @param str
 	 * @return the result of normalize space of the given string.
 	 */
@@ -104,7 +104,7 @@ public class StringUtils {
 
 	/**
 	 * Returns the result of normalize space of the given string.
-	 * 
+	 *
 	 * @param str
 	 * @return the result of normalize space of the given string.
 	 */
@@ -116,7 +116,7 @@ public class StringUtils {
 
 	/**
 	 * Returns the start whitespaces of the given line text.
-	 * 
+	 *
 	 * @param lineText
 	 * @return the start whitespaces of the given line text.
 	 */
@@ -126,7 +126,7 @@ public class StringUtils {
 
 	/**
 	 * Returns the whitespaces from the given range start/end of the given text.
-	 * 
+	 *
 	 * @param start the range start
 	 * @param end   the range end
 	 * @param text  the text
@@ -214,10 +214,10 @@ public class StringUtils {
 	/**
 	 * Given a string that is only whitespace, this will return the amount of
 	 * newline characters.
-	 * 
+	 *
 	 * If the newLineCounter becomes > newLineLimit, then the value of newLineLimit
 	 * is always returned.
-	 * 
+	 *
 	 * @param text
 	 * @param isWhitespace
 	 * @param delimiter
@@ -253,7 +253,7 @@ public class StringUtils {
 	/**
 	 * Given a string will give back a non null string that is either the given
 	 * string, or an empty string.
-	 * 
+	 *
 	 * @param text
 	 * @return
 	 */
@@ -266,12 +266,12 @@ public class StringUtils {
 
 	/**
 	 * Traverses backwards from the endOffset until it finds a whitespace character.
-	 * 
+	 *
 	 * The offset of the character after the whitespace is returned.
-	 * 
+	 *
 	 * (text = "abcd efg|h", endOffset = 8) -> 5
-	 * 
-	 * 
+	 *
+	 *
 	 * @param text
 	 * @param endOffset non-inclusive
 	 * @return Start offset directly after the first whitespace.
@@ -300,7 +300,7 @@ public class StringUtils {
 
 	/**
 	 * Returns the number of consecutive whitespace characters in front of text
-	 * 
+	 *
 	 * @param text String of interest
 	 * @return the number of consecutive whitespace characters in front of text
 	 */
@@ -320,7 +320,7 @@ public class StringUtils {
 
 	/**
 	 * Returns the number of consecutive whitespace characters from the end of text
-	 * 
+	 *
 	 * @param text String of interest
 	 * @return the number of consecutive whitespace characters from the end of text
 	 */
@@ -411,7 +411,7 @@ public class StringUtils {
 	/**
 	 * Returns the start word offset from the left of the given <code>offset</code>
 	 * and -1 if no word.
-	 * 
+	 *
 	 * @param text        the text
 	 * @param offset      the offset
 	 * @param isValidChar predicate to check if current character belong to the
@@ -434,7 +434,7 @@ public class StringUtils {
 	/**
 	 * Returns the end word offset from the right of the given <code>offset</code>
 	 * and -1 if no word.
-	 * 
+	 *
 	 * @param text        the text
 	 * @param offset      the offset
 	 * @param isValidChar predicate to check if current character belong to the
@@ -456,10 +456,10 @@ public class StringUtils {
 
 	/**
 	 * Returns <code>value</code> without surrounding quotes.
-	 * 
+	 *
 	 * If <code>value</code> does not have matching surrounding quotes,
 	 * returns <code>value</code>.
-	 * 
+	 *
 	 * @param value
 	 * @return <code>value</code> without surrounding quotes.
 	 */
@@ -474,7 +474,7 @@ public class StringUtils {
 	/**
 	 * Returns true if <code>value</code> has matching surrounding quotes
 	 * and false otherwise.
-	 * 
+	 *
 	 * @param value
 	 * @return true if <code>value</code> has matching surrounding quotes.
 	 */
@@ -489,5 +489,35 @@ public class StringUtils {
 		}
 		char quoteValueEnd = value.charAt(value.length() - 1);
 		return quoteValueEnd == quoteValueStart;
+	}
+
+	/**
+	 * Returns <code>str</code> with the trailing spaces from each line (except
+	 * potentially the last) removed.
+	 *
+	 * @param str             the String to trim the trailing spaces of
+	 * @param includeLastLine true if whitespaces should be trimmed on the last
+	 *                        line, false if whitespaces should not be trimmed on
+	 *                        the last line
+	 * @return <code>str</code> with the trailing spaces from each line except the
+	 *         last line removed
+	 */
+	public static String trimTrailingWhitespaces(String value, boolean includeLastLine) {
+		StringBuilder sb = new StringBuilder(value);
+		int i = value.length() - 1;
+		boolean removeSpaces = includeLastLine;
+		char curr;
+		while (i >= 0) {
+			curr = sb.charAt(i);
+			if (curr == '\n' || curr == '\r') {
+				removeSpaces = true;
+			} else if (removeSpaces && Character.isWhitespace(curr)) {
+				sb.deleteCharAt(i);
+			} else {
+				removeSpaces = false;
+			}
+			i--;
+		}
+		return sb.toString();
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -308,7 +308,7 @@ public class XMLBuilder {
 				text = text.trim();
 			}
 			if (isTrimTrailingWhitespace()) {
-				text = trimTrailingSpacesEachLine(text);
+				text = StringUtils.trimTrailingWhitespaces(text, hasSiblings);
 			}
 			append(text);
 		} else if (!hasSiblings && isPreserveEmptyContent()) {
@@ -369,30 +369,6 @@ public class XMLBuilder {
 		while (i >= 0 && (xml.charAt(i) == '\r' || xml.charAt(i) == '\n')) {
 			xml.deleteCharAt(i--);
 		}
-	}
-
-	/**
-	 * Returns <code>str</code> with the trailing spaces from each line removed
-	 *
-	 * @param str the String
-	 * @return <code>str</code> with the trailing spaces from each line removed
-	 */
-	private static String trimTrailingSpacesEachLine(String str) {
-		StringBuilder sb = new StringBuilder(str);
-		int i = str.length() - 1;
-		boolean removeSpaces = true;
-		while (i >= 0) {
-			char curr = sb.charAt(i);
-			if (curr == '\n' || curr == '\r') {
-				removeSpaces = true;
-			} else if (removeSpaces && Character.isWhitespace(curr)) {
-				sb.deleteCharAt(i);
-			} else {
-				removeSpaces = false;
-			}
-			i--;
-		}
-		return sb.toString();
 	}
 
 	public XMLBuilder startCDATA() {
@@ -575,6 +551,17 @@ public class XMLBuilder {
 
 	public SharedSettings getSharedSettings() {
 		return sharedSettings;
+	}
+
+	/**
+	 * Trims all the whitespace at the end of the xml
+	 */
+	public void trimFinalWhitespace() {
+		int i = xml.length() - 1;
+		while (i >= 0 && Character.isWhitespace(xml.charAt(i))) {
+			xml.deleteCharAt(i);
+			i--;
+		}
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterMixedContentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterMixedContentTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.services;
+
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.junit.jupiter.api.Test;
+
+public class XMLFormatterMixedContentTest {
+
+	@Test
+	public void testMixedContentWithTrimTrailing() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+
+		String xml = //
+				"<aaa>\n" + //
+				"  aaa!<aaa />\n" + //
+				"</aaa>\n   ";
+
+		String expected = //
+				"<aaa>\n" + //
+				"  aaa!\n" + //
+				"  <aaa />\n" + //
+				"</aaa>";
+
+		XMLAssert.assertFormat(xml, expected, settings);
+	}
+
+	@Test
+	public void testMixedContentWithTrimTrailing2() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+
+		String xml = //
+				"<aaa>\n" + //
+				"  aaa!<aaa />aaa!<!-- Comment -->\n" + //
+				"</aaa>\n   ";
+
+		String expected = //
+				"<aaa>\n" + //
+				"  aaa!\n" + //
+				"  <aaa />\n" + //
+				"  aaa! <!-- Comment -->\n" + //
+				"</aaa>";
+
+		XMLAssert.assertFormat(xml, expected, settings);
+	}
+
+	@Test
+	public void testMixedContentWithTrimTrailing3() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+
+		String xml = //
+				"<aaa>\n" + //
+				"  I believe <code>this</code> use case <b>should</b> be addressed, but in a <em>future</em> PR.\n" + //
+				"</aaa>";
+
+		String expected = //
+				"<aaa>\n" + //
+				"  I believe\n" + //
+				"  <code>this</code>\n" + //
+				"  use case\n" + //
+				"  <b>should</b>\n" + //
+				"  be addressed, but in a\n" + //
+				"  <em>future</em>\n" + //
+				"  PR.\n" + //
+				"</aaa>";
+
+		XMLAssert.assertFormat(xml, expected, settings);
+	}
+
+	@Test
+	public void testMixedContentWithTrimTrailing4() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+
+		String xml = //
+				"<aaa>\n" + //
+				"  content a <bbb> content b <ccc />  content c   </bbb>content d\n" + //
+				"</aaa>";
+
+		String expected = //
+				"<aaa>\n" + //
+				"  content a\n" + //
+				"  <bbb>\n" + //
+				"    content b\n" + //
+				"    <ccc />\n" + //
+				"    content c\n" + //
+				"  </bbb>\n" + //
+				"  content d\n" + //
+				"</aaa>";
+
+		XMLAssert.assertFormat(xml, expected, settings);
+	}
+
+	@Test
+	public void testMixedContentWithTrimTrailing5() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+
+		String xml = //
+				"<aaa>\n" + //
+				"  content a\n" + //
+				"  <bbb>\n" + //
+				"    content b\n" + //
+				"    <ccc />\n" + //
+				"    content c\n" + //
+				"  </bbb>\n" + //
+				"  content d\n" + //
+				"</aaa>";
+
+		XMLAssert.assertFormat(xml, xml, settings);
+	}
+
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2991,4 +2991,47 @@ public class XMLFormatterTest {
 		assertFormat(content, expected, settings);
 	}
 
+	@Test
+	public void testIndentingTextNode() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+		String content = "" + //
+				"<Project>\n" + //
+				"  <PropertyGroup>\n" + //
+				"    <TargetDependsOn>\n" + //
+				"      $(TargetDependsOn);\n" + //
+				"      TargetSetup;\n" + //
+				"    </TargetDependsOn>\n" + //
+				"  </PropertyGroup>\n" + //
+				"</Project>";
+		assertFormat(content, content);
+		assertFormat(content, content, settings);
+	}
+
+	@Test
+	public void testIndentingTextNodeWithTrailingSpaces() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimTrailingWhitespace(true);
+		String content =  "" + //
+				"<Project>\n" + //
+				"  <PropertyGroup>\n" + //
+				"    <TargetDependsOn>\n" + //
+				"      $(TargetDependsOn);  \n" + //
+				"      TargetSetup;  \n" + //
+				"    </TargetDependsOn>\n" + //
+				"  </PropertyGroup>\n" + //
+				"</Project>";
+		String expected =  "" + //
+				"<Project>\n" + //
+				"  <PropertyGroup>\n" + //
+				"    <TargetDependsOn>\n" + //
+				"      $(TargetDependsOn);\n" + //
+				"      TargetSetup;\n" + //
+				"    </TargetDependsOn>\n" + //
+				"  </PropertyGroup>\n" + //
+				"</Project>";
+		assertFormat(content, expected);
+		assertFormat(content, expected, settings);
+	}
+
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/StringUtilsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/StringUtilsTest.java
@@ -93,8 +93,46 @@ public class StringUtilsTest {
 		assertEquals(regularText, StringUtils.getString(regularText));
 	}
 
+
+	@Test
+	public void testNormalizeWhitespace() {
+		assertNormalizeWhitespace(" ", "");
+		assertNormalizeWhitespace(" a ", "a");
+		assertNormalizeWhitespace("  ", "");
+		assertNormalizeWhitespace("a  a", "a a");
+		assertNormalizeWhitespace("a  a   a   a  a", "a a a a a");
+		assertNormalizeWhitespace("a\na\r\na\ra", "a a a a");
+		assertNormalizeWhitespace("\n\n\na\n\n\n", "a");
+	}
+
+	@Test
+	public void testTrimTrailingWhitespacesZeroCases() {
+		assertEquals("", StringUtils.trimTrailingWhitespaces("", true));
+		assertEquals("", StringUtils.trimTrailingWhitespaces("", false));
+		assertEquals("", StringUtils.trimTrailingWhitespaces(" ", true));
+		assertEquals(" ", StringUtils.trimTrailingWhitespaces(" ", false));
+	}
+
+	@Test
+	public void testTrimTrailingWhitespacesMultiLine() {
+		assertEquals("a\nb", StringUtils.trimTrailingWhitespaces("a  \nb  ", true));
+		assertEquals("a\nb  ", StringUtils.trimTrailingWhitespaces("a  \nb  ", false));
+		assertEquals("a\nb", StringUtils.trimTrailingWhitespaces("a	 \nb	 ", true));
+		assertEquals("a\nb	 ", StringUtils.trimTrailingWhitespaces("a	 \nb	 ", false));
+		assertEquals("a\r\nb", StringUtils.trimTrailingWhitespaces("a	 \r\nb	 ", true));
+		assertEquals("a\r\nb	 ", StringUtils.trimTrailingWhitespaces("a	 \r\nb	 ", false));
+		assertEquals("a\rb", StringUtils.trimTrailingWhitespaces("a	 \rb	 ", true));
+		assertEquals("a\rb	 ", StringUtils.trimTrailingWhitespaces("a	 \rb	 ", false));
+	}
+
 	private static void assertTrimNewLines(String valueToTrim, String expected) {
 		String actual = trimNewLines(valueToTrim);
 		assertEquals(expected, actual);
 	}
+
+	private static void assertNormalizeWhitespace(String valueToNormalize, String expected) {
+		String actual = StringUtils.normalizeSpace(valueToNormalize);
+		assertEquals(expected, actual);
+	}
+
 }


### PR DESCRIPTION
When trimming trailing line whitespace for text content during formatting:
 * preserve trailing whitespace on last line of text-only nodes
 * trim the trailing whitespace on last line of text in mixed content

Closes redhat-developer/vscode-xml#377

Signed-off-by: David Thompson <davthomp@redhat.com>