### PR TITLE
Fixed tag rename for XML tags containing colons

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLRenameTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLRenameTest.java
@@ -81,7 +81,7 @@ public class XMLRenameTest {
 
 	@Test
 	public void testNamespaceRename() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xmlns:a|a=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"  <aa:b></aa:b>\n" +
@@ -90,15 +90,15 @@ public class XMLRenameTest {
 			"  <qq:b></qq:b>\n" +
 			"</aa:a>";
 		assertRename(xml, "ns", edits("ns", r(0, 12, 14), r(0, 1, 3), r(6, 2, 4), //root attribute, start tag, end tag
-																					r(1, 3, 5), r(1, 10, 12), 
-																					r(2, 3, 5), r(2, 10, 12), 
+																					r(1, 3, 5), r(1, 10, 12),
+																					r(2, 3, 5), r(2, 10, 12),
 																					r(3, 3, 5), //<aa:c
 																					r(4, 11, 13))); // attribute value
 	}
 
 	@Test
 	public void testNamespaceRenameEndTagPrefix() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"  <aa:b></a|a:b>\n" +
@@ -106,12 +106,12 @@ public class XMLRenameTest {
 			"  <t type=\"aa:b\"/>\n" +
 			"  <qq:b></qq:b>\n" +
 			"</aa:a>";
-		assertRename(xml, "ns", edits("ns", r(2, 3, 5), r(2, 10, 12))); 
+		assertRename(xml, "ns", edits("ns", r(2, 3, 5), r(2, 10, 12)));
 	}
 
 	@Test
 	public void testNamespaceRenameStartTagPrefix() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"  <a|a:b></aa:b>\n" +
@@ -119,12 +119,12 @@ public class XMLRenameTest {
 			"  <t type=\"aa:b\"/>\n" +
 			"  <qq:b></qq:b>\n" +
 			"</aa:a>";
-		assertRename(xml, "ns", edits("ns", r(2, 3, 5), r(2, 10, 12))); 
+		assertRename(xml, "ns", edits("ns", r(2, 3, 5), r(2, 10, 12)));
 	}
 
 	@Test
 	public void testNamespaceRenameEndTagSuffix() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"  <aa:|b></aa:b>\n" +
@@ -132,12 +132,12 @@ public class XMLRenameTest {
 			"  <t type=\"aa:b\"/>\n" +
 			"  <qq:b></qq:b>\n" +
 			"</aa:a>";
-		assertRename(xml, "BB", edits("BB", r(2, 6, 7), r(2, 13, 14))); 
+		assertRename(xml, "BB", edits("BB", r(2, 6, 7), r(2, 13, 14)));
 	}
 
 	@Test
 	public void testNamespaceRenameStartTagSuffix() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"  <aa:b></aa:b|>\n" +
@@ -145,16 +145,48 @@ public class XMLRenameTest {
 			"  <t type=\"aa:b\"/>\n" +
 			"  <qq:b></qq:b>\n" +
 			"</aa:a>";
-			assertRename(xml, "BB", edits("BB", r(2, 6, 7), r(2, 13, 14))); 
+			assertRename(xml, "BB", edits("BB", r(2, 6, 7), r(2, 13, 14)));
+	}
+
+	@Test
+	public void testNamespaceRenameWholeTagHoverLocalName() throws BadLocationException {
+		String xml =
+			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
+			"  <aa:b></aa:b>\n" +
+			"  <aa:|b></aa:b>\n" +
+			"  <aa:c/>\n" +
+			"  <t type=\"aa:b\"/>\n" +
+			"  <qq:b></qq:b>\n" +
+			"</aa:a>";
+
+		List<TextEdit> expectedEdits = edits("ns", r(2, 3, 5), r(2, 10, 12));
+		expectedEdits.addAll(edits("tag", r(2, 6, 7), r(2, 13, 14)));
+		assertRename(xml, "ns:tag", expectedEdits);
+	}
+
+	@Test
+	public void testNamespaceRenameWholeTagHoverPrefix() throws BadLocationException {
+		String xml =
+			"<aa:a xmlns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
+			"  <aa:b></aa:b>\n" +
+			"  <a|a:b></aa:b>\n" +
+			"  <aa:c/>\n" +
+			"  <t type=\"aa:b\"/>\n" +
+			"  <qq:b></qq:b>\n" +
+			"</aa:a>";
+
+		List<TextEdit> expectedEdits = edits("ns", r(2, 3, 5), r(2, 10, 12));
+		expectedEdits.addAll(edits("tag", r(2, 6, 7), r(2, 13, 14)));
+		assertRename(xml, "ns:tag", expectedEdits);
 	}
 
 	@Test
 	public void testTryToRenameXMLNS() throws BadLocationException {
-		String xml = 
+		String xml =
 			"<aa:a xml|ns:aa=\"aa.com\" xmlns:qq=\"qq.com\">\n" +
 			"  <aa:b></aa:b>\n" +
 			"</aa:a>";
-			assertRename(xml, "BBBB"); 
+			assertRename(xml, "BBBB");
 	}
 
 


### PR DESCRIPTION
Fixed tag rename for XML tags containing colons, fixed duplicate rename for namespace tags.

Fixes redhat-developer/vscode-xml/issues/621

Signed-off-by: Alexander Chen <alchen@redhat.com>

Behaviour:
![Peek 2021-12-08 16-48](https://user-images.githubusercontent.com/26389510/145289861-a3186184-7f98-4564-8364-ca6c56f0a8c9.gif)

