### PR TITLE
implementation of formatting for element attributes

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
@@ -353,7 +353,7 @@ class XMLSymbolsProvider {
 					for(DOMAttr attrNode : node.getAttributeNodes()){
 						XMLSymbolExpressionFilter inlineAttrfilter = filter.getFilterForInlineAttr(attrNode);
 						if(inlineAttrfilter != null){
-							if(!inlineAttrfilter.shouldShowAttributeName()){
+							if(!inlineAttrfilter.isShowAttributeName()){
 								return element.getTagName() + ": " + attrNode.getValue();
 							} else if (attrNode.getName() != null) {
 								return element.getTagName() + ": @" + attrNode.getName() + ": " + attrNode.getValue();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLSymbolsProvider.java
@@ -136,8 +136,9 @@ class XMLSymbolsProvider {
 			boolean collectAttributes = hasFilterForAttr && node.hasAttributes();
 			if (collectAttributes) {
 				// Collect attributes from the DOM element
+				List<DOMNode> attrToIgnore = getFilteredNodeAttributes(node, filter, hasFilterForAttr);
 				for (DOMAttr attr : node.getAttributeNodes()) {
-					findSymbolInformations(attr, containerName, symbols, false, filter, hasFilterForAttr,
+					findSymbolInformations(attr, containerName, symbols, attrToIgnore.contains(attr), filter, hasFilterForAttr,
 							cancelChecker);
 				}
 			}
@@ -278,10 +279,10 @@ class XMLSymbolsProvider {
 
 		List<DOMNode> attrNodesToIgnore = new ArrayList<DOMNode>();
 		for(DOMAttr attrNode : node.getAttributeNodes()){
-			XMLSymbolExpressionFilter filterExpression = filter.getFilterForPrimaryAttr(attrNode);
+			XMLSymbolExpressionFilter filterExpression = filter.getFilterForInlineAttr(attrNode);
 			if(filterExpression != null){
 				// prevent rendering the attribute as a child node if it's
-				// already shown as a primary attribute and on the parent line
+				// already shown as an inline attribute and on the parent line
 				attrNodesToIgnore.add(attrNode);
 				break;
 			}
@@ -350,9 +351,9 @@ class XMLSymbolsProvider {
 					return element.getTagName() + ": " + firstChild.getNodeValue();
 				} else if(hasFilterForAttr && node.hasAttributes()){
 					for(DOMAttr attrNode : node.getAttributeNodes()){
-						XMLSymbolExpressionFilter primaryAttrfilter = filter.getFilterForPrimaryAttr(attrNode);
-						if(primaryAttrfilter != null){
-							if(primaryAttrfilter.isValueOnly()){
+						XMLSymbolExpressionFilter inlineAttrfilter = filter.getFilterForInlineAttr(attrNode);
+						if(inlineAttrfilter != null){
+							if(!inlineAttrfilter.shouldShowAttributeName()){
 								return element.getTagName() + ": " + attrNode.getValue();
 							} else if (attrNode.getName() != null) {
 								return element.getTagName() + ": @" + attrNode.getName() + ": " + attrNode.getValue();

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
@@ -26,9 +26,9 @@ public class XMLSymbolExpressionFilter {
 
 	private boolean excluded;
 
-	private boolean primaryElementAttr;
+	private boolean inlineAttribute;
 
-	private boolean valueOnly;
+	private boolean showAttributeName;
 
 	/**
 	 * Returns the XPath expression.
@@ -51,48 +51,51 @@ public class XMLSymbolExpressionFilter {
 
 	/**
 	 * Returns true if the filter which matches an element attribute node must consider it
-	 * a primary attribute and show it on the same line as the owning element and false otherwise.
+	 * an inline attribute and show it on the same line as the owning element and false otherwise.
 	 * 
 	 * @return true if the filter which matches an element attribute node must consider it
-	 *         a primary attribute and show it on the same line as the owning element and
+	 *         an inline attribute and show it on the same line as the owning element and
 	 *         false otherwise.
 	 */
-	public boolean isPrimaryElementAttr() {
-		return primaryElementAttr;
+	public boolean isinlineAttribute() {
+		return inlineAttribute;
 	}
 
 	/**
 	 * Set whether or not a matched filter for an element attribute must be considered
-	 * a primary attribute and shown on the same line as the owning element.
+	 * an inline attribute and shown on the same line as the owning element.
 	 * 
-	 * @param primaryElementAttr whether or not a matched filter for an element attribute must be
-	 *                           considered a primary attribute and shown on the same line as the
-	 *                           owning element.
+	 * @param inlineAttribute whether or not a matched filter for an element attribute must be
+	 *                        considered an inline attribute and shown on the same line as the
+	 *                        owning element.
 	 */
-	public void setPrimaryElementAttr(boolean primaryElementAttr) {
-		this.primaryElementAttr = primaryElementAttr;
+	public void setInlineAttribute(boolean inlineAttribute) {
+		this.inlineAttribute = inlineAttribute;
 	}
 
 	/**
-	 * Returns true if the filter which matches an element attribute node must only show
-	 * the attribute value and not its name, and false otherwise.
+	 * Returns true if the filter which matches an element attribute node should show
+	 * the attribute name or not, the attribute value will always be shown, and false
+	 * otherwise.
 	 * 
-	 * @return true if the filter which matches an element attribute node must only show
-	 *              the attribute value and not its name, and false otherwise.
+	 * @return true if the filter which matches an element attribute node should show
+	 *         the attribute name or not, the attribute value will always be shown, and false
+	 *         otherwise.
 	 */
-	public boolean isValueOnly() {
-		return valueOnly;
+	public boolean shouldShowAttributeName() {
+		return showAttributeName;
 	}
 
 	/**
-	 * Set whether or not a matched filter for an element attribute must only show
-	 * the attribute value and not its name.
+	 * Set whether or not a matched filter for an element attribute should show
+	 * the attribute name or not, the attribute value will always be shown.
 	 * 
-	 * @param valueOnly whether or not a matched filter for an element attribute must only
-	 *                  show the attribute value and not its name.
+	 * @param showAttributeName whether or not a matched filter for an element attribute
+	 *                          should show the attribute name or not, the attribute value
+	 *                          will always be shown.
 	 */
-	public void setValueOnly(boolean valueOnly) {
-		this.valueOnly = valueOnly;
+	public void setShowAttributeName(boolean showAttributeName) {
+		this.showAttributeName = showAttributeName;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
@@ -57,7 +57,7 @@ public class XMLSymbolExpressionFilter {
 	 *         an inline attribute and show it on the same line as the owning element and
 	 *         false otherwise.
 	 */
-	public boolean isinlineAttribute() {
+	public boolean isInlineAttribute() {
 		return inlineAttribute;
 	}
 
@@ -82,7 +82,7 @@ public class XMLSymbolExpressionFilter {
 	 *         the attribute name or not, the attribute value will always be shown, and false
 	 *         otherwise.
 	 */
-	public boolean shouldShowAttributeName() {
+	public boolean isShowAttributeName() {
 		return showAttributeName;
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolExpressionFilter.java
@@ -26,6 +26,10 @@ public class XMLSymbolExpressionFilter {
 
 	private boolean excluded;
 
+	private boolean primaryElementAttr;
+
+	private boolean valueOnly;
+
 	/**
 	 * Returns the XPath expression.
 	 * 
@@ -43,6 +47,52 @@ public class XMLSymbolExpressionFilter {
 	public void setXpath(String xpath) {
 		this.xpath = xpath;
 		this.matcher = null;
+	}
+
+	/**
+	 * Returns true if the filter which matches an element attribute node must consider it
+	 * a primary attribute and show it on the same line as the owning element and false otherwise.
+	 * 
+	 * @return true if the filter which matches an element attribute node must consider it
+	 *         a primary attribute and show it on the same line as the owning element and
+	 *         false otherwise.
+	 */
+	public boolean isPrimaryElementAttr() {
+		return primaryElementAttr;
+	}
+
+	/**
+	 * Set whether or not a matched filter for an element attribute must be considered
+	 * a primary attribute and shown on the same line as the owning element.
+	 * 
+	 * @param primaryElementAttr whether or not a matched filter for an element attribute must be
+	 *                           considered a primary attribute and shown on the same line as the
+	 *                           owning element.
+	 */
+	public void setPrimaryElementAttr(boolean primaryElementAttr) {
+		this.primaryElementAttr = primaryElementAttr;
+	}
+
+	/**
+	 * Returns true if the filter which matches an element attribute node must only show
+	 * the attribute value and not its name, and false otherwise.
+	 * 
+	 * @return true if the filter which matches an element attribute node must only show
+	 *              the attribute value and not its name, and false otherwise.
+	 */
+	public boolean isValueOnly() {
+		return valueOnly;
+	}
+
+	/**
+	 * Set whether or not a matched filter for an element attribute must only show
+	 * the attribute value and not its name.
+	 * 
+	 * @param valueOnly whether or not a matched filter for an element attribute must only
+	 *                  show the attribute value and not its name.
+	 */
+	public void setValueOnly(boolean valueOnly) {
+		this.valueOnly = valueOnly;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
@@ -48,8 +48,8 @@ import org.eclipse.lemminx.xpath.matcher.IXPathNodeMatcher.MatcherType;
             // keep the value of the attribute "name" on the same line
             // as the "target" element, and only show the attribute value
             "xpath": "//target/@name",
-            "primaryElementAttr" : true,
-            "valueOnly": true
+            "inlineAttribute" : true,
+            "showAttributeName": false
          },
          // show "unless" and "depends" as nested attributes for
          // "target" elements
@@ -63,8 +63,8 @@ import org.eclipse.lemminx.xpath.matcher.IXPathNodeMatcher.MatcherType;
             // keep the value of the attribute "name" on the same line
             // as the "property" element, and only show the attribute value
             "xpath": "//property/@name",
-            "primaryElementAttr" : true,
-            "valueOnly": true
+            "inlineAttribute" : true,
+            "showAttributeName": false
          },
          {
             // keep the value of the attribute "file" on the same line
@@ -72,8 +72,8 @@ import org.eclipse.lemminx.xpath.matcher.IXPathNodeMatcher.MatcherType;
             // along with the value to distinguish it from the more common
             // "name" attribute
             "xpath": "//property/@file",
-            "primaryElementAttr" : true,
-            "valueOnly": false
+            "inlineAttribute" : true,
+            "showAttributeName": true
          }
       }
    ]
@@ -108,19 +108,19 @@ public class XMLSymbolFilter extends PathPatternMatcher {
 	}
 
 	/**
-	 * Gets the first matched attribute node that is set as a
-	 * primary attribute for an element.
+	 * Gets the first matched attribute node that is set as an
+	 * inline attribute for an element.
 	 * 
 	 * @param attrNode the DOMElement attribute node to check for.
 	 * 
-	 * @return the first matched attribute node that is set as a
-	 *         primary attribute for an element, or null if there
+	 * @return the first matched attribute node that is set as an
+	 *         inline attribute for an element, or null if there
 	 *         isn't one.
 	 */
-	public XMLSymbolExpressionFilter getFilterForPrimaryAttr(DOMAttr attrNode){
+	public XMLSymbolExpressionFilter getFilterForInlineAttr(DOMAttr attrNode){
 		if (expressions != null && expressions.length > 0) {
 			for (XMLSymbolExpressionFilter expression : expressions) {
-				if (expression.match(attrNode) && expression.isPrimaryElementAttr()) {
+				if (expression.match(attrNode) && expression.isinlineAttribute()) {
 					return expression;
 				}
 			}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package org.eclipse.lemminx.settings;
 
+import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.xpath.matcher.IXPathNodeMatcher.MatcherType;
 
@@ -37,8 +38,45 @@ import org.eclipse.lemminx.xpath.matcher.IXPathNodeMatcher.MatcherType;
             "xpath": "//@id"
          }
       ]
-   }
-]
+   },
+   // Declaration of symbols filter for ant/phing build.xml files to show all target names and property
+   // names/files in the Outline.
+   {
+      "pattern": "build*.xml",
+      "expressions" :[
+         {
+            // keep the value of the attribute "name" on the same line
+            // as the "target" element, and only show the attribute value
+            "xpath": "//target/@name",
+            "primaryElementAttr" : true,
+            "valueOnly": true
+         },
+         // show "unless" and "depends" as nested attributes for
+         // "target" elements
+         {
+            "xpath": "//target/@unless"
+         },
+         {
+            "xpath": "//target/@depends"
+         },
+         {
+            // keep the value of the attribute "name" on the same line
+            // as the "property" element, and only show the attribute value
+            "xpath": "//property/@name",
+            "primaryElementAttr" : true,
+            "valueOnly": true
+         },
+         {
+            // keep the value of the attribute "file" on the same line
+            // as the "property" element, and show the attribute name
+            // along with the value to distinguish it from the more common
+            // "name" attribute
+            "xpath": "//property/@file",
+            "primaryElementAttr" : true,
+            "valueOnly": false
+         }
+      }
+   ]
  * </pre>
  */
 public class XMLSymbolFilter extends PathPatternMatcher {
@@ -67,6 +105,28 @@ public class XMLSymbolFilter extends PathPatternMatcher {
 	 */
 	public XMLSymbolExpressionFilter[] getExpressions() {
 		return expressions;
+	}
+
+	/**
+	 * Gets the first matched attribute node that is set as a
+	 * primary attribute for an element.
+	 * 
+	 * @param attrNode the DOMElement attribute node to check for.
+	 * 
+	 * @return the first matched attribute node that is set as a
+	 *         primary attribute for an element, or null if there
+	 *         isn't one.
+	 */
+	public XMLSymbolExpressionFilter getFilterForPrimaryAttr(DOMAttr attrNode){
+		if (expressions != null && expressions.length > 0) {
+			for (XMLSymbolExpressionFilter expression : expressions) {
+				if (expression.match(attrNode) && expression.isPrimaryElementAttr()) {
+					return expression;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLSymbolFilter.java
@@ -120,7 +120,7 @@ public class XMLSymbolFilter extends PathPatternMatcher {
 	public XMLSymbolExpressionFilter getFilterForInlineAttr(DOMAttr attrNode){
 		if (expressions != null && expressions.length > 0) {
 			for (XMLSymbolExpressionFilter expression : expressions) {
-				if (expression.match(attrNode) && expression.isinlineAttribute()) {
+				if (expression.match(attrNode) && expression.isInlineAttribute()) {
 					return expression;
 				}
 			}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLDocumentSymbolsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLDocumentSymbolsTest.java
@@ -394,4 +394,358 @@ public class XMLDocumentSymbolsTest {
 						Arrays.asList(//
 								ds("bar", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, Arrays.asList()))));
 	}
+
+	@Test
+	public void symbolsFilterWithNonInlineAttributeShowAttributeName(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		DocumentSymbol symbolsWithAllAttr2NoInlineAttr = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr2: value2", SymbolKind.Constant, r(1, 21, 1, 35), r(1, 21, 1, 35),
+												null, //
+												Arrays.asList()))), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList( //
+										ds("@attr2: baz-value2", SymbolKind.Constant, r(2, 25, 2, 43), r(2, 25, 2, 43),
+												null, //
+												Arrays.asList())))));
+
+		// Test with //@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr2NoInlineAttr);
+
+		DocumentSymbol symbolsWithBarAttr2NoInlineAttr = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr2: value2", SymbolKind.Constant, r(1, 21, 1, 35), r(1, 21, 1, 35),
+												null, //
+												Arrays.asList()))), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, Arrays.asList())));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		// when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2NoInlineAttr);
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		// when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2NoInlineAttr);
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeNoNestedAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		DocumentSymbol symbolsWithAllAttr2InlineAttr = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: @attr2: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz: @attr2: baz-value2", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList())));
+
+		// Test with //@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr2InlineAttr);
+
+		DocumentSymbol symbolsWithAllAttr2InlineAttrNoName = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz: baz-value2", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList())));
+
+		// Test with //@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr2InlineAttrNoName);
+
+		DocumentSymbol symbolsWithBarAttr2InlineAttr = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: @attr2: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, Arrays.asList())));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttr);
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttr);
+
+		DocumentSymbol symbolsWithBarAttr2InlineAttrNoName = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, Arrays.asList())));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrNoName);
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrNoName);
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeWithNestedAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		XMLSymbolExpressionFilter expressionFilter2 = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter, expressionFilter2 });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		DocumentSymbol symbolsWithAllAttr2InlineAttrAndNestedAttr1 = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: @attr2: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr1: value1", SymbolKind.Constant, r(1, 6, 1, 20), r(1, 6, 1, 20),
+												null, //
+												Arrays.asList()))), //
+						ds("baz: @attr2: baz-value2", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList( //
+										ds("@attr1: baz-value1", SymbolKind.Constant, r(2, 6, 2, 24), r(2, 6, 2, 24),
+												null, //
+												Arrays.asList()))))); //
+
+		// Test with //@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested //@attr1
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("//@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr2InlineAttrAndNestedAttr1);
+
+		DocumentSymbol symbolsWithAllAttr2InlineAttrNoNameAndNestedAttr1 = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr1: value1", SymbolKind.Constant, r(1, 6, 1, 20), r(1, 6, 1, 20),
+												null, //
+												Arrays.asList()))), //
+						ds("baz: baz-value2", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList( //
+										ds("@attr1: baz-value1", SymbolKind.Constant, r(2, 6, 2, 24), r(2, 6, 2, 24),
+												null, //
+												Arrays.asList()))))); //
+
+		// Test with //@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested //@attr1
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr2InlineAttrNoNameAndNestedAttr1);
+
+		DocumentSymbol symbolsWithBarAttr2InlineAttrAndNestedAttr1 = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: @attr2: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr1: value1", SymbolKind.Constant, r(1, 6, 1, 20), r(1, 6, 1, 20),
+												null, //
+												Arrays.asList()))), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, Arrays.asList())));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested //bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("//bar/@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrAndNestedAttr1);
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested /foo/bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrAndNestedAttr1);
+
+		DocumentSymbol symbolsWithBarAttr2InlineAttrNoNameAndNestedAttr1 = ds("foo", SymbolKind.Field, r(0, 0, 3, 6), r(0, 0, 3, 6), null, //
+				Arrays.asList( //
+						ds("bar: value2", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList( //
+										ds("@attr1: value1", SymbolKind.Constant, r(1, 6, 1, 20), r(1, 6, 1, 20),
+												null, //
+												Arrays.asList()))), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, Arrays.asList())));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested //bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrNoNameAndNestedAttr1);
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested /foo/bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr2InlineAttrNoNameAndNestedAttr1);
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeMultipleInlineAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"	<bar attr3=\"value3\" attr2=\"value2\">IJKL</bar>\r\n" + //
+				"</foo>";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		XMLSymbolExpressionFilter expressionFilter2 = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter, expressionFilter2 });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		DocumentSymbol symbolsWithAllAttr1AndAttr3Inline = ds("foo", SymbolKind.Field, r(0, 0, 4, 6), r(0, 0, 4, 6), null, //
+				Arrays.asList( //
+						ds("bar: value1", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz: baz-value1", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList()), //
+						ds("bar: @attr3: value3", SymbolKind.Field, r(3, 1, 3, 46), r(3, 1, 3, 46), null, //
+								Arrays.asList()))); //
+
+		// Test with //@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter //@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		expressionFilter.setXpath("//@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithAllAttr1AndAttr3Inline);
+
+		DocumentSymbol symbolsWithBarAttr1AndAttr3Inline = ds("foo", SymbolKind.Field, r(0, 0, 4, 6), r(0, 0, 4, 6), null, //
+				Arrays.asList( //
+						ds("bar: value1", SymbolKind.Field, r(1, 1, 1, 46), r(1, 1, 1, 46), null, //
+								Arrays.asList()), //
+						ds("baz", SymbolKind.Field, r(2, 1, 2, 54), r(2, 1, 2, 54), null, //
+								Arrays.asList()), //
+						ds("bar: @attr3: value3", SymbolKind.Field, r(3, 1, 3, 46), r(3, 1, 3, 46), null, //
+								Arrays.asList()))); //
+
+		// Test with //bar/@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter //bar/@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//bar/@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr1AndAttr3Inline);
+
+		// Test with /foo/bar/@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter /foo/bar/@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testDocumentSymbolsFor(xml, "file:///test/foo.xml", symbolSettings, //
+				symbolsWithBarAttr1AndAttr3Inline);
+	}
+
+
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLSymbolInformationsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLSymbolInformationsTest.java
@@ -362,4 +362,301 @@ public class XMLSymbolInformationsTest {
 				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
 				si("bar", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"));
 	}
+
+	@Test
+	public void symbolsFilterWithNonInlineAttributeShowAttributeName(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		String testURI = "file:///test/foo.xml";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		// Test with //@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr2: value2", SymbolKind.Constant, l(testURI, r(1, 21, 1, 35)), "bar"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("@attr2: baz-value2", SymbolKind.Constant, l(testURI, r(2, 25, 2, 43)), "baz"));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		// when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr2: value2", SymbolKind.Constant, l(testURI, r(1, 21, 1, 35)), "bar"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false
+		// verify showAttributeName has no effect for non-inline (nested) attributes
+		// when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr2: value2", SymbolKind.Constant, l(testURI, r(1, 21, 1, 35)), "bar"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeNoNestedAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		String testURI = "file:///test/foo.xml";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		// Test with //@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz: @attr2: baz-value2", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with //@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz: baz-value2", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeWithNestedAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"</foo>";
+		String testURI = "file:///test/foo.xml";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		XMLSymbolExpressionFilter expressionFilter2 = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter, expressionFilter2 });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		// Test with //@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested //@attr1
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("//@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: @attr2: value2"), //
+				si("baz: @attr2: baz-value2", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("@attr1: baz-value1", SymbolKind.Constant, l(testURI, r(2, 6, 2, 24)), "baz: @attr2: baz-value2"));
+
+		// Test with //@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested //@attr1
+		expressionFilter.setXpath("//@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: value2"), //
+				si("baz: baz-value2", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("@attr1: baz-value1", SymbolKind.Constant, l(testURI, r(2, 6, 2, 24)), "baz: baz-value2"));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested //bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("//bar/@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: @attr2: value2"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=true, inlineAttribute=true
+		// Test with nested /foo/bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(true);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: @attr2: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: @attr2: value2"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with //bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested //bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: value2"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+
+		// Test with /foo/bar/@attr2
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with nested /foo/bar/@attr1
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr2");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr1");
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 3, 6)), ""), //
+				si("bar: value2", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("@attr1: value1", SymbolKind.Constant, l(testURI, r(1, 6, 1, 20)), "bar: value2"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"));
+	}
+
+	@Test
+	public void symbolsFilterWithInlineAttributeMultipleInlineAttributes(){
+		String xml = "<foo>\r\n" + //
+				"	<bar attr1=\"value1\" attr2=\"value2\">ABCD</bar>\r\n" + //
+				"	<baz attr1=\"baz-value1\" attr2=\"baz-value2\">EFGH</baz>\r\n" + //
+				"	<bar attr3=\"value3\" attr2=\"value2\">IJKL</bar>\r\n" + //
+				"</foo>";
+		String testURI = "file:///test/foo.xml";
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		XMLSymbolFilter filter = new XMLSymbolFilter();
+		filter.setPattern("foo.xml");
+		XMLSymbolExpressionFilter expressionFilter = new XMLSymbolExpressionFilter();
+		XMLSymbolExpressionFilter expressionFilter2 = new XMLSymbolExpressionFilter();
+		filter.setExpressions(new XMLSymbolExpressionFilter[] { expressionFilter, expressionFilter2 });
+		symbolSettings.setFilters(new XMLSymbolFilter[] { filter });
+
+		// Test with //@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter //@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		expressionFilter.setXpath("//@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 4, 6)), ""), //
+				si("bar: value1", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz: baz-value1", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("bar: @attr3: value3", SymbolKind.Field, l(testURI, r(3, 1, 3, 46)), "foo"));
+
+		// Test with //bar/@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter //bar/@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("//bar/@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("//bar/@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 4, 6)), ""), //
+				si("bar: value1", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("bar: @attr3: value3", SymbolKind.Field, l(testURI, r(3, 1, 3, 46)), "foo"));
+
+		// Test with /foo/bar/@attr1
+		// and showAttributeName=false, inlineAttribute=true
+		// Test with second inline filter /foo/bar/@attr3
+		// and showAttributeName=true, inlineAttribute=true
+		// verify when specific elements are targeted
+		expressionFilter.setXpath("/foo/bar/@attr1");
+		expressionFilter.setInlineAttribute(true);
+		expressionFilter.setShowAttributeName(false);
+		expressionFilter2.setXpath("/foo/bar/@attr3");
+		expressionFilter2.setInlineAttribute(true);
+		expressionFilter2.setShowAttributeName(true);
+		testSymbolInformationsFor(xml, testURI, symbolSettings, //
+				si("foo", SymbolKind.Field, l(testURI, r(0, 0, 4, 6)), ""), //
+				si("bar: value1", SymbolKind.Field, l(testURI, r(1, 1, 1, 46)), "foo"), //
+				si("baz", SymbolKind.Field, l(testURI, r(2, 1, 2, 54)), "foo"), //
+				si("bar: @attr3: value3", SymbolKind.Field, l(testURI, r(3, 1, 3, 46)), "foo"));
+	}
 }


### PR DESCRIPTION
proposed server side fix for:
redhat-developer/vscode-xml#633

related client side documentation update:
redhat-developer/vscode-xml#636

Creating this as a draft PR to get early feedback on this approach.
If the change looks like a good approach, automated tests
and documentation updates will follow in a separate commit

@angelozerr Can you take a look and let me know what you think please?

Here's a screenshot of the changes in the outline using the below json setting:
![newOutline](https://user-images.githubusercontent.com/6892694/149420922-710e9139-2b44-4762-bb0c-1115f7ddc652.PNG)

```json
        "pattern": "build*.xml",
            "expressions" :[
                {
                    // keep the value of the attribute "file" on the same line
                    // as the "import" element, and only show the attribute value
                    "xpath": "//import/@file"
                },
                {
                    // keep the value of the attribute "name" on the same line
                    // as the "target" element, and only show the attribute value
                    "xpath": "//target/@name",
                    "primaryElementAttr" : true,
                    "valueOnly": true
                },
                // show "unless" and "depends" as nested attributes for
                // "target" elements
                {
                "xpath": "//target/@unless"
                },
                {
                "xpath": "//target/@depends"
                },
                {
                    // keep the value of the attribute "name" on the same line
                    // as the "property" element, and only show the attribute value
                    "xpath": "//property/@name",
                    "primaryElementAttr" : true,
                    "valueOnly": true
                },
                {
                    // keep the value of the attribute "file" on the same line
                    // as the "property" element, and show the attribute name
                    // along with the value to distinguish it from the more common
                    // "name" attribute
                    "xpath": "//property/@file",
                    "primaryElementAttr" : true,
                    "valueOnly": false
                }
```