### PR TITLE
Fix CI badge, add some more badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 XML Language Server (LemMinX)
 ===========================
-[![Build Status](https://ci.eclipse.org/lemminx/buildStatus/icon?job=lemminx%2Fmaster)](https://ci.eclipse.org/lemminx/job/lemminx/job/master/)
+[![Maven](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo.eclipse.org%2Fcontent%2Frepositories%2Flemminx-releases%2Forg%2Feclipse%2Flemminx%2Forg.eclipse.lemminx%2Fmaven-metadata.xml&style=for-the-badge&logo=apachemaven&logoColor=white&color=informational)](https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/)
+[![Eclipse Site](https://img.shields.io/badge/Eclipse%20Site-lemminx-informational?logo=eclipse&style=for-the-badge)](https://download.eclipse.org/lemminx/releases/)
+[![Build Status](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Flemminx%2Fjob%2Flemminx%2Fjob%2Fmain%2F&style=for-the-badge&logo=jenkins&logoColor=white)](https://ci.eclipse.org/lemminx/job/lemminx/job/main/)
+[![CodeQL Status](https://img.shields.io/github/workflow/status/eclipse/lemminx/CodeQL/main?style=for-the-badge&label=codeql&logo=githubactions&logoColor=white)](https://github.com/eclipse/lemminx/actions/workflows/codeql-analysis.yml?query=branch%3Amain)
+[![LICENSE](https://img.shields.io/github/license/eclipse/lemminx?style=for-the-badge&color=informational)](https://github.com/eclipse/lemminx/blob/main/LICENSE)
 
 **LemMinX** is a XML language specific implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
 and can be used with any editor that supports the protocol, to offer good support for the **XML Language**. The server is based on:


### PR DESCRIPTION
The CI badge is broken, since it still points at the branch `master` instead of `main`. I fixed the badge, and took this as an opportunity to redo the badge using shields.io. I also added a few more badges.

Signed-off-by: David Thompson <davthomp@redhat.com>
