### PR TITLE
Modify reflection-config.json so that binary works in coc.nvim

### DIFF
--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -406,6 +406,14 @@
 		}]
 	},
 	{
+		"name": "org.eclipse.lsp4j.ClientInfo",
+		"allDeclaredFields": true,
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
 		"name": "org.eclipse.lsp4j.CodeAction",
 		"allDeclaredFields": true,
 		"methods": [{


### PR DESCRIPTION
coc.nvim is one of the implementations of LSP for vim/neovim. There's an existing configuration for running the Java build of LemMinX, but a reflection exception occurs when trying to run the binary build. This PR registers the class for reflection so the binary works in coc.nvim.

To test:
  *  Build the LemMinX binary, put in on your PATH
  *  Install coc.nvim: https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim
  *  If you have the existing XML support `coc-xml` already set up,
     uninstall with `:CocUninstall coc-xml`
  *  Open the configuration file with `:CocConfig`
  *  Add the following configuration:
```json
{
  "languageserver": {
    "xml": {
      "command": "lemminx",
      "trace.server": "verbose",
      "initializationOptions": {},
      "filetypes": [
        "xml"
      ]
    }
  }
}
```
  *  Save and quit
  *  Open an XML file, check if syntax errors appear

Signed-off-by: David Thompson <davthomp@redhat.com>
