### PR TITLE
Wrap JSON reading in try/catch to avoid crashes

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/settings/XMLValidationSettings.java
@@ -45,11 +45,13 @@ public class XMLValidationSettings {
 		setEnabled(true);
 		setDisallowDocTypeDecl(false);
 		setResolveExternalEntities(false);
+		setNamespaces(new XMLNamespacesSettings());
+		setSchema(new XMLSchemaSettings());
 	}
 
 	/**
 	 * Returns true if the validation is enabled and false otherwise.
-	 * 
+	 *
 	 * @return true if the validation is enabled and false otherwise.
 	 */
 	public boolean isEnabled() {
@@ -58,7 +60,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set true if the validation is enabled and false otherwise.
-	 * 
+	 *
 	 * @param enabled true if the validation is enabled and false otherwise.
 	 */
 	public void setEnabled(boolean enabled) {
@@ -67,7 +69,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Returns the XML Namespaces validation settings.
-	 * 
+	 *
 	 * @return the XML Namespaces validation settings.
 	 */
 	public XMLNamespacesSettings getNamespaces() {
@@ -76,7 +78,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set the XML Namespaces validation settings.
-	 * 
+	 *
 	 * @param namespaces the XML Namespaces validation settings.
 	 */
 	public void setNamespaces(XMLNamespacesSettings namespaces) {
@@ -94,7 +96,7 @@ public class XMLValidationSettings {
 
 	/**
 	 * Set the XML Schema validation settings.
-	 * 
+	 *
 	 * @param schema the XML Schema validation settings.
 	 */
 	public void setSchema(XMLSchemaSettings schema) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/FaultTolerantTypeAdapterFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/FaultTolerantTypeAdapterFactory.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.settings;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Creates TypeAdapters that are wrapped in a try/catch statement, so if
+ * anything goes wrong when deserializing an object, it is set to null and not
+ * parsed.
+ *
+ */
+public class FaultTolerantTypeAdapterFactory implements TypeAdapterFactory {
+
+	private static final Logger LOGGER = Logger.getLogger(FaultTolerantTypeAdapterFactory.class.getName());
+
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		return wrapTypeAdapter(gson.getDelegateAdapter(this, type));
+	}
+
+	/**
+	 * Wrap the reader of the given TypeAdapter with a try/catch, and skip reading
+	 * the value if an error occurs
+	 *
+	 * @param <T>         The type that the TypeAdapter
+	 * @param typeAdapter the TypeAdapter to wrap
+	 * @return the wrapped instance of the TypeAdapter
+	 */
+	private <T> TypeAdapter<T> wrapTypeAdapter(TypeAdapter<T> typeAdapter) {
+		return new TypeAdapter<T>() {
+
+			@Override
+			public void write(JsonWriter out, T value) throws IOException {
+				typeAdapter.write(out, value);
+			}
+
+			@Override
+			public T read(JsonReader in) throws IOException {
+				try {
+					return typeAdapter.read(in);
+				} catch (Exception e) {
+					LOGGER.warning("Encountered an invalid setting. Using the default value. " + //
+							"Please check your settings for outdated or invalid settings.\n" +
+							e);
+					in.skipValue();
+					return null;
+				}
+			}
+
+		};
+	}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/JSONUtility.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/JSONUtility.java
@@ -13,11 +13,12 @@
  *******************************************************************************/
 package org.eclipse.lemminx.utils;
 
-import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+
+import org.eclipse.lemminx.settings.FaultTolerantTypeAdapterFactory;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
 
 /**
  * JSONUtility
@@ -47,6 +48,8 @@ public class JSONUtility {
 		return new GsonBuilder() //
 				// required to deserialize XMLFormattingOptions which extends FormattingOptions
 				// which uses Either
-				.registerTypeAdapterFactory(new EitherTypeAdapter.Factory());
+				.registerTypeAdapterFactory(new EitherTypeAdapter.Factory()) //
+				.registerTypeAdapterFactory(new FaultTolerantTypeAdapterFactory());
 	}
+
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
@@ -32,6 +32,7 @@ import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings
 import org.eclipse.lemminx.extensions.contentmodel.settings.SchemaEnabled;
 import org.eclipse.lemminx.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import org.eclipse.lemminx.utils.FilesUtils;
+import org.eclipse.lemminx.utils.JSONUtility;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.junit.jupiter.api.AfterEach;
@@ -248,5 +249,11 @@ public class SettingsTest {
 		assertEquals(CodeLensKind.References, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
 		assertTrue(clientCapabilities.isActionableNotificationSupport());
 		assertTrue(clientCapabilities.isOpenSettingsCommandSupport());
+	}
+
+	@Test
+	public void oldBooleanDoesntCrashSettings() {
+		AllXMLSettings allSettings = new Gson().fromJson("{'xml': { \"validation\": { \"schema\": false}}}", AllXMLSettings.class);
+		JSONUtility.toModel(allSettings.getXml(), ContentModelSettings.class);
 	}
 }


### PR DESCRIPTION
If an invalid piece of JSON is encountered (eg. boolean where an object is expected), then it is ignored when parsing the JSON. For the settings, this means that the the default settings are used instead.

Closes #964

Signed-off-by: David Thompson <davthomp@redhat.com>
