### PR TITLE
Updated GraalVM version to 22.0.0.2

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -4,7 +4,8 @@
     build-binary-unix:
       runs-on: ${{ matrix.os }}
       env:
-        GRAALVM_VERSION: 20.3.0.java8
+        GRAALVM_VERSION: 22.0.0.2
+        GRAALVM_JAVA: java17
       strategy:
         fail-fast: true
         matrix:
@@ -35,10 +36,12 @@
           key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
           restore-keys: |
             ${{ runner.os }}-graalvm-
-      - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+      - uses: DeLaGuardo/setup-graalvm@5.0
         with:
-          graalvm-version: ${{env.GRAALVM_VERSION}}
-      - run: ./mvnw package -Dnative -DskipTests $([ $(uname -s) = Linux ] && echo "-Dgraalvm.static=--static") -Dcbi.jarsigner.skip=true
+          graalvm: ${{env.GRAALVM_VERSION}}
+          java: ${{env.GRAALVM_JAVA}}
+      - run: ./mvnw -B package -Dnative -DskipTests $([ $(uname -s) = Linux ] && echo "-Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC") -Dcbi.jarsigner.skip=true
+      - run: rm org.eclipse.lemminx/target/*.build_artifacts.txt
       - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-$(git rev-parse --short "$GITHUB_SHA")-${{ matrix.label }}
       - uses: actions/upload-artifact@v2
         with:
@@ -48,7 +51,8 @@
     build-binary-windows:
       runs-on: windows-latest
       env:
-        GRAALVM_VERSION: 20.3.0.java11
+        GRAALVM_VERSION: 22.0.0.2
+        GRAALVM_JAVA: java17
       steps:
       - uses: actions/checkout@v2
       - name: Cache Maven dependencies
@@ -69,12 +73,12 @@
           key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
           restore-keys: |
             ${{ runner.os }}-graalvm-
-      - uses: ilammy/msvc-dev-cmd@v1.4.1
-      - uses: DeLaGuardo/setup-graalvm@8bbfe44ef9c6f5c07e5af036a1bffd561c037d18
+      - uses: ilammy/msvc-dev-cmd@v1.10.0
+      - uses: DeLaGuardo/setup-graalvm@5.0
         with:
-          graalvm-version: '${{env.GRAALVM_VERSION}}'
-      - run: Invoke-Expression -Command "$Env:JAVA_HOME/bin/gu install native-image"
-      - run: .\mvnw.cmd package -Dnative -DskipTests "-Dcbi.jarsigner.skip=true"
+          graalvm: ${{env.GRAALVM_VERSION}}
+          java: ${{env.GRAALVM_JAVA}}
+      - run: .\mvnw.cmd -B package -Dnative -DskipTests -D "cbi.jarsigner.skip=true"
       - run: mv org.eclipse.lemminx\target\lemminx-*.exe lemminx-$(git rev-parse --short "$Env:GITHUB_SHA")-win32.exe
       - uses: actions/upload-artifact@v2
         with:

--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -11,7 +11,7 @@
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
-		<graalvm.version>20.3.0</graalvm.version>
+		<native.maven.plugin.version>0.9.10</native.maven.plugin.version>
 		<graalvm.static />
 	</properties>
 	<build>
@@ -152,13 +152,13 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.graalvm.nativeimage</groupId>
-						<artifactId>native-image-maven-plugin</artifactId>
-						<version>${graalvm.version}</version>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>${native.maven.plugin.version}</version>
 						<executions>
 							<execution>
 								<goals>
-									<goal>native-image</goal>
+									<goal>build</goal>
 								</goals>
 								<phase>package</phase>
 							</execution>


### PR DESCRIPTION
Updated GraalVM version used in binary verification builds to 22.0.0.2
- Update native-maven-plugin to 0.9.10
- Use setup-graalvm 5.0 GitHub Action
- Replace deprecated "graalvm-version" with "graalvm" & "java"
- Use msvc-dev-cmd 1.10.0 GitHub Action

Fixes #1158 

Some changes adopted from https://github.com/eclipse/lemminx/pull/1173

Signed-off-by: Alexander Chen <alchen@redhat.com>