### PR TITLE
Fix trimFinalNewlines

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/XMLBuilder.java
@@ -366,7 +366,7 @@ public class XMLBuilder {
 	 */
 	public void trimFinalNewlines() {
 		int i = xml.length() - 1;
-		while (i >= 0 && Character.isWhitespace(xml.charAt(i))) {
+		while (i >= 0 && (xml.charAt(i) == '\r' || xml.charAt(i) == '\n')) {
 			xml.deleteCharAt(i--);
 		}
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2906,6 +2906,17 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void testFormatRemoveFinalNewlinesWithoutTrimTrailing() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setTrimFinalNewlines(true);
+		settings.getFormattingSettings().setTrimTrailingWhitespace(false);
+		settings.getFormattingSettings().setSpaceBeforeEmptyCloseTag(false);
+		String content = "<aaa/>    \r\n\r\n\r\n";
+		String expected = "<aaa/>    ";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
 	public void testTemplate() throws BadLocationException {
 		String content = "";
 		String expected = "";


### PR DESCRIPTION
When `trimFinalNewlines = true`, the formatter removes `'\r'` and `'\n'` from the end of the document instead of all whitespace.

Fixes #827

Signed-off-by: David Thompson <davthomp@redhat.com>
