### PR TITLE
Register a command "xml.check.file.pattern"

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelPlugin.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.extensions.contentmodel.commands.AssociateGrammarCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.CheckBoundGrammarCommand;
+import org.eclipse.lemminx.extensions.contentmodel.commands.CheckFilePatternCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationAllFilesCommand;
 import org.eclipse.lemminx.extensions.contentmodel.commands.XMLValidationFileCommand;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
@@ -203,6 +204,8 @@ public class ContentModelPlugin implements IXMLExtension {
 					new AssociateGrammarCommand(documentProvider));
 			commandService.registerCommand(CheckBoundGrammarCommand.COMMAND_ID,
 					new CheckBoundGrammarCommand(documentProvider));
+			commandService.registerCommand(CheckFilePatternCommand.COMMAND_ID,
+					new CheckFilePatternCommand());
 		}
 	}
 
@@ -225,6 +228,7 @@ public class ContentModelPlugin implements IXMLExtension {
 			commandService.unregisterCommand(XMLValidationAllFilesCommand.COMMAND_ID);
 			commandService.unregisterCommand(AssociateGrammarCommand.COMMAND_ID);
 			commandService.unregisterCommand(CheckBoundGrammarCommand.COMMAND_ID);
+			commandService.unregisterCommand(CheckFilePatternCommand.COMMAND_ID);
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommand.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import org.eclipse.lemminx.services.extensions.commands.ArgumentsUtils;
+import org.eclipse.lemminx.services.extensions.commands.IXMLCommandService.IDelegateCommandHandler;
+import org.eclipse.lemminx.settings.PathPatternMatcher;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * XML Command "xml.check.file.pattern" whose first argument is a file pattern,
+ * and whose second argument is some file URI. The command returns true when
+ * the given pattern matches against the given file URI and false otherwise.
+ */
+public class CheckFilePatternCommand implements IDelegateCommandHandler {
+
+	public static final String COMMAND_ID = "xml.check.file.pattern";
+
+	@Override
+	public Object executeCommand(ExecuteCommandParams params, SharedSettings sharedSettings,
+			CancelChecker cancelChecker) throws Exception {
+		String pattern = ArgumentsUtils.getArgAt(params, 0, String.class);
+		String currentUri = ArgumentsUtils.getArgAt(params, 1, String.class);
+		PathPatternMatcher matcher = new PathPatternMatcher();
+		matcher.setPattern(pattern);
+		return matcher.matches(currentUri);
+	}
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommandTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.eclipse.lemminx.MockXMLLanguageServer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for checking if a file URI matches a given file pattern using an XML command.
+ */
+public class CheckFilePatternCommandTest {
+
+	@Test
+	public void checkPatternMatchSucceeds() throws Exception {
+		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		String xmlPath = "file:/path/to/src/test/resources/tag.xml";
+		String [] patterns = new String [] { "**/*.xml",  "**/tag.xml", "tag.xml", "**/test/*/*.xml"};
+
+		for (String pattern : patterns) {
+			Boolean actual = (Boolean) languageServer.executeCommand(CheckFilePatternCommand.COMMAND_ID, pattern, xmlPath).get();
+			assertNotNull(actual);
+			assertEquals(true, actual);
+		}
+	}
+
+	@Test
+	public void checkPatternMatchFails() throws Exception {
+		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		String xmlPath = "file:/path/to/src/test/resources/tag.xml";
+		String [] patterns = new String [] { "**/res/tag.xml",  "**/element.xml", "**/tag.html"};
+
+		for (String pattern : patterns) {
+			Boolean actual = (Boolean) languageServer.executeCommand(CheckFilePatternCommand.COMMAND_ID, pattern, xmlPath).get();
+			assertNotNull(actual);
+			assertEquals(false, actual);
+		}
+	}
+}


### PR DESCRIPTION
- Create class CheckFilePattern
- "xml.check.file.pattern" validates that some file in the project
  folder will match against a given pattern

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This permits https://github.com/redhat-developer/vscode-xml/issues/586 to be resolved on the server side.