### PR TITLE
added CodeAction for opening XML binding wizard

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLTextDocumentService.java
@@ -197,6 +197,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 			sharedSettings
 					.setActionableNotificationSupport(extendedClientCapabilities.isActionableNotificationSupport());
 			sharedSettings.setOpenSettingsCommandSupport(extendedClientCapabilities.isOpenSettingsCommandSupport());
+			sharedSettings.setBindingWizardSupport(extendedClientCapabilities.isBindingWizardSupport());
 		}
 
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/ExtendedClientCapabilities.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/client/ExtendedClientCapabilities.java
@@ -13,9 +13,9 @@ package org.eclipse.lemminx.client;
 
 /**
  * Extended client capabilities not defined by the LSP.
- * 
+ *
  * @author Angelo ZERR
- * 
+ *
  * @see https://github.com/microsoft/language-server-protocol/issues/788
  */
 public class ExtendedClientCapabilities {
@@ -25,6 +25,8 @@ public class ExtendedClientCapabilities {
 	private boolean actionableNotificationSupport;
 
 	private boolean openSettingsCommandSupport;
+
+	private boolean bindingWizardSupport;
 
 	private boolean shouldLanguageServerExitOnShutdown;
 
@@ -38,10 +40,10 @@ public class ExtendedClientCapabilities {
 
 	/**
 	 * Returns true if the client supports actionable notifications and false otherwise
-	 * 
+	 *
 	 * See {@link org.eclipse.lemminx.customservice.ActionableNotification} and
 	 * {@link org.eclipse.lemminx.customservice.XMLLanguageClientAPI#actionableNotification}
-	 * 
+	 *
 	 * @return true if the client supports actionable notifications and false otherwise
 	 */
 	public boolean isActionableNotificationSupport() {
@@ -50,7 +52,7 @@ public class ExtendedClientCapabilities {
 
 	/**
 	 * Sets the actionableNotificationSupport boolean
-	 * 
+	 *
 	 * @param actionableNotificationSupport
 	 */
 	public void setActionableNotificationSupport(boolean actionableNotificationSupport) {
@@ -59,9 +61,9 @@ public class ExtendedClientCapabilities {
 
 	/**
 	 * Returns true if the client supports the open settings command and false otherwise
-	 * 
+	 *
 	 * See {@link org.eclipse.lemminx.client.ClientCommands#OPEN_SETTINGS}
-	 * 
+	 *
 	 * @return true if the client supports the open settings command and false otherwise
 	 */
 	public boolean isOpenSettingsCommandSupport() {
@@ -70,11 +72,29 @@ public class ExtendedClientCapabilities {
 
 	/**
 	 * Sets the openSettingsCommandSupport boolean
-	 * 
+	 *
 	 * @param openSettingsCommandSupport
 	 */
 	public void setOpenSettingsCommandSupport(boolean openSettingsCommandSupport) {
 		this.openSettingsCommandSupport = openSettingsCommandSupport;
+	}
+
+	/**
+	 * Returns true if the client supports the `xml.open.binding.wizard` command using dropdown and false otherwise
+	 *
+	 * @return bindingWizardSupport
+	 */
+	public boolean isBindingWizardSupport() {
+		return this.bindingWizardSupport;
+	}
+
+	/**
+	 * Sets the bindingWizardSupport boolean
+	 *
+	 * @param bindingWizardSupport
+	 */
+	public void setBindingWizardSupport(boolean bindingWizardSupport) {
+		this.bindingWizardSupport = bindingWizardSupport;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/CodeActionFactory.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.CreateFileOptions;
 import org.eclipse.lsp4j.Diagnostic;
@@ -41,7 +42,7 @@ public class CodeActionFactory {
 
 	/**
 	 * Create a CodeAction to remove the content from the given range.
-	 * 
+	 *
 	 * @param title
 	 * @param range
 	 * @param document
@@ -54,13 +55,13 @@ public class CodeActionFactory {
 
 	/**
 	 * Create a CodeAction to insert a new content at the end of the given range.
-	 * 
+	 *
 	 * @param title
 	 * @param range
 	 * @param insertText
 	 * @param document
 	 * @param diagnostic
-	 * 
+	 *
 	 * @return the CodeAction to insert a new content at the end of the given range.
 	 */
 	public static CodeAction insert(String title, Position position, String insertText, TextDocumentItem document,
@@ -77,11 +78,11 @@ public class CodeActionFactory {
 
 	/**
 	 * Returns the text edit to insert a new content at the end of the given range.
-	 * 
+	 *
 	 * @param insertText text to insert.
 	 * @param position   the position.
 	 * @param document   the text document.
-	 * 
+	 *
 	 * @return the text edit to insert a new content at the end of the given range.
 	 */
 	public static TextDocumentEdit insertEdit(String insertText, Position position, TextDocumentItem document) {
@@ -142,7 +143,7 @@ public class CodeActionFactory {
 
 	/**
 	 * Makes a CodeAction to create a file and add content to the file.
-	 * 
+	 *
 	 * @param title      The displayed name of the CodeAction
 	 * @param docURI     The file to create
 	 * @param content    The text to put into the newly created document.
@@ -164,6 +165,24 @@ public class CodeActionFactory {
 
 		CodeAction codeAction = new CodeAction(title);
 		codeAction.setEdit(createAndAddContentEdit);
+		codeAction.setDiagnostics(Collections.singletonList(diagnostic));
+		codeAction.setKind(CodeActionKind.QuickFix);
+
+		return codeAction;
+	}
+
+	/**
+	 * Makes a CodeAction to call a command from the available server commands.
+	 *
+	 * @param title         The displayed name of the CodeAction
+	 * @param commandId     The id of the given command to add as CodeAction
+	 * @param commandParams The document URI of the document the command is called on
+	 * @param diagnostic    The diagnostic that this CodeAction will fix
+	 */
+	public static CodeAction createCommand(String title, String commandId, List<Object> commandParams, Diagnostic diagnostic) {
+		CodeAction codeAction = new CodeAction(title);
+		Command command = new Command(title, commandId, commandParams);
+		codeAction.setCommand(command);
 		codeAction.setDiagnostics(Collections.singletonList(diagnostic));
 		codeAction.setKind(CodeActionKind.QuickFix);
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/NoGrammarConstraintsCodeAction.java
@@ -11,6 +11,8 @@
 *******************************************************************************/
 package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions;
 
+import static org.eclipse.lemminx.client.ClientCommands.OPEN_BINDING_WIZARD;
+
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
@@ -101,6 +103,15 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 					diagnostic);
 			codeActions.add(dtdWithXmlModelAction);
 
+			// ---------- Open Binding Wizard
+			if (sharedSettings.isBindingWizardSupport()) {
+				String documentURI = document.getDocumentURI();
+				String title = "Bind to existing grammar/schema";
+				List<Object> commandParams = Arrays.asList(documentURI);
+				CodeAction bindWithExistingGrammar = CodeActionFactory.createCommand(title, OPEN_BINDING_WIZARD, commandParams, diagnostic);
+				codeActions.add(bindWithExistingGrammar);
+			}
+
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "In NoGrammarConstraintsCodeAction position error", e);
 		}
@@ -108,10 +119,10 @@ public class NoGrammarConstraintsCodeAction implements ICodeActionParticipant {
 
 	/**
 	 * Returns the unique grammar URI file.
-	 * 
+	 *
 	 * @param documentURI   the XML document URI.
 	 * @param fileExtension the grammar file extension.
-	 * 
+	 *
 	 * @return the unique grammar URI file.
 	 */
 	static String getGrammarURI(String documentURI, String fileExtension) {

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/SharedSettings.java
@@ -29,6 +29,7 @@ public class SharedSettings {
 	private final XMLWorkspaceSettings workspaceSettings;
 	private boolean actionableNotificationSupport;
 	private boolean openSettingsCommandSupport;
+	private boolean bindingWizardSupport;
 
 	public SharedSettings() {
 		this.completionSettings = new XMLCompletionSettings();
@@ -55,6 +56,7 @@ public class SharedSettings {
 		this.preferences.merge(newSettings.getPreferences());
 		this.actionableNotificationSupport = newSettings.isActionableNotificationSupport();
 		this.openSettingsCommandSupport = newSettings.isOpenSettingsCommandSupport();
+		this.bindingWizardSupport = newSettings.isBindingWizardSupport();
 	}
 
 	public XMLCompletionSettings getCompletionSettings() {
@@ -96,10 +98,10 @@ public class SharedSettings {
 	/**
 	 * Returns true if the client supports actionable notifications and false
 	 * otherwise
-	 * 
+	 *
 	 * See {@link org.eclipse.lemminx.customservice.ActionableNotification} and
 	 * {@link org.eclipse.lemminx.customservice.XMLLanguageClientAPI}
-	 * 
+	 *
 	 * @return true if the client supports actionable notifications and false
 	 *         otherwise
 	 */
@@ -109,7 +111,7 @@ public class SharedSettings {
 
 	/**
 	 * Sets the actionableNotificationSupport boolean
-	 * 
+	 *
 	 * @param actionableNotificationSupport
 	 */
 	public void setActionableNotificationSupport(boolean actionableNotificationSupport) {
@@ -119,9 +121,9 @@ public class SharedSettings {
 	/**
 	 * Returns true if the client supports the open settings command and false
 	 * otherwise
-	 * 
+	 *
 	 * See {@link org.eclipse.lemminx.client.ClientCommands#OPEN_SETTINGS}
-	 * 
+	 *
 	 * @return true if the client supports the open settings command and false
 	 *         otherwise
 	 */
@@ -131,11 +133,29 @@ public class SharedSettings {
 
 	/**
 	 * Sets the openSettingsCommandSupport boolean
-	 * 
+	 *
 	 * @param openSettingsCommandSupport
 	 */
 	public void setOpenSettingsCommandSupport(boolean openSettingsCommandSupport) {
 		this.openSettingsCommandSupport = openSettingsCommandSupport;
+	}
+
+	/**
+	 * Returns true if the client supports the `xml.open.binding.wizard` command using dropdown and false otherwise
+	 *
+	 * @return bindingWizardSupport
+	 */
+	public boolean isBindingWizardSupport() {
+		return this.bindingWizardSupport;
+	}
+
+	/**
+	 * Sets the bindingWizardSupport boolean
+	 *
+	 * @param bindingWizardSupport
+	 */
+	public void setBindingWizardSupport(boolean bindingWizardSupport) {
+		this.bindingWizardSupport = bindingWizardSupport;
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -609,7 +609,6 @@ public class XMLAssert {
 	public static void assertCodeActions(List<CodeAction> actual, CodeAction... expected) {
 		actual.stream().forEach(ca -> {
 			// we don't want to compare title, etc
-			ca.setCommand(null);
 			ca.setKind(null);
 			ca.setTitle("");
 			if (ca.getDiagnostics() != null) {
@@ -633,6 +632,19 @@ public class XMLAssert {
 		TextDocumentEdit textDocumentEdit = tde(FILE_URI, 0, te);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		codeAction.setEdit(workspaceEdit);
+		return codeAction;
+	}
+
+	/**
+	 * Mock code action for creating a command code action
+	 */
+	public static CodeAction ca(Diagnostic d, Command c) {
+		CodeAction codeAction = new CodeAction();
+		codeAction.setTitle("");
+		codeAction.setDiagnostics(Arrays.asList(d));
+
+		codeAction.setCommand(c);
+
 		return codeAction;
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.lemminx.extensions.contentmodel;
 
+import static org.eclipse.lemminx.client.ClientCommands.OPEN_BINDING_WIZARD;
+
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.ca;
 import static org.eclipse.lemminx.XMLAssert.createFile;
@@ -22,6 +24,7 @@ import static org.eclipse.lemminx.XMLAssert.testDiagnosticsFor;
 
 import java.util.Arrays;
 
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -74,6 +77,8 @@ public class XMLProblemsTest {
 		workspaceEdit.setResourceOperations(Arrays.asList(ResourceOperationKind.Create));
 		workspace.setWorkspaceEdit(workspaceEdit);
 		settings.getWorkspaceSettings().setCapabilities(workspace);
+		// Expose `xml.open.binding.wizard` command
+		settings.setBindingWizardSupport(true);
 
 		// Code action to generate DTD, XSD
 		String schemaTemplate = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + lineSeparator() + //
@@ -110,8 +115,10 @@ public class XMLProblemsTest {
 						teOp("test.dtd", 0, 0, 0, 0, //
 								dtdTemplate), //
 						teOp("test.xml", 0, 0, 0, 0, //
-								"<?xml-model href=\"test.dtd\"?>" + lineSeparator() //
-						)));
+								"<?xml-model href=\"test.dtd\"?>" + lineSeparator())),
+				// Open binding wizard command
+				ca(d, new Command("Bind to existing grammar/schema", OPEN_BINDING_WIZARD, Arrays.asList(new Object[]{"test.xml"})))
+				);
 
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/SettingsTest.java
@@ -95,7 +95,8 @@ public class SettingsTest {
 			"			}\r\n" + "		}\r\n" + "	},\r\n" + "	\"extendedClientCapabilities\": {\r\n"
 			+ "		\"codeLens\": {\r\n" + "			\"codeLensKind\": {\r\n" + "				\"valueSet\": [\r\n"
 			+ "					\"references\"\r\n" + "				]\r\n" + "			}\r\n" + "		},\r\n"
-			+ "		actionableNotificationSupport: true,\r\n" + "		openSettingsCommandSupport: true\r\n" + "	}"
+			+ "		actionableNotificationSupport: true,\r\n" + "		openSettingsCommandSupport: true,\r\n"
+			+ "		bindingWizardSupport: true\r\n" + "	}"
 			+ "}";
 	// @formatter:on
 
@@ -249,6 +250,7 @@ public class SettingsTest {
 		assertEquals(CodeLensKind.References, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
 		assertTrue(clientCapabilities.isActionableNotificationSupport());
 		assertTrue(clientCapabilities.isOpenSettingsCommandSupport());
+		assertTrue(clientCapabilities.isBindingWizardSupport());
 	}
 
 	@Test


### PR DESCRIPTION
Added CodeAction for opening XML binding wizard to bind document to existing grammar/schema file.
(edit) made binding wizard CodeAction dependent on client support (reference: https://github.com/eclipse/lemminx/pull/1088#pullrequestreview-713931073)

Closes redhat-developer/vscode-xml/issues/515

Signed-off-by: Alexander Chen alchen@redhat.com