### PR TITLE
Report telemetry events for text document services

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -13,6 +13,11 @@ When telemetry events are enabled, the following information is emitted when the
     * The free, total, and max VM memory
  * Version information:
     * The server version number
+ * Text Document Information
+   * When a document is opened :
+      * The file extension (eg. `xml`, `xsd`, `dtd`)
+      * The associated grammar types (eg. `none`, `doctype`, `xml-model`, `xsi:schemaLocation`, `xsi:noNamespaceSchemaLocation`)
+      * The resolver used to resolve the grammar identifier (eg. `catalog`, `file association`, `embedded catalog.xsd`, `embedded xml.xsd`, `embedded xslt.xsd`)
  * Note: Does NOT include the `JAVA_HOME` environment variable for privacy reasons
 
 Currently, the startup event is the only telemetry event that is emitted.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
@@ -115,6 +115,7 @@ public class XMLLanguageServer
 
 		this.parentProcessId = params.getProcessId();
 
+		xmlLanguageService.setTelemetryManager(getTelemetryManager());
 		// Update XML language service extensions with InitializeParams
 		xmlLanguageService.initializeParams(params);
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
@@ -27,6 +27,7 @@ import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelDocu
 import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelHoverParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelSymbolsProviderParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.participants.ContentModelTypeDefinitionParticipant;
+import org.eclipse.lemminx.extensions.contentmodel.participants.DocumentTelemetryParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.participants.diagnostics.ContentModelDiagnosticsParticipant;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
@@ -79,6 +80,8 @@ public class ContentModelPlugin implements IXMLExtension {
 	private ContentModelSettings cmSettings;
 
 	private XMLValidationSettings currentValidationSettings;
+
+	private DocumentTelemetryParticipant documentTelemetryParticipant;
 
 	public ContentModelPlugin() {
 		completionParticipant = new ContentModelCompletionParticipant();
@@ -184,6 +187,8 @@ public class ContentModelPlugin implements IXMLExtension {
 		registry.registerSymbolsProviderParticipant(symbolsProviderParticipant);
 		codeLensParticipant = new ContentModelCodeLensParticipant(contentModelManager);
 		registry.registerCodeLensParticipant(codeLensParticipant);
+		documentTelemetryParticipant = new DocumentTelemetryParticipant(registry.getTelemetryManager(), contentModelManager);
+		registry.registerDocumentLifecycleParticipant(documentTelemetryParticipant);
 
 		// Register custom commands to re-validate XML files
 		IXMLCommandService commandService = registry.getCommandService();
@@ -211,6 +216,7 @@ public class ContentModelPlugin implements IXMLExtension {
 		registry.unregisterTypeDefinitionParticipant(typeDefinitionParticipant);
 		registry.unregisterSymbolsProviderParticipant(symbolsProviderParticipant);
 		registry.unregisterCodeLensParticipant(codeLensParticipant);
+		registry.unregisterDocumentLifecycleParticipant(documentTelemetryParticipant);
 
 		// Un-register custom commands to re-validate XML files
 		IXMLCommandService commandService = registry.getCommandService();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DocumentTelemetryParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/DocumentTelemetryParticipant.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.participants;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
+import org.eclipse.lemminx.services.extensions.IDocumentLifecycleParticipant;
+import org.eclipse.lemminx.telemetry.TelemetryManager;
+
+public class DocumentTelemetryParticipant implements IDocumentLifecycleParticipant {
+
+	private TelemetryManager telemetryManager;
+
+	private ContentModelManager contentManager;
+
+	public DocumentTelemetryParticipant(TelemetryManager telemetryManager, ContentModelManager contentManager) {
+		this.telemetryManager = telemetryManager;
+		this.contentManager = contentManager;
+	}
+
+	@Override
+	public void didOpen(DOMDocument document) {
+		telemetryManager.onDidOpen(document, contentManager);
+	}
+
+	@Override
+	public void didChange(DOMDocument document) {}
+
+	@Override
+	public void didSave(DOMDocument document) {}
+
+	@Override
+	public void didClose(DOMDocument document) {}
+
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/XMLExtensionsRegistry.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/XMLExtensionsRegistry.java
@@ -32,6 +32,7 @@ import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipa
 import org.eclipse.lemminx.services.extensions.format.IFormatterParticipant;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext.SaveContextType;
+import org.eclipse.lemminx.telemetry.TelemetryManager;
 import org.eclipse.lemminx.uriresolver.URIResolverExtensionManager;
 import org.eclipse.lsp4j.InitializeParams;
 
@@ -74,6 +75,8 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 
 	private final Map<Class<?>, Object> components;
 
+	private TelemetryManager telemetryManager;
+
 	public XMLExtensionsRegistry() {
 		extensions = new ArrayList<>();
 		completionParticipants = new ArrayList<>();
@@ -93,6 +96,7 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 		documentLifecycleParticipants = new ArrayList<>();
 		resolverExtensionManager = new URIResolverExtensionManager();
 		components = new HashMap<>();
+		telemetryManager = new TelemetryManager(null);
 		registerComponent(resolverExtensionManager);
 	}
 
@@ -503,6 +507,14 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 	 */
 	public void setCommandService(IXMLCommandService commandService) {
 		this.commandService = commandService;
+	}
+
+	public TelemetryManager getTelemetryManager() {
+		return telemetryManager;
+	}
+
+	public void setTelemetryManager(TelemetryManager telemetryManager) {
+		this.telemetryManager = telemetryManager;
 	}
 
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/DocumentTelemetryInfo.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/DocumentTelemetryInfo.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.telemetry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
+import org.eclipse.lemminx.extensions.contentmodel.model.ReferencedGrammarInfo;
+
+public class DocumentTelemetryInfo {
+
+	private static final String DOC_PROP_EXT = "file.extension";
+	private static final String DOC_PROP_RESOLVER = "file.resolver";
+	private static final String DOC_PROP_GRAMMAR_NONE = "file.grammar.none";
+	private static final String DOC_PROP_GRAMMAR_DOCTYPE = "file.grammar.doctype";
+	private static final String DOC_PROP_GRAMMAR_XMLMODEL = "file.grammar.xmlmodel";
+	private static final String DOC_PROP_GRAMMAR_SCHEMALOC = "file.grammar.schemalocation";
+	private static final String DOC_PROP_GRAMMAR_NONSSCHEMALOC = "file.grammar.nonsschemalocation";
+
+	public static Map<String, Object> getDocumentTelemetryInfo (DOMDocument doc, ContentModelManager manager) {
+		String uri = doc.getDocumentURI();
+		int index = uri.lastIndexOf('.');
+		String fileExtension = uri.substring(index + 1, uri.length()).toLowerCase();
+		Set<ReferencedGrammarInfo> referencedGrammarInfos = manager.getReferencedGrammarInfos(doc);
+		HashMap<String, Object> props = new HashMap<>();
+		props.put(DOC_PROP_EXT, fileExtension);
+
+		if (referencedGrammarInfos.isEmpty()) {
+			if ("xml".equals(fileExtension)) {
+				props.put(DOC_PROP_GRAMMAR_NONE, true);
+			}
+		} else {
+			List<String> resolvers = new ArrayList<String>();
+			for (ReferencedGrammarInfo info : referencedGrammarInfos) {
+				String kind = info.getBindingKind() == null ? "none" : info.getBindingKind();
+				String resolver = info.getResolvedBy();
+				if ("xml".equals(fileExtension)) {
+					switch (kind) {
+					case "none":
+						props.put(DOC_PROP_GRAMMAR_NONE, true);
+						break;
+					case "doctype":
+						props.put(DOC_PROP_GRAMMAR_DOCTYPE, true);
+						break;
+					case "xml-model":
+						props.put(DOC_PROP_GRAMMAR_XMLMODEL, true);
+						break;
+					case "xsi:schemaLocation":
+						props.put(DOC_PROP_GRAMMAR_SCHEMALOC, true);
+						break;
+					case "xsi:noNamespaceSchemaLocation":
+						props.put(DOC_PROP_GRAMMAR_NONSSCHEMALOC, true);
+						break;
+					}
+				}
+				resolvers.add(resolver == null ? "default" : resolver);
+			}
+
+			props.put(DOC_PROP_RESOLVER, resolvers);
+		}
+		return props;
+	}
+}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryManager.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package org.eclipse.lemminx.telemetry;
 
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
@@ -23,6 +25,8 @@ public class TelemetryManager {
 	 * "startup" telemetry event name
 	 */
 	private static final String STARTUP_EVENT_NAME = "server.initialized";
+
+	private static final String DOC_OPEN_EVENT_NAME = "server.document.open";
 
 	private final LanguageClient languageClient;
 
@@ -49,6 +53,10 @@ public class TelemetryManager {
 		if (isEnabled()) {
 			telemetryEvent(STARTUP_EVENT_NAME, InitializationTelemetryInfo.getInitializationTelemetryInfo());
 		}
+	}
+
+	public void onDidOpen(DOMDocument document, ContentModelManager manager) {
+		telemetryEvent(DOC_OPEN_EVENT_NAME, DocumentTelemetryInfo.getDocumentTelemetryInfo(document, manager));
 	}
 
 	/**


### PR DESCRIPTION
- ~This change is currently based off of #1091 so once that gets merged, we'll need to rebase against that.~
- ~Need to update USAGE_DATA.md~
- ~Need to review the naming of certain events. Eg. "extension" is a pretty overloaded term.~
- ~Currently only records document file extension, but grammar/schema can also be done.~