### PR TITLE
Update gson to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.2</version>
+				<version>2.8.9</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.lsp4j</groupId>


### PR DESCRIPTION
gson 2.8.2 is flagged as insecure:

![gson 2.8.2 is flagged as insecure](https://user-images.githubusercontent.com/148698/151771083-60e4de92-f9d5-43f7-914f-3d891b794791.png)

 upgrading to recommended 2.8.9

Signed-off-by: Fred Bricon <fbricon@gmail.com>
