### PR TITLE
fixed `src-import.3.2` XSD error highlighting support

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/participants/XSDErrorCode.java
@@ -60,7 +60,8 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	src_resolve_4_2("src-resolve.4.2"), //
 	src_resolve("src-resolve"), src_element_2_1("src-element.2.1"),
 	EmptyTargetNamespace("EmptyTargetNamespace"),
-	src_import_3_1("src-import.3.1");
+	src_import_3_1("src-import.3.1"),
+	src_import_3_2("src-import.3.2");
 
 	private final String code;
 
@@ -177,6 +178,8 @@ public enum XSDErrorCode implements IXMLErrorCode {
 				return XMLPositionUtility.selectAttributeValueAt(XSDUtils.NAMESPACE_ATTR, offset, document);
 			}
 		}
+		case src_import_3_2:
+			return XMLPositionUtility.selectChildNodeAttributeValueFromGivenNameAt(XSDUtils.XS_IMPORT_TAG, XSDUtils.SCHEMA_LOCATION_ATTR, offset, document);
 		}
 
 		return null;

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
@@ -401,6 +401,19 @@ public class XSDValidationExtensionsTest {
 		testDiagnosticsFor(xsd, d);
 	}
 
+	@Test
+	public void src_import_3_2_NoNamespaceFound() throws BadLocationException {
+		String xsd = "<xs:schema\n" +
+		"xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n" +
+		"targetNamespace=\"http://example.org/my-example\"\n" +
+		"xmlns:NS=\"http://example.org/my-example\">\n" +
+	  	"<xs:import schemaLocation=\"src/test/resources/xsd/baseSchema.xsd\"/>\n" +
+		"</xs:schema>";
+
+		Diagnostic d = d(4, 26, 4, 65, XSDErrorCode.src_import_3_2);
+		testDiagnosticsFor(xsd, d);
+	}
+
 
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) throws BadLocationException {
 		XMLAssert.testDiagnosticsFor(xml, null, null, "test.xsd", expected);

--- a/org.eclipse.lemminx/src/test/resources/xsd/baseSchema.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/baseSchema.xsd
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	<xs:element name="root-element">
-
-	</xs:element>
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://foo.bar"
+>
+  <xs:element name="root-element"></xs:element>
 </xs:schema>


### PR DESCRIPTION
Fixed the `src-import.3.2` XSD error highlighting support to highlight the `xs:import` `schemaLocation` attribute.

Closes #1069 

Signed-off-by: Alexander Chen alchen@redhat.com