### PR TITLE
Send (aggregated) server.document.open events at fixed periods.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -15,10 +15,10 @@ When telemetry events are enabled, the following information is emitted when the
     * The server version number
  * Text Document Information
    * When a document is opened :
-      * The file extension (eg. `xml`, `xsd`, `dtd`)
+      * The file extension (eg. `xml`, `xsd`, `dtd`, `rng`)
       * The associated grammar types (eg. `none`, `doctype`, `xml-model`, `xsi:schemaLocation`, `xsi:noNamespaceSchemaLocation`)
       * The grammar identifiers for an XML document (eg. `http://maven.apache.org/xsd/maven-4.0.0.xsd`)
-      * The resolver used to resolve the grammar identifier (eg. `catalog`, `file association`, `embedded catalog.xsd`, `embedded xml.xsd`, `embedded xslt.xsd`)
+      * The resolver used to resolve the grammar identifier (eg. `catalog`, `file association`, `embedded catalog.xsd`, `embedded xml.xsd`, `embedded xslt.xsd`, `relaxng.rng`)
  * Note: Does NOT include the `JAVA_HOME` environment variable for privacy reasons
 
 Currently, the startup event is the only telemetry event that is emitted.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/XMLLanguageServer.java
@@ -238,7 +238,6 @@ public class XMLLanguageServer implements ProcessLanguageServer, XMLLanguageServ
 		if (capabilityManager.getClientCapabilities().shouldLanguageServerExitOnShutdown()) {
 			delayer.schedule(() -> exit(0), 1, TimeUnit.SECONDS);
 		}
-		getTelemetryManager().shutdown();
 		return computeAsync(cc -> new Object());
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryCache.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryCache.java
@@ -29,4 +29,12 @@ public class TelemetryCache {
 		return cache;
 	}
 
+	public boolean isEmpty () {
+		return cache.isEmpty();
+	}
+
+	public void clear () {
+		cache.clear();
+	}
+
 }


### PR DESCRIPTION
- Use an executor with fixed period (1 day) to send server.document.open
  events (if any) to the client

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>