### PR TITLE
Add support for exiting immediately from a shutdown() request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.17.1](https://github.com/eclipse/lemminx/milestone/25?closed=1) (June 25, 2021)
+
+### Bug Fixes
+
+ * Add support for exiting immediately from a shutdown() request. See [#1070](https://github.com/eclipse/lemminx/pull/1070).
+
 ## [0.17.0](https://github.com/eclipse/lemminx/milestone/23?closed=1) (June 22, 2021)
 
 ### Enhancements

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
@@ -226,6 +226,9 @@ public class XMLLanguageServer
 	@Override
 	public CompletableFuture<Object> shutdown() {
 		xmlLanguageService.dispose();
+		if (capabilityManager.getClientCapabilities().getExtendedCapabilities().shouldLanguageServerExitOnShutdown()) {
+			delayer.schedule(() -> exit(0) , 1, TimeUnit.SECONDS);
+		}
 		return computeAsync(cc -> new Object());
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/ExtendedClientCapabilities.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/ExtendedClientCapabilities.java
@@ -26,6 +26,8 @@ public class ExtendedClientCapabilities {
 
 	private boolean openSettingsCommandSupport;
 
+	private boolean shouldLanguageServerExitOnShutdown;
+
 	public ExtendedCodeLensCapabilities getCodeLens() {
 		return codeLens;
 	}
@@ -73,6 +75,26 @@ public class ExtendedClientCapabilities {
 	 */
 	public void setOpenSettingsCommandSupport(boolean openSettingsCommandSupport) {
 		this.openSettingsCommandSupport = openSettingsCommandSupport;
+	}
+
+	/**
+	 * Sets the boolean permitting language server to exit on client
+	 * shutdown() request, without waiting for client to call exit()
+	 *
+	 * @param shouldLanguageServerExitOnShutdown
+	 */
+	public void setShouldLanguageServerExitOnShutdown(boolean shouldLanguageServerExitOnShutdown) {
+		this.shouldLanguageServerExitOnShutdown = shouldLanguageServerExitOnShutdown;
+	}
+
+	/**
+	 * Returns true if the client should exit on shutdown() request and
+	 * avoid waiting for an exit() request
+	 *
+	 * @return true if the language server should exit on shutdown() request
+	 */
+	public boolean shouldLanguageServerExitOnShutdown() {
+		return shouldLanguageServerExitOnShutdown;
 	}
 
 }


### PR DESCRIPTION
LemMinX (at least for those adopting vscode-languageclient 7.x) will not exit immediately after the client shuts down, and relies on the parent process watcher, which can take some time.

- In languageclient 7.x, the client fails to send the necessary exit()
  once a shutdown() response is received from the language server
- When client defines shouldLanguageServerExitOnShutdown as true, the
  language server will exit immediately after the shutdown request

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

The delay ensures the shutdown() response will be received by the client.