### PR TITLE
Set xml.format.xsiSchemaLocationSplit to onPair by default

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/settings/XSISchemaLocationSplit.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsi/settings/XSISchemaLocationSplit.java
@@ -40,6 +40,6 @@ public enum XSISchemaLocationSplit {
 				// Do nothing
 			}
 		}
-		return XSISchemaLocationSplit.none;
+		return XSISchemaLocationSplit.onPair;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLFormattingOptions.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.lemminx.dom.DOMElement;
+import org.eclipse.lemminx.extensions.xsi.settings.XSISchemaLocationSplit;
 import org.eclipse.lemminx.services.format.FormatElementCategory;
 import org.eclipse.lsp4j.FormattingOptions;
 
@@ -40,6 +41,8 @@ public class XMLFormattingOptions extends org.eclipse.lemminx.settings.LSPFormat
 	public static final boolean DEFAULT_TRIM_TRAILING_SPACES = false;
 
 	public static final int DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE = 2;
+
+	public static final String DEFAULT_XSI_SCHEMA_LOCATION_SPLIT = XSISchemaLocationSplit.onPair.name();
 
 	public static final boolean DEFAULT_CLOSING_BRACKET_NEW_LINE = false;
 
@@ -160,6 +163,7 @@ public class XMLFormattingOptions extends org.eclipse.lemminx.settings.LSPFormat
 		this.setPreservedNewlines(DEFAULT_PRESERVER_NEW_LINES);
 		this.setEmptyElement(EmptyElements.ignore);
 		this.setSplitAttributesIndentSize(DEFAULT_SPLIT_ATTRIBUTES_INDENT_SIZE);
+		this.setXsiSchemaLocationSplit(DEFAULT_XSI_SCHEMA_LOCATION_SPLIT);
 		this.setClosingBracketNewLine(DEFAULT_CLOSING_BRACKET_NEW_LINE);
 		this.setPreserveAttributeLineBreaks(DEFAULT_PRESERVE_ATTR_LINE_BREAKS);
 		this.setPreserveSpace(DEFAULT_PRESERVE_SPACE);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterExperimentalTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterExperimentalTest.java
@@ -31,6 +31,7 @@ public class XSIFormatterExperimentalTest {
 	public void xsiSchemaLocationSplitNone() throws BadLocationException {
 		// Default
 		SharedSettings settings = createSettings();
+		XSISchemaLocationSplit.setSplit(XSISchemaLocationSplit.none, settings.getFormattingSettings());
 		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" " + //
 				"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterTest.java
@@ -29,6 +29,7 @@ public class XSIFormatterTest {
 	public void xsiSchemaLocationSplitNone() throws BadLocationException {
 		// Default
 		SharedSettings settings = createSettings();
+		XSISchemaLocationSplit.setSplit(XSISchemaLocationSplit.none, settings.getFormattingSettings());
 		String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans\r\n" + //
 				"    xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/XMLFormatterTest.java
@@ -1128,8 +1128,8 @@ public class XMLFormatterTest {
 		String expected = "<web-app\n" + //
 				"    xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\"\n" + //
 				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
-				"    xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee \n" + //
-				"                http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\"\n" + //
+				"    xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\"\n"
+				+ //
 				"    version=\"3.1\">\n" + //
 				"  <servlet>\n" + //
 				"    <servlet-name>sssi</servlet-name>\n" + //
@@ -2931,9 +2931,9 @@ public class XMLFormatterTest {
 		settings.getFormattingSettings().setClosingBracketNewLine(true);
 		String content = "<a b='' c=''/>";
 		String expected = "<a" + lineSeparator() +
-		"b=''" + lineSeparator() +
-		"c=''"  + lineSeparator() +
-		"/>";
+				"b=''" + lineSeparator() +
+				"c=''" + lineSeparator() +
+				"/>";
 		assertFormat(content, expected, settings);
 	}
 
@@ -2945,9 +2945,9 @@ public class XMLFormatterTest {
 		settings.getFormattingSettings().setPreserveAttributeLineBreaks(true);
 		String content = "<a b='b' c='c'/>";
 		String expected = "<a" + System.lineSeparator() + //
-		"    b='b'" + System.lineSeparator() + //
-		"    c='c'" + System.lineSeparator() + //
-		"    />";
+				"    b='b'" + System.lineSeparator() + //
+				"    c='c'" + System.lineSeparator() + //
+				"    />";
 		assertFormat(content, expected, settings);
 	}
 
@@ -2980,14 +2980,14 @@ public class XMLFormatterTest {
 		settings.getFormattingSettings().setPreserveEmptyContent(true);
 		settings.getFormattingSettings().setClosingBracketNewLine(true);
 		String content = "<a>" + lineSeparator() +
-		"<b c='' d=''></b>" + lineSeparator() +
-		"</a>";
+				"<b c='' d=''></b>" + lineSeparator() +
+				"</a>";
 		String expected = "<a>" + lineSeparator() +
-		"  <b" + lineSeparator() +
-		"  c=''" + lineSeparator() +
-		"  d=''" + lineSeparator() +
-		"  ></b>" + lineSeparator() +
-		"</a>";
+				"  <b" + lineSeparator() +
+				"  c=''" + lineSeparator() +
+				"  d=''" + lineSeparator() +
+				"  ></b>" + lineSeparator() +
+				"</a>";
 		assertFormat(content, expected, settings);
 	}
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterSplitAttributesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterSplitAttributesTest.java
@@ -200,8 +200,8 @@ public class XMLFormatterSplitAttributesTest {
 		String expected = "<web-app\n" + //
 				"    xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\"\n" + //
 				"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
-				"    xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee \n" + //
-				"                http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\"\n" + //
+				"    xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\"\n"
+				+ //
 				"    version=\"3.1\">\n" + //
 				"  <servlet>\n" + //
 				"    <servlet-name>sssi</servlet-name>\n" + //
@@ -211,6 +211,7 @@ public class XMLFormatterSplitAttributesTest {
 				te(0, 8, 1, 9, "\n    "), //
 				te(1, 51, 2, 9, "\n    "), //
 				te(2, 62, 3, 9, "\n    "), //
+				te(3, 63, 4, 16, " "), //
 				te(4, 67, 5, 9, "\n    "), //
 				te(5, 23, 6, 9, "\n  "), //
 				te(6, 18, 7, 13, "\n    "), //


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/749

Signed-off-by: Jessica He <jhe@redhat.com>