### PR TITLE
Fix build with Java 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>4.1.0</version>
+					<version>5.1.1</version>
 					<executions>
 						<execution>
 							<id>bundle-manifest</id>


### PR DESCRIPTION
updated maven-bundle-plugin to 5.1.1. Can now build with Java 15.
Unsure if this causes any issues with the binary (it shouldn't)