### PR TITLE
Added request for 'canBindGrammar' for vscode-xml command

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.commands.AssociateGrammarCommand;
+import org.eclipse.lemminx.extensions.contentmodel.commands.CheckBoundGrammarCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationAllFilesCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationFileCommand;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
@@ -48,7 +49,7 @@ import org.eclipse.lsp4j.InitializeParams;
 
 /**
  * Content model plugin extension to provide:
- * 
+ *
  * <ul>
  * <li>completion based on XML Schema, DTD...</li>
  * <li>hover based on XML Schema</li>
@@ -195,6 +196,8 @@ public class ContentModelPlugin implements IXMLExtension {
 					new XMLValidationAllFilesCommand(contentModelManager, documentProvider, validationService));
 			commandService.registerCommand(AssociateGrammarCommand.COMMAND_ID,
 					new AssociateGrammarCommand(documentProvider));
+			commandService.registerCommand(CheckBoundGrammarCommand.COMMAND_ID,
+					new CheckBoundGrammarCommand(documentProvider));
 		}
 	}
 
@@ -215,6 +218,7 @@ public class ContentModelPlugin implements IXMLExtension {
 			commandService.unregisterCommand(XMLValidationFileCommand.COMMAND_ID);
 			commandService.unregisterCommand(XMLValidationAllFilesCommand.COMMAND_ID);
 			commandService.unregisterCommand(AssociateGrammarCommand.COMMAND_ID);
+			commandService.unregisterCommand(CheckBoundGrammarCommand.COMMAND_ID);
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommand.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.services.IXMLDocumentProvider;
+import org.eclipse.lemminx.services.extensions.commands.AbstractDOMDocumentCommandHandler;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * XML Command "xml.check.bound.grammar" to verify if an XML document already has a bound
+ * grammar/schema, opened from the command palette.
+ *
+ */
+public class CheckBoundGrammarCommand extends AbstractDOMDocumentCommandHandler {
+
+	public static final String COMMAND_ID = "xml.check.bound.grammar";
+
+	public CheckBoundGrammarCommand(IXMLDocumentProvider documentProvider) {
+		super(documentProvider);
+	}
+
+	@Override
+	protected Object executeCommand(DOMDocument document, ExecuteCommandParams params, SharedSettings sharedSettings,
+			CancelChecker cancelChecker) throws Exception {
+		// Check if the document has a bound grammar.
+		return !document.hasGrammar();
+	}
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
@@ -29,14 +29,14 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for associating a grammar to a given XML command.
- * 
+ *
  * @author Angelo ZERR
  *
  */
 public class AssociateGrammarCommandTest {
 
 	@Test
-	public void associateWithXSDNoNamespaceShemaLocation() throws InterruptedException, ExecutionException {
+	public void associateWithXSDNoNamespaceSchemaLocation() throws InterruptedException, ExecutionException {
 		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
 
 		String xml = "<?xml version=\"1.0\" ?>\r\n" + //
@@ -159,7 +159,7 @@ public class AssociateGrammarCommandTest {
 	}
 
 	@Test
-	public void unkwownFileUri() throws InterruptedException, ExecutionException {
+	public void unknownFileUri() throws InterruptedException, ExecutionException {
 		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
 
 		String xmlPath = "tag.xml";

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommandTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lemminx.MockXMLLanguageServer;
+
+import org.eclipse.lemminx.utils.platform.Platform;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for checking if a document contains an associated grammar/schema using a XML command.
+ *
+ * @author Alexander Chen
+ */
+public class CheckBoundGrammarCommandTest {
+
+	@Test
+	public void checkDocumentWithoutBoundGrammar() throws Exception {
+		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		String xml = "<foo/>";
+		String xmlPath = getFileURI("src/test/resources/tag.xml");
+		TextDocumentIdentifier xmlIdentifier = languageServer.didOpen(xmlPath, xml);
+		String xsdPath = getFileURI("src/test/resources/xsd/tag.xsd");
+
+		Boolean actual = (Boolean) languageServer.executeCommand(CheckBoundGrammarCommand.COMMAND_ID, xmlIdentifier, xsdPath).get();
+		assertNotNull(actual);
+		assertEquals(true, actual);
+	}
+
+	@Test
+	public void checkDocumentWithXSIDocTypeBoundGrammar() throws Exception {
+		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		String xml = "<foo xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"tag.xsd\"/>";
+		String xmlPath = getFileURI("src/test/resources/tag.xml");
+		TextDocumentIdentifier xmlIdentifier = languageServer.didOpen(xmlPath, xml);
+		String xsdPath = getFileURI("src/test/resources/xsd/tag.xsd");
+
+		Boolean actual = (Boolean) languageServer.executeCommand(CheckBoundGrammarCommand.COMMAND_ID, xmlIdentifier, xsdPath).get();
+		assertNotNull(actual);
+		assertEquals(false, actual);
+	}
+
+	@Test
+	public void checkDocumentWithXMLModelBoundGrammar() throws Exception {
+		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		String xml = "<?xml-model href=\"tag1.xsd\"?>\r\n" +
+						"<foo/>";
+		String xmlPath = getFileURI("src/test/resources/tag.xml");
+		TextDocumentIdentifier xmlIdentifier = languageServer.didOpen(xmlPath, xml);
+		String xsdPath = getFileURI("src/test/resources/xsd/tag.xsd");
+
+		Boolean actual = (Boolean) languageServer.executeCommand(CheckBoundGrammarCommand.COMMAND_ID, xmlIdentifier, xsdPath).get();
+		assertNotNull(actual);
+		assertEquals(false, actual);
+	}
+
+	private static String getFileURI(String fileName) {
+		String uri = new File(fileName).toURI().toString();
+		if (Platform.isWindows && !uri.startsWith("file://")) {
+			uri = uri.replace("file:/", "file:///");
+		}
+		return uri;
+	}
+}


### PR DESCRIPTION
Added request for 'canBindGrammar' for vscode-xml 'Open Binding Wizard' command.

References: redhat-developer/vscode-xml/pull/544

Signed-off-by: Alexander Chen alchen@redhat.com