### PR TITLE
limit redirects

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -74,7 +74,7 @@
         with:
           graalvm-version: '${{env.GRAALVM_VERSION}}'
       - run: Invoke-Expression -Command "$Env:JAVA_HOME/bin/gu install native-image"
-      - run: .\mvnw.cmd package -Dnative -DskipTests -D cbi.jarsigner.skip=true
+      - run: .\mvnw.cmd package -Dnative -DskipTests "-Dcbi.jarsigner.skip=true"
       - run: mv org.eclipse.lemminx\target\lemminx-*.exe lemminx-$(git rev-parse --short "$Env:GITHUB_SHA")-win32.exe
       - uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.18.5](https://github.com/eclipse/lemminx/milestone/31?closed=1) (February 14, 2022)
+## [0.19.0](https://github.com/eclipse/lemminx/milestone/31?closed=1) (February 14, 2022)
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 
  * Bad SYSTEM for DTD DocType and Entity breaks the XML validation. See [#1169](https://github.com/eclipse/lemminx/issues/1169).
  * Prevent suspicious directory traversal. See [#1171](https://github.com/eclipse/lemminx/pull/1171).
+ * Limit resource downloads to http, https and ftp and prevent insecure redirects. See [#1174](https://github.com/eclipse/lemminx/pull/1174).
 
 ## [0.18.4](https://github.com/eclipse/lemminx/milestone/30?closed=1) (February 01, 2022)
 

--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lemminx</groupId>
 		<artifactId>lemminx-parent</artifactId>
-		<version>0.18.5-SNAPSHOT</version>
+		<version>0.19.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lemminx</artifactId>
 	<properties>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/InvalidURIException.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/InvalidURIException.java
@@ -30,7 +30,11 @@ public class InvalidURIException extends CacheResourceException {
 
 		ILLEGAL_SYNTAX("The ''{0}'' URI cannot be parsed: {1}"),
 		
-		INVALID_PATH("''{0}'' does not resolve to a valid URI.");
+		INVALID_PATH("''{0}'' does not resolve to a valid URI."),
+		
+		UNSUPPORTED_PROTOCOL("Unsupported ''{1}'' protocol in ''{0}''"),
+		
+		INSECURE_REDIRECTION("Redirection from ''{0}'' to insecure ''{1}'' is forbidden");
 
 		private final String rawMessage;
 
@@ -51,9 +55,19 @@ public class InvalidURIException extends CacheResourceException {
 		this.errorCode = errorCode;
 	}
 
-	public InvalidURIException(String resourceURI, InvalidURIError errorCode) {
-		super(resourceURI, errorCode.getMessage(resourceURI));
+	public InvalidURIException(String resourceURI, InvalidURIError errorCode, String... arguments) {
+		super(resourceURI, errorCode.getMessage(combine(resourceURI, arguments)));
 		this.errorCode = errorCode;
+	}
+
+	private static Object[] combine(String resourceURI, String[] arguments) {
+		if (arguments == null || arguments.length == 0) {
+			return new Object[]{resourceURI};
+		}
+		String[] newArr = new String[arguments.length + 1];
+		System.arraycopy(arguments, 0, newArr, 1, arguments.length);
+		newArr[0] = resourceURI;
+		return newArr;
 	}
 
 	public InvalidURIError getErrorCode() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/uriresolver/FileServer.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/uriresolver/FileServer.java
@@ -52,15 +52,26 @@ public class FileServer {
 	 */
 	public FileServer(Path baseDir) throws IOException {
 		Files.createDirectories(baseDir);
-		server = new Server(0);
 		ResourceHandler resourceHandler = new ModifiedResourceHandler();
 		resourceHandler.setResourceBase(baseDir.toUri().toString());
 		resourceHandler.setDirectoriesListed(true);
-		HandlerList handlers = new HandlerList();
-		handlers.setHandlers(new Handler[] { resourceHandler, new DefaultHandler() });
-		server.setHandler(handlers);
+		serve(resourceHandler, new DefaultHandler());
+	}
+	
+	/**
+	 * Creates an http server on a random port, delegating to the given handlers
+	 * @param handlers the Handlers to delegate serving to.
+	 * @throws IOException
+	 */
+	public FileServer(Handler...handlers) throws IOException {
+		serve(handlers);
 	}
 
+	private void serve(Handler...handlers) {
+		server = new Server(0);
+		server.setHandler(new HandlerList(handlers));
+	}
+	
 	/**
 	 * @return the port the server was started on.
 	 * @throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lemminx</groupId>
 	<artifactId>lemminx-parent</artifactId>
-	<version>0.18.5-SNAPSHOT</version>
+	<version>0.19.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse LemMinX</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
- Upversion to 0.19.0-SNAPSHOT
- Fix typo in native-image.yaml
- Limit resource downloads and redirects to http, https and ftp
- update changelog