### PR TITLE
'No definition found' when using 'Go to Definition' for types defined in imported XSD

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/utils/XSDUtils.java
@@ -157,13 +157,20 @@ public class XSDUtils {
 		if (matchAttr && StringUtils.isEmpty(originAttrValue)) {
 			return;
 		}
-
-		// <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		// xmlns:tns="http://camel.apache.org/schema/spring"
-		// targetNamespace="http://camel.apache.org/schema/spring" version="1.0">
-		String targetNamespace = documentElement.getAttribute(TARGET_NAMESPACE_ATTR); // ->
-																						// http://camel.apache.org/schema/spring
-		String targetNamespacePrefix = documentElement.getPrefix(targetNamespace); // -> tns
+		String targetNamespacePrefix = null;
+		int index = originAttrValue.indexOf(':');
+		if (index != -1) {
+			// ex : jakartaee:applicationType
+			targetNamespacePrefix = originAttrValue.substring(0, index);
+		} else {
+			// <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+			// xmlns:tns="http://camel.apache.org/schema/spring"
+			// targetNamespace="http://camel.apache.org/schema/spring" version="1.0">
+			String targetNamespace = documentElement.getAttribute(TARGET_NAMESPACE_ATTR); // ->
+																							// http://camel.apache.org/schema/spring
+			targetNamespacePrefix = documentElement.getPrefix(targetNamespace); //
+			// -> tns
+		}
 
 		String originName = null;
 		if (matchAttr) {
@@ -197,7 +204,7 @@ public class XSDUtils {
 					if (targetAttr != null && (!matchAttr || Objects.equal(originName, targetAttr.getValue()))) {
 						collector.accept(targetNamespacePrefix, targetAttr);
 					}
-				} else if (isXSInclude(targetElement)) {
+				} else if (isXSInclude(targetElement) || isXSImport(targetElement)) {
 					// collect xs:include XML Schema location
 					String schemaLocation = targetElement.getAttribute(SCHEMA_LOCATION_ATTR);
 					if (schemaLocation != null) {
@@ -498,7 +505,8 @@ public class XSDUtils {
 						DOMAttr schemaLocationAttr = XSDUtils.getSchemaLocation(xsdElement);
 						if (schemaLocationAttr != null) {
 							String attrValue = schemaLocationAttr.getValue();
-							if (grammarURI.equals(attrValue) || ((grammarURI.endsWith(attrValue) && grammarURI.equals(getResolvedLocation(document.getDocumentURI(), attrValue))))) {
+							if (grammarURI.equals(attrValue) || ((grammarURI.endsWith(attrValue)
+									&& grammarURI.equals(getResolvedLocation(document.getDocumentURI(), attrValue))))) {
 								return schemaLocationAttr;
 							}
 						}
@@ -508,7 +516,7 @@ public class XSDUtils {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Returns the expanded system location
 	 *

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
@@ -186,8 +186,27 @@ public class XSDDefinitionExtensionsTest {
 				"		</xs:sequence>\r\n" + //
 				"	</xs:complexType>";
 		String schemaCPath = Paths.get("src/test/resources/xsd/SchemaC.xsd").toUri().toString();
-		testDefinitionFor(xml, ll(schemaCPath, r(6,19,6,30), r(3, 18, 3, 29)));
+		testDefinitionFor(xml, ll(schemaCPath, r(6, 19, 6, 30), r(3, 18, 3, 29)));
 
+	}
+
+	@Test
+	public void definitionWithXSImport() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
+				"<xs:schema targetNamespace=\"SomeNamespace\"\r\n" + //
+				"           xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //
+				"           xmlns:ct=\"ChildTypes\"\r\n" + //
+				"           xmlns=\"SomeNamespace\"\r\n" + //
+				"           elementFormDefault=\"unqualified\">\r\n" + //
+				"  <xs:import schemaLocation=\"src/test/resources/xsd/Child.xsd\" namespace=\"ChildTypes\"/>\r\n"
+				+ " \r\n" + //
+				"  <xs:complexType name=\"SpecialType\">\r\n" + "    <xs:complexContent>\r\n" + //
+				"      <xs:extension base=\"ct:Som|eGenericType\">\r\n" + "        <xs:sequence>\r\n" + //
+				"          <xs:element name=\"AdditionalField\" type=\"xs:string\" />\r\n" + //
+				"        </xs:sequence>\r\n" + "      </xs:extension>\r\n" + "    </xs:complexContent>\r\n" + //
+				"  </xs:complexType>\r\n" + "</xs:schema>";
+		String childPath = Paths.get("src/test/resources/xsd/Child.xsd").toUri().toString();
+		testDefinitionFor(xml, ll(childPath, r(10, 25, 10, 45), r(5, 23, 5, 40)));
 	}
 
 	private static void testDefinitionFor(String xml, LocationLink... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/resources/xsd/Child.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/Child.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="ChildTypes"
+           xmlns="ChildTypes"
+           elementFormDefault="unqualified">
+  <xs:complexType name="SomeGenericType">
+    <xs:sequence>
+      <xs:element name="FirstName" type="xs:string" minOccurs="0"/>
+      <xs:element name="LastName" type="xs:string" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+</xs:schema>


### PR DESCRIPTION
'No definition found' when using 'Go to Definition' for types defined in imported XSD

Fixes [#632](https://github.com/redhat-developer/vscode-xml/issues/632)

Signed-off-by: azerr <azerr@redhat.com>