### PR TITLE
changed `closingBracketNewLine` indent to match `splitAttributeIndentSize`

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLFormatter.java
@@ -559,7 +559,9 @@ class XMLFormatter {
 			}
 			if ((this.sharedSettings.getFormattingSettings().getClosingBracketNewLine() && this.sharedSettings.getFormattingSettings().isSplitAttributes()) && !isSingleAttribute) {
 				xmlBuilder.linefeed();
-				xmlBuilder.indent(this.indentLevel);
+				// Indent by tag + splitAttributesIndentSize to match with attribute indent level
+				int totalIndent = this.indentLevel + this.sharedSettings.getFormattingSettings().getSplitAttributesIndentSize();
+				xmlBuilder.indent(totalIndent);
 			}
 		}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLFormatterTest.java
@@ -2938,6 +2938,20 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void testClosingBracketNewLineWithDefaultIndentSize() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setSplitAttributes(true);
+		settings.getFormattingSettings().setClosingBracketNewLine(true);
+		settings.getFormattingSettings().setPreserveAttrLineBreaks(true);
+		String content = "<a b='b' c='c'/>";
+		String expected = "<a\n" +
+		"    b='b'\n" +
+		"    c='c'\n" +
+		"    />";
+		assertFormat(content, expected, settings);
+	}
+
+	@Test
 	public void testClosingBracketNewLineWithoutSplitAttributes() throws BadLocationException {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setSplitAttributes(false);


### PR DESCRIPTION
Changed `closingBracketNewLine` indent level to match `splitAttributeIndentSize` when both `splitAttributeIndentSize` and `closingBracketNewLine` are `true`.

Closes: redhat-developer/vscode-xml/issues/516

Signed-off-by: Alexander Chen alchen@redhat.com