### PR TITLE
Add test for TreeLineTracker.getLineInformation

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -153,6 +154,18 @@ public class TextDocumentTest {
 		int offset = document.offsetAt(position);
 		assertEquals(0, offset);
 
+	}
+
+	@Test
+	public void testGetLineInformation() throws BadLocationException {
+		Assertions.assertThrows(BadLocationException.class,
+				() -> {
+					TextDocument document = new TextDocument("", "");
+					document.setIncremental(true);
+					Position position = document.positionAt(0);
+					position = new Position(-1, 0);
+					int offset = document.offsetAt(position);
+				});
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java
@@ -14,9 +14,9 @@ package org.eclipse.lemminx.commons;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.lsp4j.Position;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -158,14 +158,12 @@ public class TextDocumentTest {
 
 	@Test
 	public void testGetLineInformation() throws BadLocationException {
-		Assertions.assertThrows(BadLocationException.class,
-				() -> {
-					TextDocument document = new TextDocument("", "");
-					document.setIncremental(true);
-					Position position = document.positionAt(0);
-					position = new Position(-1, 0);
-					int offset = document.offsetAt(position);
-				});
+		assertThrows(BadLocationException.class, () -> {
+			TextDocument document = new TextDocument("", "");
+			document.setIncremental(true);
+			Position position = new Position(-1, 0);
+			document.offsetAt(position);
+		});
 	}
 
 	@Test


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `org.eclipse.lemminx.commons.BadLocationException` is thrown when the parameter `line` of `Position.<init>` is set to `-1`.
This tests the method [`TreeLineTracker.getLineInformation`](https://github.com/eclipse/lemminx/blob/9e879e3de0c363e12651f3aa0cdc82a050d79143/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/commons/TreeLineTracker.java#L1281).
This test is based on the test [`testEmptyDocumentInc`](https://github.com/eclipse/lemminx/blob/9e879e3de0c363e12651f3aa0cdc82a050d79143/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/commons/TextDocumentTest.java#L144).

Curious to hear what you think!

Also, is the description I provided of the test is helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))