### PR TITLE
Updated Xerces to 2.12.2

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -223,7 +223,7 @@
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
-			<version>2.12.1</version>
+			<version>2.12.2</version>
 		</dependency>
 		<dependency>
 			<groupId>xml-apis</groupId>


### PR DESCRIPTION
Updated Xerces to 2.12.2 due to <2.12.1 vulnerability: https://www.eclipse.org/lists/cross-project-issues-dev/msg18920.html

Signed-off-by: Alexander Chen <alchen@redhat.com>