### PR TITLE
let scanner check for whitespace

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -354,8 +354,6 @@ public class DOMParser {
 			}
 
 			case Content: {
-				// FIXME: don't use getTokenText (substring) to know if the content is only
-				// spaces or line feed (scanner should know that).
 				boolean currIsDeclNode = curr instanceof DTDDeclNode;
 				if (currIsDeclNode) {
 					curr.end = scanner.getTokenOffset() - 1;
@@ -368,8 +366,7 @@ public class DOMParser {
 				DOMText textNode = xmlDocument.createText(start, end);
 				textNode.closed = true;
 
-				String content = scanner.getTokenText();
-				if (StringUtils.isWhitespace(content)) {
+				if (scanner.isTokenTextBlank()) {
 					if (ignoreWhitespaceContent) {
 						if (curr.hasChildNodes()) {
 							break;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/Scanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/Scanner.java
@@ -48,4 +48,9 @@ public interface Scanner {
 	String getTokenError();
 
 	ScannerState getScannerState();
+
+	/**
+	 * @return True if the token's Text is empty or all whitespace
+	 */
+	boolean isTokenTextBlank();
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/parser/XMLScanner.java
@@ -61,7 +61,8 @@ import static org.eclipse.lemminx.dom.parser.Constants._YVL;
 
 import java.util.function.Predicate;
 
-import org.eclipse.lemminx.dom.DOMDocumentType.DocumentTypeKind;;
+import org.eclipse.lemminx.dom.DOMDocumentType.DocumentTypeKind;
+import org.eclipse.lemminx.utils.StringUtils;;
 
 /**
  * XML scanner implementation.
@@ -1013,6 +1014,11 @@ public class XMLScanner implements Scanner {
 	@Override
 	public String getTokenText() {
 		return stream.getSource().substring(tokenOffset, stream.pos());
+	}
+
+	@Override
+	public boolean isTokenTextBlank() {
+		return StringUtils.isWhitespace(stream.getSource(), tokenOffset, stream.pos());
 	}
 
 	@Override


### PR DESCRIPTION
removing the need to create a substring just for the check after which it will be thrown away

This should lead to a minor speedup and less work for the garbage collector and removes a FIXME; but may break the API because there's no default implementation - @angelozerr if you want me to add it I'll do it, using the getTokenText and issue the whitespace-check on this.
It will also bring me to the next entry in the memory handling which currently points to that place

~~~
Caused by: java.lang.OutOfMemoryError: GC overhead limit exceeded
	at java.util.Arrays.copyOfRange(Arrays.java:3664)
	at java.lang.String.<init>(String.java:207)
	at java.lang.String.substring(String.java:1969)
	at org.eclipse.lemminx.dom.parser.XMLScanner.getTokenText(XMLScanner.java:1015)
	at org.eclipse.lemminx.dom.DOMParser.parse(DOMParser.java:371)
	at org.eclipse.lemminx.XMLTextDocumentService.lambda$new$0(XMLTextDocumentService.java:162)
	at org.eclipse.lemminx.XMLTextDocumentService$$Lambda$1/1854731462.apply(Unknown Source)
	at org.eclipse.lemminx.commons.ModelTextDocument.lambda$getModel$0(ModelTextDocument.java:66)
	at org.eclipse.lemminx.commons.ModelTextDocument$$Lambda$21/1909505440.apply(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602)
	... 6 more
~~~