### PR TITLE
Added closingBracketNewLine option

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -81,7 +81,7 @@ class XMLFormatter {
 		/**
 		 * Returns a List containing a single TextEdit, containing the newly formatted
 		 * changes of this.textDocument
-		 * 
+		 *
 		 * @return List containing a single TextEdit
 		 * @throws BadLocationException
 		 */
@@ -345,7 +345,7 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM text node.
-		 * 
+		 *
 		 * @param textNode the DOM text node to format.
 		 */
 		private void formatText(DOMText textNode) {
@@ -360,7 +360,7 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM document type.
-		 * 
+		 *
 		 * @param documentType the DOM document type to format.
 		 */
 		private void formatDocumentType(DOMDocumentType documentType) {
@@ -393,7 +393,7 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM ProcessingIntsruction.
-		 * 
+		 *
 		 * @param element the DOM ProcessingIntsruction to format.
 		 *
 		 */
@@ -406,7 +406,7 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM Comment
-		 * 
+		 *
 		 * @param element the DOM Comment to format.
 		 *
 		 */
@@ -424,9 +424,9 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM CDATA
-		 * 
+		 *
 		 * @param element the DOM CDATA to format.
-		 * 
+		 *
 		 */
 		private void formatCDATA(DOMCDATASection cdata) {
 			this.xmlBuilder.startCDATA();
@@ -439,9 +439,9 @@ class XMLFormatter {
 
 		/**
 		 * Format the given DOM element
-		 * 
+		 *
 		 * @param element the DOM element to format.
-		 * 
+		 *
 		 * @throws BadLocationException
 		 */
 		private void formatElement(DOMElement element) throws BadLocationException {
@@ -506,11 +506,11 @@ class XMLFormatter {
 		/**
 		 * Formats the start tag's closing bracket (>) according to
 		 * {@code XMLFormattingOptions#isPreserveAttrLineBreaks()}
-		 * 
+		 *
 		 * {@code XMLFormattingOptions#isPreserveAttrLineBreaks()}: If true, must add a
 		 * newline + indent before the closing bracket if the last attribute of the
 		 * element and the closing bracket are in different lines.
-		 * 
+		 *
 		 * @param element
 		 * @throws BadLocationException
 		 */
@@ -526,11 +526,11 @@ class XMLFormatter {
 		/**
 		 * Formats the self-closing tag (/>) according to
 		 * {@code XMLFormattingOptions#isPreserveAttrLineBreaks()}
-		 * 
+		 *
 		 * {@code XMLFormattingOptions#isPreserveAttrLineBreaks()}: If true, must add a
 		 * newline + indent before the self-closing tag if the last attribute of the
 		 * element and the closing bracket are in different lines.
-		 * 
+		 *
 		 * @param element
 		 * @throws BadLocationException
 		 */
@@ -551,22 +551,26 @@ class XMLFormatter {
 
 		private void formatAttributes(DOMElement element) throws BadLocationException {
 			List<DOMAttr> attributes = element.getAttributeNodes();
-			boolean isSingleElement = hasSingleAttributeInFullDoc(element);
+			boolean isSingleAttribute = hasSingleAttributeInFullDoc(element);
 			int prevOffset = element.getStart();
 			for (DOMAttr attr : attributes) {
-				formatAttribute(attr, isSingleElement, prevOffset);
+				formatAttribute(attr, isSingleAttribute, prevOffset);
 				prevOffset = attr.getEnd();
+			}
+			if ((this.sharedSettings.getFormattingSettings().getClosingBracketNewLine() && this.sharedSettings.getFormattingSettings().isSplitAttributes()) && !isSingleAttribute) {
+				xmlBuilder.linefeed();
+				xmlBuilder.indent(this.indentLevel);
 			}
 		}
 
-		private void formatAttribute(DOMAttr attr, boolean isSingleElement, int prevOffset)
+		private void formatAttribute(DOMAttr attr, boolean isSingleAttribute, int prevOffset)
 				throws BadLocationException {
 			if (this.sharedSettings.getFormattingSettings().isPreserveAttrLineBreaks()
 					&& !isSameLine(prevOffset, attr.getStart())) {
 				xmlBuilder.linefeed();
 				xmlBuilder.indent(this.indentLevel + 1);
 				xmlBuilder.addSingleAttribute(attr, false, false);
-			} else if (isSingleElement) {
+			} else if (isSingleAttribute) {
 				xmlBuilder.addSingleAttribute(attr);
 			} else {
 				xmlBuilder.addAttribute(attr, this.indentLevel);
@@ -576,10 +580,10 @@ class XMLFormatter {
 		/**
 		 * Returns true if first offset and second offset belong in the same line of the
 		 * document
-		 * 
+		 *
 		 * If current formatting is range formatting, the provided offsets must be
 		 * ranged offsets (offsets relative to the formatting range)
-		 * 
+		 *
 		 * @param first  the first offset
 		 * @param second the second offset
 		 * @return true if first offset and second offset belong in the same line of the
@@ -610,7 +614,7 @@ class XMLFormatter {
 		/**
 		 * Returns true if the provided element has one attribute in the fullDomDocument
 		 * (not the rangeDomDocument)
-		 * 
+		 *
 		 * @param element
 		 * @return true if the provided element has one attribute in the fullDomDocument
 		 *         (not the rangeDomDocument)
@@ -622,7 +626,7 @@ class XMLFormatter {
 
 		/**
 		 * Return the option to use to generate empty elements.
-		 * 
+		 *
 		 * @param element the DOM element
 		 * @return the option to use to generate empty elements.
 		 */
@@ -808,7 +812,7 @@ class XMLFormatter {
 	/**
 	 * Returns a List containing a single TextEdit, containing the newly formatted
 	 * changes of the document.
-	 * 
+	 *
 	 * @param textDocument   document to perform formatting on
 	 * @param range          specified range in which formatting will be done
 	 * @param sharedSettings settings containing formatting preferences
@@ -827,7 +831,7 @@ class XMLFormatter {
 
 	/**
 	 * Returns list of {@link IFormatterParticipant}.
-	 * 
+	 *
 	 * @return list of {@link IFormatterParticipant}.
 	 */
 	private Collection<IFormatterParticipant> getFormatterParticipants() {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
@@ -29,6 +29,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 	public static final boolean DEFAULT_PRESERVE_ATTR_LINE_BREAKS = false;
 	public static final boolean DEFAULT_TRIM_TRAILING_SPACES = false;
 	public static final int DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE = 2;
+	public static final boolean DEFAULT_CLOSING_BRACKET_NEW_LINE = false;
 
 	// All possible keys
 	private static final String SPLIT_ATTRIBUTES = "splitAttributes";
@@ -45,6 +46,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 	private static final String PRESERVE_ATTR_LINE_BREAKS = "preserveAttributeLineBreaks";
 	private static final String PRESERVE_EMPTY_CONTENT = "preserveEmptyContent";
 	private static final String SPLIT_ATTRIBUTES_INDENT_SIZE = "splitAttributesIndentSize";
+	private static final String CLOSING_BRACKET_NEW_LINE = "closingBracketNewLine";
 
 	/**
 	 * Options for formatting empty elements.
@@ -128,6 +130,7 @@ public class XMLFormattingOptions extends FormattingOptions {
 		this.setPreservedNewlines(DEFAULT_PRESERVER_NEW_LINES);
 		this.setEmptyElement(EmptyElements.ignore);
 		this.setSplitAttributesIndentSize(DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE);
+		this.setClosingBracketNewLine(DEFAULT_CLOSING_BRACKET_NEW_LINE);
 	}
 
 	public XMLFormattingOptions(int tabSize, boolean insertSpaces, boolean initializeDefaultSettings) {
@@ -376,6 +379,28 @@ public class XMLFormattingOptions extends FormattingOptions {
 
 	public static XMLFormattingOptions create(FormattingOptions options, FormattingOptions sharedFormattingOptions) {
 		return new XMLFormattingOptions(options).merge(sharedFormattingOptions);
+	}
+
+	/**
+	 * Returns the value of closingBracketNewLine or false if it was set to null
+	 * 
+	 * A setting for enabling the XML formatter to move the closing bracket of a tag with at least 2 attributes
+	 * to a new line.
+	 *
+	 * @return the value of closingBracketNewLine or false if it was set to null
+	 */
+	public boolean getClosingBracketNewLine() {
+		final Boolean value = this.getBoolean(CLOSING_BRACKET_NEW_LINE);
+		return (value == null) ? DEFAULT_CLOSING_BRACKET_NEW_LINE: value;
+	}
+
+	/**
+	 * Sets the value of closingBracketNewLine
+	 *
+	 * @param closingBracketNewLine the new value for closingBracketNewLine
+	 */
+	public void setClosingBracketNewLine(final boolean closingBracketNewLine) {
+		this.putBoolean(XMLFormattingOptions.CLOSING_BRACKET_NEW_LINE, Boolean.valueOf(closingBracketNewLine));
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2923,4 +2923,58 @@ public class XMLFormatterTest {
 		assertFormat(content, expected);
 	}
 
+	@Test
+	public void testClosingBracketNewLine() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(0);
+		settings.getFormattingSettings().setClosingBracketNewLine(true);
+		String content = "<a b='' c=''/>";
+		String expected = "<a" + lineSeparator() +
+		"b=''" + lineSeparator() +
+		"c=''"  + lineSeparator() +
+		"/>";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void testClosingBracketNewLineWithoutSplitAttributes() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(false);
+		settings.getFormattingSettings().setClosingBracketNewLine(true);
+		String content = "<a b='' c=''/>";
+		String expected = "<a b='' c='' />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void testClosingBracketNewLineWithSingleAttribute() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(0);
+		settings.getFormattingSettings().setClosingBracketNewLine(true);
+		String content = "<a b=''/>";
+		String expected = "<a b='' />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
+	public void testClosingBracketNewLineWithPreserveEmptyContent() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setSplitAttributesIndentSize(0);
+		settings.getFormattingSettings().setPreserveEmptyContent(true);
+		settings.getFormattingSettings().setClosingBracketNewLine(true);
+		String content = "<a>" + lineSeparator() +
+		"<b c='' d=''></b>" + lineSeparator() +
+		"</a>";
+		String expected = "<a>" + lineSeparator() +
+		"  <b" + lineSeparator() +
+		"  c=''" + lineSeparator() +
+		"  d=''" + lineSeparator() +
+		"  ></b>" + lineSeparator() +
+		"</a>";
+		assertFormat(content, expected, settings);
+	}
+
 }


### PR DESCRIPTION
Added formatting option to put XML closing ~~tag~~bracket on newline.

Closes redhat-developer/vscode-xml#435

Signed-off-by: Alexander Chen alchen@redhat.com