### PR TITLE
Move check for whitespace to DOMCharacterData

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMCharacterData.java
@@ -30,7 +30,7 @@ public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.Ch
 
 	private String normalizedData;
 
-	private boolean isWhitespace;
+	private Boolean isWhitespace;
 
 	private String delimiter;
 
@@ -159,16 +159,10 @@ public abstract class DOMCharacterData extends DOMNode implements org.w3c.dom.Ch
 	 * @return the isWhitespace
 	 */
 	public boolean isWhitespace() {
+		if (isWhitespace == null) {
+			isWhitespace = Boolean.valueOf(StringUtils.isWhitespace(getData()));
+		}
 		return isWhitespace;
-	}
-
-	/**
-	 * Set true if this node's data is all whitespace
-	 * 
-	 * @param isWhitespace
-	 */
-	public void setWhitespace(boolean isWhitespace) {
-		this.isWhitespace = isWhitespace;
 	}
 
 	/*

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/dom/DOMParser.java
@@ -378,9 +378,7 @@ public class DOMParser {
 						tempWhitespaceContent = textNode;
 						break;
 
-					} else if (!currIsDeclNode) {
-						textNode.setWhitespace(true);
-					} else {
+					} else if (currIsDeclNode) {
 						break;
 					}
 


### PR DESCRIPTION
per @angelozerr in https://github.com/eclipse/lemminx/pull/1077#issuecomment-874682394 - I _guess_ there are more changes meant for DOMParser, but I wasn't sure how this should work with the existing additional conditions leading to a `break`, so here is the first draft (instead of a new issue) to not drop the initial idea which sounded good.

I guess that this PR is _not_ very useful without additional changes.