### PR TITLE
fix stackoverflow and ressource leak in folding

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFoldings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFoldings.java
@@ -99,7 +99,11 @@ class XMLFoldings {
 					}
 					if (i >= 0) {
 						TagInfo stackElement = stack.get(i);
-						stack = stack.subList(0, i); // stack.length = i;
+						// remove obsolete entries ()
+						int j = stack.size() - 1;
+						while (j >= i) {
+							stack.remove(j--);
+						}
 						int line = document.positionAt(scanner.getTokenOffset()).getLine();
 						int startLine = stackElement.startLine;
 						int endLine = line - 1;
@@ -123,7 +127,11 @@ class XMLFoldings {
 							}
 							if (i >= 0) {
 								TagInfo stackElement = stack.get(i);
-								stack = stack.subList(0, i); // stack.length = i;
+								// remove obsolete entries ()
+								int j = stack.size() - 1;
+								while (j >= i) {
+									stack.remove(j--);
+								}
 								int endLine = startLine;
 								startLine = stackElement.startLine;
 								if (endLine > startLine && prevStart != startLine) {


### PR DESCRIPTION
The old code used `ArrayList.subList()` which is only an adjusted view on the original list:
* likely to StackOverflow when called multitude of times in this recursive subList->subList->subList case
* resource hungry because:
   * the old ArrayList is still there and the view has a reference on it
   * the stackElement items (Tags) are kept until the loop is left because they are still referenced there

The new code removes the trailing elements directly, so the references are gone and the garbage collector is free to do its work; and most important: there's only one List, not one for each close tag/comment.