### PR TITLE
Support xml.format.preserveEmptyContent with experimental formatter.

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMElementFormatter.java
@@ -77,10 +77,12 @@ public class DOMElementFormatter {
 			break;
 		case IgnoreSpace:
 			// remove spaces and indent
-			boolean addLineSperator = element.getParentElement() == null && element.getPreviousSibling() == null;
-			int startTagOffset = element.getStartTagOpenOffset();
-			int nbSpaces = replaceLeftSpacesWithIndentation(indentLevel, startTagOffset, !addLineSperator, edits);
-			width = nbSpaces + element.getStartTagCloseOffset() - startTagOffset;
+			if (!isPreserveEmptyContent()) {
+				boolean addLineSperator = element.getParentElement() == null && element.getPreviousSibling() == null;
+				int startTagOffset = element.getStartTagOpenOffset();
+				int nbSpaces = replaceLeftSpacesWithIndentation(indentLevel, startTagOffset, !addLineSperator, edits);
+				width = nbSpaces + element.getStartTagCloseOffset() - startTagOffset;
+			}
 		case NormalizeSpace:
 			break;
 		}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMTextFormatter.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/DOMTextFormatter.java
@@ -74,7 +74,8 @@ public class DOMTextFormatter {
 			}
 		}
 		if (formatElementCategory != FormatElementCategory.PreserveSpace
-				&& formatElementCategory != FormatElementCategory.IgnoreSpace) {
+				&& formatElementCategory != FormatElementCategory.IgnoreSpace
+				&& !isPreserveEmptyContent()) {
 			replaceSpacesWithOneSpace(spaceStart, spaceEnd, edits);
 		}
 	}
@@ -89,5 +90,9 @@ public class DOMTextFormatter {
 
 	private void replaceSpacesWithOneSpace(int spaceStart, int spaceEnd, List<TextEdit> edits) {
 		formatterDocument.replaceSpacesWithOneSpace(spaceStart, spaceEnd, edits);
+	}
+
+	private boolean isPreserveEmptyContent() {
+		return formatterDocument.getSharedSettings().getFormattingSettings().isPreserveEmptyContent();
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentNew.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentNew.java
@@ -664,6 +664,10 @@ public class XMLFormatterDocumentNew {
 		return sharedSettings.getFormattingSettings().isInsertFinalNewline();
 	}
 
+	public boolean isPreserveEmptyContent () {
+		return sharedSettings.getFormattingSettings().isPreserveEmptyContent();
+	}
+
 	SharedSettings getSharedSettings() {
 		return sharedSettings;
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalTest.java
@@ -979,6 +979,23 @@ public class XMLFormatterExperimentalTest {
 		assertFormat(content, expected, settings);
 	}
 
+	@Test
+	public void testPreserveWhitespaceInEmptyContent() throws BadLocationException {
+		SharedSettings settings = new SharedSettings();
+		settings.getFormattingSettings().setPreserveEmptyContent(true);
+		String content = "<a> </a>\r\n" + //
+				"<b>  </b>\r\n" + //
+				"\r\n" + //
+				"<c>   </c>\r\n" + //
+				"\r\n" + //
+				"\r\n" + //
+				"<d>    </d>\r\n" + //
+				"\r\n" + //
+				"<e>     </e>";
+		assertFormat(content, content, settings);
+		return;
+	}
+
 	private static void assertFormat(String unformatted, String actual, TextEdit... expectedEdits)
 			throws BadLocationException {
 		assertFormat(unformatted, actual, new SharedSettings(), expectedEdits);


### PR DESCRIPTION
- Fixes #1242
- Add testcase

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>