### PR TITLE
Fix code action title by adding closing quotation mark

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/cvc_elt_1_aCodeAction.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/cvc_elt_1_aCodeAction.java
@@ -91,7 +91,7 @@ public class cvc_elt_1_aCodeAction implements ICodeActionParticipant {
 
 			for (String expectedElementText : expectedElements) {
 				CodeAction addReplaceRootElement = CodeActionFactory.replaceAt(
-						"Replace '" + unexpectedElementText + "' with '" + expectedElementText, expectedElementText,
+						"Replace '" + unexpectedElementText + "' with '" + expectedElementText + "'", expectedElementText,
 						document.getTextDocument(), diagnostic, ranges);
 
 				codeActions.add(addReplaceRootElement);


### PR DESCRIPTION

![issue1148](https://user-images.githubusercontent.com/73968480/173694412-d8c8f23d-0687-4ad8-8683-725f59194e94.gif)

https://github.com/eclipse/lemminx/pull/1225 Already fixes this issue, but I realized I was missing a closing quotation mark in the code action title. 

Fixes #1148

Signed-off-by: Jessica He <jhe@redhat.com>