### PR TITLE
HTML/Markdown -> HTML -> just Markdown

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -267,5 +267,10 @@
 			<version>9.4.38.v20210224</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.commonmark</groupId>
+			<artifactId>commonmark</artifactId>
+			<version>0.17.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/XSDAnnotationModel.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/XSDAnnotationModel.java
@@ -54,7 +54,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns content from appinfo element(s)
-	 * 
+	 *
 	 * @return content from appinfo element(s)
 	 */
 	public List<String> getAppInfo() {
@@ -63,7 +63,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns content from documentation elements(s)
-	 * 
+	 *
 	 * @return content from documentation elements(s)
 	 */
 	public List<String> getDocumentation() {
@@ -72,7 +72,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns documentation content from the provided collection of annotations
-	 * 
+	 *
 	 * @param annotations the collection of annotations
 	 * @return documentation content from the provided collection of annotations
 	 */
@@ -82,7 +82,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns documentation content from the provided collection of annotations
-	 * 
+	 *
 	 * @param annotations the collection of attribute value annotations
 	 * @param value       the attribute value to find documentation content for
 	 * @return documentation content from the provided collection of annotations
@@ -115,7 +115,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns appinfo content from the provided collection of annotations
-	 * 
+	 *
 	 * @param annotations the collection of annotations
 	 * @return appinfo content from the provided collection of annotations
 	 */
@@ -125,7 +125,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns appinfo content from the provided collection of annotations
-	 * 
+	 *
 	 * @param annotations the collection of attribute value annotations
 	 * @param value       the attribute value to find appinfo content for
 	 * @return appinfo content from the provided collection of annotations
@@ -147,7 +147,7 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns the prefix (ie. xs) from the provided collection of annotations
-	 * 
+	 *
 	 * @param annotations the collection of annotations
 	 * @return the prefix (ie. xs) from the provided collection of annotations
 	 */
@@ -157,10 +157,10 @@ class XSDAnnotationModel {
 
 	/**
 	 * Returns the prefix (ie. xs) from the provided collection of annotations
-	 * 
+	 *
 	 * Prerequisite: <code>value</code> should be provided if <code>annotations</code>
 	 * is a collection of attribute value annotations
-	 * 
+	 *
 	 * @param annotations the collection of annotations
 	 * @param value       the attribute value
 	 * @return the prefix (ie. xs) from the provided collection of annotations
@@ -192,20 +192,20 @@ class XSDAnnotationModel {
 			return null;
 		}
 	}
-	
+
 	/**
-	 * Returns the <code>XSAnnotation</code> instance for the 
+	 * Returns the <code>XSAnnotation</code> instance for the
 	 * provided <code>annotation</code>
-	 * 
+	 *
 	 * If <code>value</code> is provided, the <code>XSAnnotation</code> for
 	 * an attribute value will be searched for
-	 * 
+	 *
 	 * If not provided, the <code>XSAnnotation</code> for
 	 * an attribute or element will be searched for
-	 * 
-	 * @param annotation the annotation object 
+	 *
+	 * @param annotation the annotation object
 	 * @param value      the attribute value
-	 * @return the <code>XSAnnotation</code> instance for the 
+	 * @return the <code>XSAnnotation</code> instance for the
 	 * provided <code>annotation</code>
 	 */
 	private static XSAnnotation getXSAnnotation(XSObject annotation, String value) {
@@ -258,9 +258,9 @@ class XSDAnnotationModel {
 			super.endElement(uri, localName, qName);
 			if (current != null) {
 				if (qName.endsWith(APPINFO_ELEMENT)) {
-					addIfNonEmptyString(model.appInfo, normalizeSpace(current.toString()));
+					addIfNonEmptyString(model.appInfo, current.toString().trim());
 				} else if (qName.endsWith(DOCUMENTATION_ELEMENT)) {
-					addIfNonEmptyString(model.documentation, normalizeSpace(current.toString()));
+					addIfNonEmptyString(model.documentation, current.toString().trim());
 				}
 				current = null;
 			}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelHoverExtensionsTest.java
@@ -37,7 +37,10 @@ public class XMLModelHoverExtensionsTest {
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" >\r\n" + //
 				"	<bea|n>";
 		assertHover(xml,
-				"Defines a single (usually named) bean. A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
+				"Defines a single (usually named) bean." + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
 						+ //
 						System.lineSeparator() + //
 						System.lineSeparator() + "Source: [spring-beans-3.0.xsd](" + schemaURI + ")",

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
@@ -46,7 +46,10 @@ public class XMLSchemaHoverExtensionsTest {
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"
 				+ "	<bea|n>";
 		assertHover(xml,
-				"Defines a single (usually named) bean. A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
+				"Defines a single (usually named) bean." + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
 						+ //
 						System.lineSeparator() + //
 						System.lineSeparator() + "Source: [spring-beans-3.0.xsd](" + schemaURI + ")",
@@ -387,6 +390,66 @@ public class XMLSchemaHoverExtensionsTest {
 
 		};
 		assertNull(hoverParticipant.onText(hoverRequest));
+	}
+
+	public void hoverMixedHtmlMarkdown1() throws BadLocationException, MalformedURIException {
+		String schemaURI = getXMLSchemaFileURI("mixedHtmlMarkdown.xsd");
+		String sep = System.lineSeparator();
+		sep = sep + sep;
+		String xml = //
+				"<ro|ot\n" + //
+				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"    xsi:noNamespaceSchemaLocation=\"xsd/mixedHtmlMarkdown.xsd\" >\n" + //
+				"</root>";
+				XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/mixed.xml", //
+				"# root" + sep + //
+				"This is the root element of the document." + sep + //
+				"Use it like this:" + sep + //
+				"`<root> ... </root>`" + sep + //
+				"*Since 0.1.0*" + sep + //
+				"Source: [mixedHtmlMarkdown.xsd](" + schemaURI + ")", //
+				r(0, 1, 0, 5));
+	}
+
+	@Test
+	public void hoverMixedHtmlMarkdown2() throws BadLocationException, MalformedURIException {
+		String schemaURI = getXMLSchemaFileURI("mixedHtmlMarkdown.xsd");
+		String sep = System.lineSeparator();
+		sep = sep + sep;
+		String xml = //
+				"<root\n" + //
+				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"    xsi:noNamespaceSchemaLocation=\"xsd/mixedHtmlMarkdown.xsd\" >\n" + //
+				"  <cont|ainer />\n" + //
+				"</root>";
+				XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/mixed.xml", //
+				"## container" + sep + //
+				"Groups *several* `content` together in a logical structure." + sep + //
+				"`<em> This case is handled correctly </em>`" + sep + //
+				"![whale image](https://openclipart.org/image/400px/3243)" + sep + //
+				"Source: [mixedHtmlMarkdown.xsd](" + schemaURI + ")", //
+				r(3, 3, 3, 12));
+	}
+
+	@Test
+	public void hoverMixedHtmlMarkdown3() throws BadLocationException, MalformedURIException {
+		String schemaURI = getXMLSchemaFileURI("mixedHtmlMarkdown.xsd");
+		String sep = System.lineSeparator();
+		sep = sep + sep;
+		String xml = //
+				"<root\n" + //
+				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				"    xsi:noNamespaceSchemaLocation=\"xsd/mixedHtmlMarkdown.xsd\" >\n" + //
+				"  <container>\n" + //
+				"    <con|tent />\n" + //
+				"  </container>\n" + //
+				"</root>";
+				XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/mixed.xml", //
+				"## content" + sep + //
+				"This node represents *text* content." + sep + //
+				"This is the second [paragraph](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) in the documentation." + sep + //
+				"Source: [mixedHtmlMarkdown.xsd](" + schemaURI + ")", //
+				r(4, 5, 4, 12));
 	}
 
 	private static void assertHover(String value, String expectedHoverLabel, Range expectedHoverRange)

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/AggregetedHoverValuesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/AggregetedHoverValuesTest.java
@@ -47,7 +47,10 @@ public class AggregetedHoverValuesTest {
 				MARKDOWN_SEPARATOR + //
 				System.lineSeparator() + //
 				System.lineSeparator() + //
-				"Defines a single (usually named) bean. A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
+				"Defines a single (usually named) bean." + //
+				System.lineSeparator() + //
+				System.lineSeparator() + //
+				"A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported."
 				+ //
 				System.lineSeparator() + //
 				System.lineSeparator() + "Source: [spring-beans-3.0.xsd](" + schemaURI + ")", r(2, 2, 2, 6));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/MarkdownConverterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/MarkdownConverterTest.java
@@ -24,48 +24,70 @@ public class MarkdownConverterTest {
 	@Test
 	public void testHTMLConversion() {
 		assertEquals("This is `my code`", convert("This is <code>my code</code>"));
-		assertEquals("This is" + System.lineSeparator() + "**bold**", convert("This is<br><b>bold</b>"));
-		assertEquals("The `<project>` element is the root of the descriptor.", convert("The <code>&lt;project&gt;</code> element is the root of the descriptor."));
+		assertEquals("This is  " + System.lineSeparator() + "**bold**", convert("This is<br><b>bold</b>"));
+		// This is suboptimal, but this is how `<project>` will need to be added into xml docs
+		assertEquals("The `<project>` element is the root of the descriptor.", convert("The &lt;code>&amp;lt;project&amp;gt;&lt;/code> element is the root of the descriptor."));
 		assertEquals("# Hey Man #", convert("<h1>Hey Man</h1>"));
 		assertEquals("[Placeholder](https://www.xml.com)", convert("<a href=\"https://www.xml.com\">Placeholder</a>"));
 
 		String htmlList =
-			"<ul>" + System.lineSeparator() + 
+			"<ul>" + System.lineSeparator() +
 			"  <li>Coffee</li>" + System.lineSeparator() +
 			"  <li>Tea</li>" + System.lineSeparator() +
 			"  <li>Milk</li>" + System.lineSeparator() +
 			"</ul>";
-		String expectedList = 
+		String expectedList =
 			" *  Coffee" + System.lineSeparator() +
 			" *  Tea" + System.lineSeparator() +
 			" *  Milk";
 		assertEquals(expectedList, convert(htmlList));
 		assertEquals("ONLY_THIS_TEXT", convert("<p>ONLY_THIS_TEXT</p>"));
 
-		String multilineHTML = 
+		String multilineHTML =
 			"multi" + System.lineSeparator() +
 			"line" + System.lineSeparator() +
 			"<code>HTML</code>" + System.lineSeparator() +
 			"stuff";
 		assertEquals("multi line `HTML` stuff", convert(multilineHTML));
 
-		String multilineHTML2 = 
+		String multilineHTML2 =
 			"<p>multi<p>" + System.lineSeparator() +
 			"line" + System.lineSeparator() +
 			"<code>HTML</code>" + System.lineSeparator() +
 			"stuff";
-			String multilineHTML2Expected = 
+			String multilineHTML2Expected =
 			"multi" + System.lineSeparator() +
 			"" + System.lineSeparator() +
 			"line `HTML` stuff";
 		assertEquals(multilineHTML2Expected, convert(multilineHTML2));
 	}
-	
+
 	@Test
 	public void testMarkdownConversion() {
 		assertEquals("This is `my code`", convert("This is `my code`"));
 		assertEquals("The `<thing>` element is the root of the descriptor.", convert("The `<thing>` element is the root of the descriptor."));
 		assertEquals("The `<project>` element is the root of the descriptor.", convert("The `&lt;project&gt;` element is the root of the descriptor."));
+	}
+
+	@Test
+	public void mixedMarkdownAndHTML() {
+		assertEquals("*This* `code` is **bold**", convert("<em>This</em> `code` is **bold**"));
+		assertEquals( //
+				"This doesn't get turned into a code block", //
+				convert(
+				"    This doesn't" + System.lineSeparator() + //
+				"    get turned into" + System.lineSeparator() + //
+				"    a code block"));
+		assertEquals("My documentation has *not* been misformatted" + System.lineSeparator() + System.lineSeparator() + "It still looks nice :D",
+				convert(
+				"<p>" + System.lineSeparator() + //
+				"    My documentation has *not* been misformatted" + System.lineSeparator() + //
+				"</p>" + System.lineSeparator() + //
+				"It still looks nice :D"));
+		assertEquals("Markdown line breaks..." + System.lineSeparator() + System.lineSeparator() + "...are respected", //
+				"Markdown line breaks..." + System.lineSeparator() + //
+				System.lineSeparator() + //
+				"...are respected");
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/resources/xsd/mixedHtmlMarkdown.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/mixedHtmlMarkdown.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:annotation>
+      <xs:documentation>
+        # root
+
+        This is the root element of the document.
+
+        Use it like this:
+
+        ```
+        &amp;lt;root>
+          ...
+        &amp;lt;/root>
+        ```
+
+        *Since 0.1.0*
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="container" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>
+              ## container
+
+              Groups &lt;em>several&lt;/em> `content` together in a logical structure.
+
+              `&lt;em> This case is handled correctly &lt;/em>`
+
+              ![whale image](https://openclipart.org/image/400px/3243)
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="content" maxOccurs="unbounded" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>
+                    ## content
+                    &lt;p> This node represents *text* content. &lt;/p>
+                    &lt;p> This is the second [paragraph](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) in the documentation. &lt;/p>
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Treat `xs:documentation` and `xs:appinfo` as mixed Markdown and HTML, with the HTML tags escaped using entities. Unescape the entities, then render the Markdown portions into HTML using the commonmark-java library. Finally, use the existing code to convert this HTML into Markdown that doesn't contain any HTML tags.

Closes #962 

Signed-off-by: David Thompson <davthomp@redhat.com>
