### PR TITLE
Add eclipse/dash-licenses for tracking IP metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ And if you want to consume the SNAPSHOT builds instead:
 </repository>
 ```
 
+Verify 3rd Party Libraries
+----------------------------
+
+_Currently generating the IP Log report requires a Java Runtime Environment (JRE) >= 11._
+
+Run `./mvnw clean verify -Pverify-iplog` to generate a report for the 3rd party libraries used by this project. See the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#ip-license-tool) for further details.
+
+
 Clients
 -------
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
 			<id>cbi-release</id>
 			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
 		</pluginRepository>
+		<pluginRepository>
+			<id>dash-licenses-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+			<snapshots>
+			    <enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
 	</pluginRepositories>
 	<dependencyManagement>
 		<dependencies>
@@ -294,6 +301,27 @@
 						</plugin>
 					</plugins>
 				</pluginManagement>
+			</build>
+		</profile>
+		<profile>
+			<id>verify-iplog</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.dash</groupId>
+						<artifactId>license-tool-plugin</artifactId>
+						<version>0.0.1-SNAPSHOT</version>
+						<executions>
+							<execution>
+								<id>license-check</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>license-check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
 			</build>
 		</profile>
 	</profiles>


### PR DESCRIPTION
- Enable with 'verify-iplog' profile under the 'verify' lifecycle
- Summary generated under ${project.build.directory}/dash/summary

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>