### PR TITLE
Prevent `xml.validation.schema = true` from crashing server

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
@@ -45,11 +45,13 @@ public class XMLValidationSettings {
 		setEnabled(true);
 		setDisallowDocTypeDecl(false);
 		setResolveExternalEntities(false);
+		setNamespaces(new XMLNamespacesSettings());
+		setSchema(new XMLSchemaSettings());
 	}
 
 	/**
 	 * Returns true if the validation is enabled and false otherwise.
-	 * 
+	 *
 	 * @return true if the validation is enabled and false otherwise.
 	 */
 	public boolean isEnabled() {
@@ -58,7 +60,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set true if the validation is enabled and false otherwise.
-	 * 
+	 *
 	 * @param enabled true if the validation is enabled and false otherwise.
 	 */
 	public void setEnabled(boolean enabled) {
@@ -67,7 +69,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Returns the XML Namespaces validation settings.
-	 * 
+	 *
 	 * @return the XML Namespaces validation settings.
 	 */
 	public XMLNamespacesSettings getNamespaces() {
@@ -76,7 +78,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set the XML Namespaces validation settings.
-	 * 
+	 *
 	 * @param namespaces the XML Namespaces validation settings.
 	 */
 	public void setNamespaces(XMLNamespacesSettings namespaces) {
@@ -94,7 +96,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set the XML Schema validation settings.
-	 * 
+	 *
 	 * @param schema the XML Schema validation settings.
 	 */
 	public void setSchema(XMLSchemaSettings schema) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/adapters/XMLValidationSettingsTypeAdapter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/adapters/XMLValidationSettingsTypeAdapter.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.settings.adapters;
+
+import java.lang.reflect.Type;
+import java.util.logging.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
+
+/**
+ * XMLValidationSettingsSerializer
+ */
+public class XMLValidationSettingsTypeAdapter
+		implements JsonDeserializer<XMLValidationSettings>, JsonSerializer<XMLValidationSettings> {
+
+
+	private static final Logger LOGGER = Logger.getLogger(XMLValidationSettingsTypeAdapter.class.getName());
+
+	// Doesn't include this class as a type adapter in this GSON instance order to avoid infinite recursion
+	private static final Gson LOCAL_GSON = new GsonBuilder().registerTypeAdapterFactory(new EitherTypeAdapter.Factory()).create();
+
+	@Override
+	public XMLValidationSettings deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+			throws JsonParseException {
+		try {
+			return LOCAL_GSON.fromJson(json, XMLValidationSettings.class);
+		} catch (Exception e) {
+			LOGGER.warning(
+					"The setting 'xml.validation.schema' was recent changed from a boolean to an object with several sub-settings. "
+							+ //
+							"Please remove the old configuration option, and refer to the documentation on these settings.");
+			return new XMLValidationSettings();
+		}
+	}
+
+	@Override
+	public JsonElement serialize(XMLValidationSettings src, Type typeOfSrc, JsonSerializationContext context) {
+		return LOCAL_GSON.toJsonTree(src);
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/AllXMLSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/AllXMLSettings.java
@@ -19,7 +19,7 @@ import com.google.gson.annotations.JsonAdapter;
 
 /**
  * Represents all settings under the 'xml' key
- * 
+ *
  * { 'xml': {...} }
  */
 public class AllXMLSettings {
@@ -38,7 +38,6 @@ public class AllXMLSettings {
 	 * @param xml the xml to set
 	 */
 	public void setXml(Object xml) {
-
 		this.xml = xml;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/JSONUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/JSONUtility.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.lemminx.utils;
 
+import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
+import org.eclipse.lemminx.extensions.contentmodel.settings.adapters.XMLValidationSettingsTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
 
 import com.google.gson.Gson;
@@ -47,6 +49,9 @@ public class JSONUtility {
 		return new GsonBuilder() //
 				// required to deserialize XMLFormattingOptions which extends FormattingOptions
 				// which uses Either
-				.registerTypeAdapterFactory(new EitherTypeAdapter.Factory());
+				.registerTypeAdapterFactory(new EitherTypeAdapter.Factory()) //
+				// required to prevent the old boolean setting 'xml.validation.schema' from crashing
+				.registerTypeAdapter(XMLValidationSettings.class, new XMLValidationSettingsTypeAdapter());
 	}
+
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
@@ -32,6 +32,7 @@ import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings
 import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
 import org.eclipse.lemminx.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import org.eclipse.lemminx.utils.FilesUtils;
+import org.eclipse.lemminx.utils.JSONUtility;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.junit.jupiter.api.AfterEach;
@@ -248,5 +249,12 @@ public class SettingsTest {
 		assertEquals(CodeLensKind.References, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
 		assertTrue(clientCapabilities.isActionableNotificationSupport());
 		assertTrue(clientCapabilities.isOpenSettingsCommandSupport());
+	}
+
+	@Test
+	public void oldBooleanDoesntCrashSettings() {
+		AllXMLSettings allSettings = new Gson().fromJson("{'xml': { \"validation\": { \"schema\": false}}}", AllXMLSettings.class);
+		ContentModelSettings contentModelSettings = JSONUtility.toModel(allSettings.getXml(), ContentModelSettings.class);
+		assertEquals(SchemaEnabled.always, contentModelSettings.getValidation().getSchema().getEnabled());
 	}
 }


### PR DESCRIPTION
Decorate the deserializing for `xml.validation` in order to catch the exception that's raised when `xml.validation.schema` is set to a boolean. Instead of crashing, log a message that the setting is invalid and has been changed, and use the default configuration.

Fixes #964

Signed-off-by: David Thompson <davthomp@redhat.com>
