### PR TITLE
Prevent the unit tests from using `~/.lemminx` or `~/cache`

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/uriresolver/CacheResourcesManager.java
@@ -63,6 +63,17 @@ public class CacheResourcesManager {
 	private static final String CACHE_PATH = "cache";
 	private static final Logger LOGGER = Logger.getLogger(CacheResourcesManager.class.getName());
 
+	private static final Path TEMP_DOWNLOAD_DIR;
+
+	static {
+		Path tempDownloadDir = null;
+		try {
+			tempDownloadDir = Files.createTempDirectory("lemminx-temp");
+		} catch (Exception e) {
+		}
+		TEMP_DOWNLOAD_DIR = tempDownloadDir;
+	}
+
 	private final Map<String, CompletableFuture<Path>> resourcesLoading;
 	private boolean useCache;
 
@@ -222,7 +233,7 @@ public class CacheResourcesManager {
 				}
 
 				// Download resource in a temporary file
-				Path path = Files.createTempFile(resourceCachePath.getFileName().toString(), ".lemminx");
+				Path path = Files.createTempFile(TEMP_DOWNLOAD_DIR, resourceCachePath.getFileName().toString(), ".lemminx");
 				try (ReadableByteChannel rbc = Channels.newChannel(conn.getInputStream());
 						FileOutputStream fos = new FileOutputStream(path.toFile())) {
 					fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
@@ -369,7 +380,7 @@ public class CacheResourcesManager {
 
 	/**
 	 * Returns true if the external resources can be downloaded and false otherwise.
-	 * 
+	 *
 	 * @return true if the external resources can be downloaded and false otherwise.
 	 */
 	public boolean isDownloadExternalResources() {
@@ -378,7 +389,7 @@ public class CacheResourcesManager {
 
 	/**
 	 * Set true if the external resources can be downloaded and false otherwise.
-	 * 
+	 *
 	 * @param downloadExternalResources the external resources
 	 */
 	public void setDownloadExternalResources(boolean downloadExternalResources) {
@@ -463,7 +474,7 @@ public class CacheResourcesManager {
 
 	/**
 	 * Force the given <code>url</code> to download.
-	 * 
+	 *
 	 * @param url the url to download.
 	 */
 	public void forceDownloadExternalResource(String url) {
@@ -473,7 +484,7 @@ public class CacheResourcesManager {
 	/**
 	 * Returns true if the given <code>url</code> can be downloaded and false
 	 * otherwise.
-	 * 
+	 *
 	 * @param url the url to download.
 	 * @return true if the given <code>url</code> can be downloaded and false
 	 *         otherwise.

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDiagnosticsTest.java
@@ -2,10 +2,11 @@ package org.eclipse.lemminx.extensions.catalog;
 
 import static org.eclipse.lemminx.XMLAssert.d;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.junit.jupiter.api.Test;
 
-public class XMLCatalogDiagnosticsTest {
+public class XMLCatalogDiagnosticsTest extends AbstractCacheBasedTest {
 	@Test
 	public void testCatalogWithValidFile() {
 		String xml = "<?xml version=\"1.0\"?>\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogDocumentLinkTest.java
@@ -14,12 +14,13 @@ import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.XMLAssert.testDocumentLinkFor;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the document links in XML catalog files
  */
-public class XMLCatalogDocumentLinkTest {
+public class XMLCatalogDocumentLinkTest extends AbstractCacheBasedTest {
 
 	private static String CATALOG_PATH = "src/test/resources/catalog.xml";
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogExtensionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/catalog/XMLCatalogExtensionTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.catalog;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.d;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * Schema.
  *
  */
-public class XMLCatalogExtensionTest {
+public class XMLCatalogExtensionTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completion() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/AssociateGrammarCodeLensExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/AssociateGrammarCodeLensExtensionsTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.lemminx.client.ClientCommands.OPEN_URI;
 import java.util.Collections;
 import java.util.function.Consumer;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.client.CodeLensKind;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
@@ -31,7 +32,7 @@ import org.junit.jupiter.api.Test;
  * Associate grammar codelens tests
  *
  */
-public class AssociateGrammarCodeLensExtensionsTest {
+public class AssociateGrammarCodeLensExtensionsTest extends AbstractCacheBasedTest {
 
 	// Codelens for Binding
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/BaseFileTempTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/BaseFileTempTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.lemminx.extensions.contentmodel;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -20,39 +19,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
-
-public class BaseFileTempTest {
-
-	private static final Path tempDirPath = Paths.get("target/temp/");
-	protected static final URI tempDirUri = tempDirPath.toAbsolutePath().toUri();
-
-	@BeforeAll
-	public static void setup() throws FileNotFoundException, IOException {
-		deleteTempDirIfExists();
-		createTempDir();
-	}
-
-	@AfterAll
-	public static void tearDown() throws IOException {
-		deleteTempDirIfExists();
-	}
-
-	private static void deleteTempDirIfExists() throws IOException {
-		File tempDir = new File(tempDirUri);
-		if (tempDir.exists()) {
-			MoreFiles.deleteRecursively(tempDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
-		}
-	}
-
-	private static void createTempDir() {
-		File tempDir = new File(tempDirUri);
-		tempDir.mkdir();
-	}
+public abstract class BaseFileTempTest extends AbstractCacheBasedTest {
 
 	protected static void createFile(String fileName, String contents) throws IOException {
 		URI fileURI = new File(fileName).toURI();
@@ -81,8 +50,8 @@ public class BaseFileTempTest {
 		}
 		createFile(fileURI, contents);
 	}
-	
-	protected static Path getTempDirPath() {
-		return tempDirPath;
+
+	protected Path getTempDirPath() {
+		return testWorkDirectory;
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerCacheTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerCacheTest.java
@@ -25,7 +25,7 @@ import com.google.common.io.RecursiveDeleteOption;
 
 /**
  * Content model manager cache test
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -33,8 +33,8 @@ public class ContentModelManagerCacheTest extends BaseFileTempTest {
 
 	@Test
 	public void testXSDCache() throws IOException, BadLocationException {
-		String xsdPath = tempDirUri.getPath() + "/tag.xsd";
-		String xmlPath = tempDirUri.toString() + "/tag.xml";
+		String xsdPath = getTempDirPath().toString() + "/tag.xsd";
+		String xmlPath = getTempDirPath().toString() + "/tag.xml";
 
 		// Create a XSD file in the temp directory
 		String xsd = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
@@ -87,13 +87,13 @@ public class ContentModelManagerCacheTest extends BaseFileTempTest {
 		MoreFiles.deleteRecursively(new File(xsdPath).toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
 		// Completion must be empty
 		XMLAssert.testCompletionFor(xml, null, xmlPath, 4 /* region, endregion, cdata, comment */);
-		
+
 		// recreate the XSD file
 		createFile(xsdPath, xsd);
 		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, label */,
 				c("label", "<label></label>"));
 		XMLAssert.testCompletionFor(xml, null, xmlPath, 5 /* region, endregion, cdata, comment, label */,
 				c("label", "<label></label>"));
-		
+
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerDependsOnGrammarTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ContentModelManagerDependsOnGrammarTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMParser;
@@ -28,11 +29,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with {@link ContentModelManager#dependsOnGrammar(DOMDocument, String)}
- * 
+ *
  * @author Angelo ZERR
  *
  */
-public class ContentModelManagerDependsOnGrammarTest {
+public class ContentModelManagerDependsOnGrammarTest extends AbstractCacheBasedTest {
 
 	private ContentModelManager modelManager;
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.lemminx.XMLAssert.PROCESSING_INSTRUCTION_SNIPPETS;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -28,7 +29,7 @@ import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.junit.jupiter.api.Test;
 
-public class DTDCompletionExtensionsTest {
+public class DTDCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completionInRoot() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionWithCacheExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionWithCacheExtensionsTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with DTD completion and cache.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -45,7 +45,7 @@ public class DTDCompletionWithCacheExtensionsTest extends AbstractCacheBasedTest
 		};
 
 		// Copy the svg.dtd in the cache folder
-		Path expectedLocation = TEST_WORK_DIRECTORY
+		Path expectedLocation = testWorkDirectory
 				.resolve("cache/http/www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd");
 		// Download resource in a temporary file
 		Files.createDirectories(expectedLocation.getParent());

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDiagnosticsTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
@@ -39,7 +40,7 @@ import org.junit.jupiter.api.Test;
  * DTD diagnostics services tests
  *
  */
-public class DTDDiagnosticsTest {
+public class DTDDiagnosticsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void MSG_ELEMENT_NOT_DECLARED() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDoctypeDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDoctypeDiagnosticsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 
 import static org.eclipse.lemminx.XMLAssert.d;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * DTD doctype diagnostics services tests
  *
  */
-public class DTDDoctypeDiagnosticsTest {
+public class DTDDoctypeDiagnosticsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void MSG_ELEMENT_TYPE_REQUIRED_IN_ELEMENTDECL() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDDocumentLinkTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
  * DTD document links tests
  *
  */
-public class DTDDocumentLinkTest {
+public class DTDDocumentLinkTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void docTypeSYSTEM() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDEntityDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDEntityDiagnosticsTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
 import java.util.Locale;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * DTD diagnostics services tests with DTD Entity.
  *
  */
-public class DTDEntityDiagnosticsTest {
+public class DTDEntityDiagnosticsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void EntityDeclUnterminated() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDHoverExtensionsTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -33,7 +34,7 @@ import org.eclipse.lemminx.uriresolver.FileServer;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
-public class DTDHoverExtensionsTest {
+public class DTDHoverExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testTagHover() throws BadLocationException, MalformedURIException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ReferencedGrammarSymbolsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/ReferencedGrammarSymbolsTest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.settings.XMLFileAssociation;
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Referenced grammar symbols test.
  */
-public class ReferencedGrammarSymbolsTest {
+public class ReferencedGrammarSymbolsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void withDoctype() throws BadLocationException, MalformedURIException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLExternalTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLExternalTest.java
@@ -33,13 +33,13 @@ import org.junit.jupiter.api.Test;
 /**
  * This class tests the functionality where an XML file undergoes
  * validation against its schema when the XSD schema file (or DTD file)
- * has been modified and saved externally through means, not within 
+ * has been modified and saved externally through means, not within
  * the LS client.
- * 
+ *
  * @author David Kwon
  *
  */
-public class XMLExternalTest extends BaseFileTempTest  {
+public class XMLExternalTest extends BaseFileTempTest {
 
 	private int threadSleepMs = 600;
 	private MockXMLLanguageServer languageServer;
@@ -51,7 +51,7 @@ public class XMLExternalTest extends BaseFileTempTest  {
 
 	@Test
 	public void externalDTDTest() throws InterruptedException, IOException {
-		String dtdPath = tempDirUri.getPath() + "/note.dtd";
+		String dtdPath = getTempDirPath().toString() + "/note.dtd";
 
 		//@formatter:off
 		String dtdContents =
@@ -60,8 +60,8 @@ public class XMLExternalTest extends BaseFileTempTest  {
 		"<!ELEMENT from (#PCDATA)>\n" +
 		"<!ELEMENT heading (#PCDATA)>\n" +
 		"<!ELEMENT body (#PCDATA)>";
-	
-		String xmlContents = 
+
+		String xmlContents =
 		"<?xml version=\"1.0\"?>\n" +
 		"<!DOCTYPE note SYSTEM \"note.dtd\">\n" +
 		"<note>\n" +
@@ -72,13 +72,13 @@ public class XMLExternalTest extends BaseFileTempTest  {
 		"</note>";
 		//@formatter:on
 
-		
+
 		TextDocumentItem xmlTextDocument = getXMLTextDocumentItem("test.xml", xmlContents);
 		createFile(dtdPath, dtdContents);
 		File testDtd = new File(dtdPath);
 
 		clientOpenFile(languageServer, xmlTextDocument);
-	
+
 		Thread.sleep(threadSleepMs);
 
 		List<PublishDiagnosticsParams> actualDiagnostics = languageServer.getPublishDiagnostics();
@@ -97,7 +97,7 @@ public class XMLExternalTest extends BaseFileTempTest  {
 
 	@Test
 	public void externalXSDTest() throws InterruptedException, IOException {
-		String xsdPath = tempDirUri.getPath() + "/sequence.xsd";
+		String xsdPath = getTempDirPath().toString() + "/sequence.xsd";
 
 		//@formatter:off
 		String xsdContents =
@@ -117,8 +117,8 @@ public class XMLExternalTest extends BaseFileTempTest  {
 		"    </xs:complexType>\n" +
 		"  </xs:element>\n" +
 		"</xs:schema>";
-	
-		String xmlContents = 
+
+		String xmlContents =
 		"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
 		"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"sequence.xsd\">\n" +
 		"  <tag></tag>\n" +
@@ -133,7 +133,7 @@ public class XMLExternalTest extends BaseFileTempTest  {
 		File testXsd = new File(xsdPath);
 
 		clientOpenFile(languageServer, xmlTextDocument);
-	
+
 		Thread.sleep(threadSleepMs);
 
 		List<PublishDiagnosticsParams> actualDiagnostics = languageServer.getPublishDiagnostics();
@@ -152,7 +152,7 @@ public class XMLExternalTest extends BaseFileTempTest  {
 	private TextDocumentItem getXMLTextDocumentItem(String filename, String xmlContents) {
 		String languageId = "xml";
 		int version = 1;
-		return new TextDocumentItem(tempDirUri.toString() + "/" + filename, languageId, version, xmlContents);
+		return new TextDocumentItem(getTempDirPath().toString() + "/" + filename, languageId, version, xmlContents);
 	}
 
 	private void clientOpenFile(XMLLanguageServer languageServer, TextDocumentItem textDocumentItem) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsCompletionTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.te;
 
 import java.util.function.Consumer;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
 /**
  * XML file associations completion tests.
  */
-public class XMLFileAssociationsCompletionTest {
+public class XMLFileAssociationsCompletionTest extends AbstractCacheBasedTest {
 
 	// ------- XML file association with XSD xs:noNamespaceShemaLocation like
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsDiagnosticsTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.function.Consumer;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.XMLAssert.SettingsSaveContext;
 import org.eclipse.lemminx.commons.BadLocationException;
@@ -40,7 +41,7 @@ import com.google.gson.JsonObject;
 /**
  * XML file associations diagnostics tests.
  */
-public class XMLFileAssociationsDiagnosticsTest {
+public class XMLFileAssociationsDiagnosticsTest extends AbstractCacheBasedTest {
 
 	// ------- XML file association with XSD xs:noNamespaceShemaLocation like
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsHoverTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLFileAssociationsHoverTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * XML hover tests with file association.
  *
  */
-public class XMLFileAssociationsHoverTest {
+public class XMLFileAssociationsHoverTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void hoverBasedOnXSDWithFileAssociation() throws BadLocationException, MalformedURIException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelCompletionExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.COMMENT_SNIPPETS;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * XML completion tests based on xml-model processing instruction.
  *
  */
-public class XMLModelCompletionExtensionsTest {
+public class XMLModelCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completionBasedOnDTDWithXMLModel() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelDiagnosticsTest.java
@@ -16,11 +16,11 @@ import static org.eclipse.lemminx.XMLAssert.d;
 import static org.eclipse.lemminx.XMLAssert.te;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
-
 import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * XML Validation test with xml-model processing instruction association.
  *
  */
-public class XMLModelDiagnosticsTest {
+public class XMLModelDiagnosticsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xmlModelWithBadDTD() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelDocumentLinkTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
  * XML Model document links tests
  *
  */
-public class XMLModelDocumentLinkTest {
+public class XMLModelDocumentLinkTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xmlModelHref() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelHoverExtensionsTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XML hover tests with xml-model.
  *
  */
-public class XMLModelHoverExtensionsTest {
+public class XMLModelHoverExtensionsTest extends AbstractCacheBasedTest {
 
 	private static final String HOVER_SEPARATOR = "___";
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLProblemsTest.java
@@ -25,6 +25,7 @@ import static org.eclipse.lemminx.client.ClientCommands.OPEN_BINDING_WIZARD;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.GenerateDocTypeCodeActionResolver;
@@ -53,7 +54,7 @@ import com.google.gson.JsonObject;
  * XML problems like noGrammar.
  *
  */
-public class XMLProblemsTest {
+public class XMLProblemsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noGrammarIgnore() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -540,7 +540,7 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 	@Test
 	public void completionWithXMLSchemaContentChanged() throws Exception {
 		// This https://github.com/eclipse/lemminx/issues/194 for the test scenario
-		String xsdPath = tempDirUri.getPath() + "/resources.xsd";
+		String xsdPath = getTempDirPath().toString() + "/resources.xsd";
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
@@ -46,14 +47,13 @@ import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
 import org.eclipse.lsp4j.ResourceOperationKind;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEditCapabilities;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
  * XML diagnostics services tests
  *
  */
-public class XMLSchemaDiagnosticsTest {
+public class XMLSchemaDiagnosticsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void prematureEOFNoErrorReported() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaDocumentLinkTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.contentmodel;
 import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * XML Schema document links tests
  *
  */
-public class XMLSchemaDocumentLinkTest {
+public class XMLSchemaDocumentLinkTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noNamespaceSchemaLocation() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
@@ -15,11 +15,12 @@ import java.util.Arrays;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
-import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.SchemaDocumentationType;
+import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.HoverCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * XML hover tests with XML Schema.
  *
  */
-public class XMLSchemaHoverDocumentationTypeTest {
+public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest {
 
 	private static final String schemaName = "docAppinfo.xsd";
 	private static final String schemaPath = "src/test/resources/" + schemaName;
@@ -145,12 +146,12 @@ public class XMLSchemaHoverDocumentationTypeTest {
 				"first element documentation" + System.lineSeparator() + System.lineSeparator() +
 				"second element documentation" + System.lineSeparator() + System.lineSeparator() +
 				"third element documentation";
-		
+
 		String appinfo =
 				"first element appinfo" + System.lineSeparator() + System.lineSeparator() +
 				"second element appinfo" + System.lineSeparator() + System.lineSeparator() +
 				"third element appinfo";
-		
+
 		assertElementMultipleBothHover(documentation, SchemaDocumentationType.documentation, true);
 		assertElementMultipleBothHover(appinfo, SchemaDocumentationType.appinfo, true);
 		assertElementMultipleBothHover(
@@ -166,12 +167,12 @@ public class XMLSchemaHoverDocumentationTypeTest {
 				"first element documentation" + System.lineSeparator() +System.lineSeparator() +
 				"second element documentation" + System.lineSeparator() +System.lineSeparator() +
 				"third element documentation";
-		
+
 		String appinfo =
 				"first element appinfo" + System.lineSeparator() +System.lineSeparator() +
 				"second element appinfo" + System.lineSeparator() +System.lineSeparator() +
 				"third element appinfo";
-		
+
 		assertElementMultipleBothHover(documentation, SchemaDocumentationType.documentation, false);
 		assertElementMultipleBothHover(appinfo, SchemaDocumentationType.appinfo, false);
 		assertElementMultipleBothHover(
@@ -207,9 +208,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeNameDocHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	attribu|teNameOnlyDocumentation=\"onlyDocumentation\">\n" +
@@ -219,9 +220,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeValueDocHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	attributeNameOnlyDocumentation=\"o|nlyDocumentation\">\n" +
@@ -231,9 +232,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeNameAppinfoHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	a|ttributeNameOnlyAppinfo=\"onlyAppinfo\">\n" +
@@ -243,9 +244,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeValueAppinfoHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	attributeNameOnlyAppinfo=\"o|nlyAppinfo\">\n" +
@@ -255,9 +256,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeNameBothHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	a|ttributeNameBoth=\"bothDocumentationAndAppinfo\">\n" +
@@ -267,9 +268,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertAttributeValueBothHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	attributeNameBoth=\"b|othDocumentationAndAppinfo\">\n" +
@@ -279,9 +280,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertElementDocHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	<e|lementOnlyDocumentation></elementOnlyDocumentation>\n" +
@@ -291,9 +292,9 @@ public class XMLSchemaHoverDocumentationTypeTest {
 
 	private void assertElementAppinfoHover(String expected, SchemaDocumentationType docSource,
 			boolean markdownSupported) throws BadLocationException {
-		String xml = 
+		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	<e|lementOnlyAppinfo></elementOnlyAppinfo>\n" +
@@ -305,7 +306,7 @@ public class XMLSchemaHoverDocumentationTypeTest {
 			boolean markdownSupported) throws BadLocationException {
 		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	<e|lementBoth></elementBoth>\n" +
@@ -317,7 +318,7 @@ public class XMLSchemaHoverDocumentationTypeTest {
 			boolean markdownSupported) throws BadLocationException {
 		String xml =
 				"<root\n" +
-				"	xmlns=\"http://docAppinfo\"\n" + 
+				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
 				"	<e|lementMultipleBoth></elementMultipleBoth>\n" +
@@ -348,7 +349,7 @@ public class XMLSchemaHoverDocumentationTypeTest {
 	}
 
 	private void assertHover(String xml, String expected, SchemaDocumentationType docSource, boolean markdownSupported) throws BadLocationException {
-		
+
 		if (expected != null) {
 			String currSource = markdownSupported ? source : plainTextSource;
 			StringBuilder content = new StringBuilder(expected);
@@ -378,5 +379,5 @@ public class XMLSchemaHoverDocumentationTypeTest {
 				"/");
 	}
 
-	
+
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtendedComplexTypeTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtendedComplexTypeTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -27,7 +28,7 @@ import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
-public class XMLSchemaHoverExtendedComplexTypeTest {
+public class XMLSchemaHoverExtendedComplexTypeTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testHoverComplexTypeDocumentation() throws BadLocationException, MalformedURIException {
@@ -83,7 +84,7 @@ public class XMLSchemaHoverExtendedComplexTypeTest {
 		return XMLEntityManager.expandSystemId("xsd/" + schemaURI, "src/test/resources/test.xml", true).replace("///",
 				"/");
 	}
-	
+
 	private void assertHover(String xml, String expected, Range range) throws BadLocationException, MalformedURIException {
 		XMLAssert.assertHover(new XMLLanguageService(), xml, null, "src/test/resources/extendedComplexType.xml", expected, range, //
 				createSharedSettings(SchemaDocumentationType.documentation, true));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMDocument;
@@ -37,7 +38,7 @@ import org.junit.jupiter.api.Test;
  * XML hover tests with XML Schema.
  *
  */
-public class XMLSchemaHoverExtensionsTest {
+public class XMLSchemaHoverExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testTagHover() throws BadLocationException, MalformedURIException {
@@ -342,7 +343,7 @@ public class XMLSchemaHoverExtensionsTest {
 						"Source: [attr-enum.xsd](" + schemaURI + ")",
 				r(2, 16, 2, 24));
 	}
-	
+
 	@Test
 	public void hoverWithNullParentNode() throws Exception {
 		ContentModelHoverParticipant hoverParticipant = new ContentModelHoverParticipant();

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.testTypeDefinitionFor;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XSD type definition tests.
  *
  */
-public class XMLSchemaTypeDefinitionExtensionsTest {
+public class XMLSchemaTypeDefinitionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void globalXSElementWithXSChoice() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionWithCacheExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaTypeDefinitionWithCacheExtensionsTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test with XML Schema type definition and cache.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -45,7 +45,7 @@ public class XMLSchemaTypeDefinitionWithCacheExtensionsTest extends AbstractCach
 		};
 
 		// Copy the svg.dtd in the cache folder
-		Path expectedLocation = TEST_WORK_DIRECTORY.resolve("cache/http/maven.apache.org/xsd/maven-4.0.0.xsd");
+		Path expectedLocation = testWorkDirectory.resolve("cache/http/maven.apache.org/xsd/maven-4.0.0.xsd");
 		// Download resource in a temporary file
 		Files.createDirectories(expectedLocation.getParent());
 		Path path = Files.createFile(expectedLocation);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.lemminx.XMLAssert.te;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 import static org.eclipse.lemminx.XMLAssert.testDiagnosticsFor;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -34,7 +35,7 @@ import org.junit.jupiter.api.Test;
  * XML diagnostics services tests
  *
  */
-public class XMLSyntaxDiagnosticsTest {
+public class XMLSyntaxDiagnosticsTest extends AbstractCacheBasedTest {
 
 	/**
 	 * AttributeNotUnique tests

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxRelatedInfoFinderTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSyntaxRelatedInfoFinderTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import java.util.Arrays;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
@@ -26,7 +27,7 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
 import org.junit.jupiter.api.Test;
 
-public class XMLSyntaxRelatedInfoFinderTest {
+public class XMLSyntaxRelatedInfoFinderTest extends AbstractCacheBasedTest {
 
 	final String XML_FILE_PATH = "src/test/resources/test.xml";
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnDTDTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnDTDTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.Test;
  * XML validation based on DTD with external download.
  *
  */
-public class XMLValidationExternalResourcesBasedOnDTDTest {
+public class XMLValidationExternalResourcesBasedOnDTDTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void docTypeDownloadDisabled() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnXSDTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationExternalResourcesBasedOnXSDTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.ExternalResourceErrorCode;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.Test;
  * XML validation based on XSD with external download.
  *
  */
-public class XMLValidationExternalResourcesBasedOnXSDTest {
+public class XMLValidationExternalResourcesBasedOnXSDTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noNamespaceSchemaLocationDownloadDisabled() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationPoolCacheTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLValidationPoolCacheTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test to check the LSP XML Grammar Pool.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -60,7 +60,7 @@ public class XMLValidationPoolCacheTest extends BaseFileTempTest {
 	public void includedSchemaLocation() throws IOException {
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 
-		String schemaAPath = tempDirUri.getPath() + "/SchemaA.xsd";
+		String schemaAPath = getTempDirPath().toString() + "/SchemaA.xsd";
 		String schemaA = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
 				"<xs:schema id=\"tns\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n"
 				+ //
@@ -83,7 +83,7 @@ public class XMLValidationPoolCacheTest extends BaseFileTempTest {
 				"</xs:schema>";
 		createFile(schemaAPath, schemaA);
 
-		String schemaBPath = tempDirUri.getPath() + "/SchemaB.xsd";
+		String schemaBPath = getTempDirPath().toString() + "/SchemaB.xsd";
 		String schemaB = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\r\n" + //
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
 				"\r\n" + //
@@ -208,7 +208,7 @@ public class XMLValidationPoolCacheTest extends BaseFileTempTest {
 	public void dtdELEMENT() throws IOException {
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 
-		String dtdPath = tempDirUri.getPath() + "/note.dtd";
+		String dtdPath = getTempDirPath().toString() + "/note.dtd";
 		String dtd = "<!ELEMENT note (to)>\r\n" + //
 				"<!ELEMENT to (#PCDATA)>\r\n" + //
 				"";
@@ -248,7 +248,7 @@ public class XMLValidationPoolCacheTest extends BaseFileTempTest {
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
 
-		String dtdPath = tempDirUri.getPath() + "/base.dtd";
+		String dtdPath = getTempDirPath().toString() + "/base.dtd";
 		String dtd = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
 				"<!ELEMENT root-element (#PCDATA)>\r\n" + //
 				"<!ENTITY external \"EXTERNALLY DECLARED ENTITY\">"; //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.eclipse.lemminx.extensions.contentmodel.commands.AssociateGrammarCommand.GrammarBindingType;
 import org.eclipse.lemminx.utils.platform.Platform;
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.Test;
  * @author Angelo ZERR
  *
  */
-public class AssociateGrammarCommandTest {
+public class AssociateGrammarCommandTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void associateWithXSDNoNamespaceSchemaLocation() throws InterruptedException, ExecutionException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommandTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.eclipse.lemminx.utils.platform.Platform;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Alexander Chen
  */
-public class CheckBoundGrammarCommandTest {
+public class CheckBoundGrammarCommandTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void checkDocumentWithoutBoundGrammar() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckFilePatternCommandTest.java
@@ -14,13 +14,14 @@ package org.eclipse.lemminx.extensions.contentmodel.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test for checking if a file URI matches a given file pattern using an XML command.
  */
-public class CheckFilePatternCommandTest {
+public class CheckFilePatternCommandTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void checkPatternMatchSucceeds() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/model/FilesChangedTrackerTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/model/FilesChangedTrackerTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link FilesChangedTracker}
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -31,7 +31,7 @@ public class FilesChangedTrackerTest extends BaseFileTempTest {
 	@Test
 	public void trackFile() throws IOException {
 		FilesChangedTracker tracker = new FilesChangedTracker();
-		URI fileURI = tempDirUri.resolve("track.xml");
+		URI fileURI = getTempDirPath().toUri().resolve("track.xml");
 		createFile(fileURI, "<root />");
 		tracker.addFileURI(fileURI);
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeActionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeActionTest.java
@@ -13,14 +13,14 @@ package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nog
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints.NoGrammarConstraintsCodeAction;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.junit.jupiter.api.Test;
 
 /**
  * Generate grammar URI tests.
  *
  */
-public class NoGrammarConstraintsCodeActionTest {
+public class NoGrammarConstraintsCodeActionTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void generateGrammarURI() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDCodeLensExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDCodeLensExtensionsTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.lemminx.XMLAssert.cl;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.client.ClientCommands.SHOW_REFERENCES;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * DTD codelens tests
  *
  */
-public class DTDCodeLensExtensionsTest {
+public class DTDCodeLensExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void codeLensOnDTDElementInDOCTYPE() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDDefinitionExtensionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDDefinitionExtensionTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.dtd;
 import static org.eclipse.lemminx.XMLAssert.ll;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Angelo ZERR
  */
-public class DTDDefinitionExtensionTest {
+public class DTDDefinitionExtensionTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noDefinition() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDDocumentLinkTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDDocumentLinkTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.dtd;
 import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
  * DTD entities document links tests inside a DTD.
  *
  */
-public class DTDDocumentLinkTest {
+public class DTDDocumentLinkTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void entity() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDHighlightingExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDHighlightingExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.testHighlightsFor;
 import static org.eclipse.lsp4j.DocumentHighlightKind.Read;
 import static org.eclipse.lsp4j.DocumentHighlightKind.Write;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Angelo ZERR
  */
-public class DTDHighlightingExtensionsTest {
+public class DTDHighlightingExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noHighlighting() throws BadLocationException {
@@ -36,17 +37,17 @@ public class DTDHighlightingExtensionsTest {
 				"]>";
 		testHighlightsFor(xml);
 	}
-	
+
 	@Test
 	public void noHighlighting2() throws BadLocationException {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //
 				"<!DOCTYPE note [\r\n" + //
-				"	<!ELEMENT note (to,from,heading,body, note?)>\r\n" + 
+				"	<!ELEMENT note (to,from,heading,body, note?)>\r\n" +
 				"	<!ATTLIST note version CD|ATA #REQUIRED>\r\n" + // // <-- in CDATA, no highlight
 				"]>";
 		testHighlightsFor(xml);
 	}
-	
+
 	@Test
 	public void highlightingOnDTDElementName() throws BadLocationException {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDReferenceExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDReferenceExtensionsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.dtd;
 import static org.eclipse.lemminx.XMLAssert.l;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.Location;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * DTD references tests
  *
  */
-public class DTDReferenceExtensionsTest {
+public class DTDReferenceExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void referencesOnDTDElementName() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDValidationExternalResourcesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/dtd/DTDValidationExternalResourcesTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.DTDErrorCode;
@@ -37,7 +38,7 @@ import org.junit.jupiter.api.Test;
  * DTD file diagnostics.
  *
  */
-public class DTDValidationExternalResourcesTest {
+public class DTDValidationExternalResourcesTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void EntityDeclUnterminated() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.XMLAssert.testCompletionFor;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.entities.EntitiesDocumentationUtils.PredefinedEntity;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * Test for entities completion used in a text node.
  *
  */
-public class EntitiesCompletionExtensionsTest {
+public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	// Test for local entities
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesDefinitionExtensionsTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.lemminx.XMLAssert.testDefinitionFor;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * Test for entities definition used in a text node.
  *
  */
-public class EntitiesDefinitionExtensionsTest {
+public class EntitiesDefinitionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void local() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesHoverExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * Test for entities hover used in a text node.
  *
  */
-public class EntitiesHoverExtensionsTest {
+public class EntitiesHoverExtensionsTest extends AbstractCacheBasedTest {
 
 	// Test for local entities
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/general/FilePathCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/general/FilePathCompletionTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 import static org.eclipse.lemminx.utils.platform.Platform.isWindows;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.utils.FilesUtils;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * Test folders are in
  * org.eclipse.lemminx/src/test/resources/filePathCompletion/
  */
-public class FilePathCompletionTest {
+public class FilePathCompletionTest extends AbstractCacheBasedTest {
 
 	private static final String userDir = FilesUtils.encodePath(System.getProperty("user.dir")); // C:..\..\folderName
 																									// || /bin/.../java

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2dtd/XML2DTDGeneratorTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2dtd/XML2DTDGeneratorTest.java
@@ -16,13 +16,14 @@ import static org.eclipse.lemminx.XMLAssert.assertGrammarGenerator;
 
 import java.io.IOException;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for generating DTD from XML source.
  *
  */
-public class XML2DTDGeneratorTest {
+public class XML2DTDGeneratorTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void dtd() throws IOException {
@@ -294,7 +295,7 @@ public class XML2DTDGeneratorTest {
 				"<!ATTLIST item attr2 NMTOKEN #FIXED \"A\">";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);
 	}
-	
+
 	@Test
 	public void attrIDsAndEnums() {
 		String xml = "<root>\r\n" + //
@@ -315,24 +316,24 @@ public class XML2DTDGeneratorTest {
 				"<!ATTLIST item attr2 (A|B) #REQUIRED>";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);
 	}
-	
+
 	@Test
 	public void invalidStartTag() throws IOException {
 		String xml = "<a><</a>";
 		String dtd = "<!ELEMENT a EMPTY>";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);
-		
+
 		xml = "<a>bcd   <   </a>";
 		dtd = "<!ELEMENT a (#PCDATA)>";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);
 	}
-	
+
 	@Test
 	public void invalidEndTag() throws IOException {
 		String xml = "<a></</a>";
 		String dtd = "<!ELEMENT a EMPTY>";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);
-		
+
 		xml = "<a>bcd   </   </a>";
 		dtd = "<!ELEMENT a (#PCDATA)>";
 		assertGrammarGenerator(xml, new DTDGeneratorSettings(), dtd);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2xsd/XML2XMLSchemaGeneratorTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/generators/xml2xsd/XML2XMLSchemaGeneratorTest.java
@@ -16,13 +16,14 @@ import static org.eclipse.lemminx.XMLAssert.assertGrammarGenerator;
 
 import java.io.IOException;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for generating XSD (XML Schema) from XML source.
- * 
+ *
  */
-public class XML2XMLSchemaGeneratorTest {
+public class XML2XMLSchemaGeneratorTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void schema() throws IOException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.xsl.XSLURIResolverExtension;
@@ -32,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * XSL completion tests which test the {@link XSLURIResolverExtension}.
  *
  */
-public class PrologCompletionExtensionsTest {
+public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completionVersionWithV() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCodeLensExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCodeLensExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 import static org.eclipse.lemminx.client.ClientCommands.OPEN_URI;
 import static org.eclipse.lemminx.client.ClientCommands.SHOW_REFERENCES;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XSD codelens tests
  *
  */
-public class XSDCodeLensExtensionsTest {
+public class XSDCodeLensExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void codeLensOnGroupAndElement() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.xsd;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.CompletionItem;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XSD completion tests which test the {@link XDLURIResolverExtension}.
  *
  */
-public class XSDCompletionExtensionsTest {
+public class XSDCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completion() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDefinitionExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import java.nio.file.Paths;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.LocationLink;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Angelo ZERR
  */
-public class XSDDefinitionExtensionsTest {
+public class XSDDefinitionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void noXSDefinition() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDocumentLinkingExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDDocumentLinkingExtensionsTest.java
@@ -12,6 +12,7 @@ package org.eclipse.lemminx.extensions.xsd;
 import static org.eclipse.lemminx.XMLAssert.dl;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
@@ -19,10 +20,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for the document links in .xsd provided by
  * <code>XSDDocumentLinkParticipant</code>
- * 
+ *
  * @see org.eclipse.lemminx.extensions.xsd.participants.XSDDocumentLinkParticipant
  */
-public class XSDDocumentLinkingExtensionsTest {
+public class XSDDocumentLinkingExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xsIncludeUsualNamespace() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDHighlightingExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDHighlightingExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.testHighlightsFor;
 import static org.eclipse.lsp4j.DocumentHighlightKind.Read;
 import static org.eclipse.lsp4j.DocumentHighlightKind.Write;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Angelo ZERR
  */
-public class XSDHighlightingExtensionsTest {
+public class XSDHighlightingExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void highlightingOnElementType() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDReferenceExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDReferenceExtensionsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.xsd;
 import static org.eclipse.lemminx.XMLAssert.l;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.Location;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * XSD references tests
  *
  */
-public class XSDReferenceExtensionsTest {
+public class XSDReferenceExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void referenceOnElementName() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDRenameExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDRenameExtensionsTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -27,12 +28,12 @@ import org.junit.jupiter.api.Test;
  * XSD rename tests.
  *
  */
-public class XSDRenameExtensionsTest {
+public class XSDRenameExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testRenameComplexTypeName() throws BadLocationException {
 
-		String xml = 
+		String xml =
 			"<?xml version=\"1.1\" ?>\r\n" +
 			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
 			"\r\n" +
@@ -45,13 +46,13 @@ public class XSDRenameExtensionsTest {
 			"  </xs:complexType>\r\n" +
 			"</xs:schema>";
 
-		assertRename(xml, "newName", edits("newName", r(4, 24, 34), r(3, 36, 46), r(7, 26, 36))); 
+		assertRename(xml, "newName", edits("newName", r(4, 24, 34), r(3, 36, 46), r(7, 26, 36)));
 	}
 
 	@Test
 	public void testRenameSimpleTypeName() throws BadLocationException {
 
-		String xml = 
+		String xml =
 			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
 			"<xsd:schema elementFormDefault=\"qualified\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://invoice\" xmlns:i=\"http://invoice\">\r\n" +
 			"	<xsd:simpleType name=\"paymentMe|thodType\">\r\n" +
@@ -60,13 +61,13 @@ public class XSDRenameExtensionsTest {
 			"	</xsd:simpleType>\r\n" +
 			"</xsd:schema>";
 
-		assertRename(xml, "newName", edits("newName", r(2, 23, 40))); 
+		assertRename(xml, "newName", edits("newName", r(2, 23, 40)));
 	}
 
 	@Test
 	public void testRenameSimpleTypeNameWithPrefix() throws BadLocationException {
 
-		String xml = 
+		String xml =
 			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
 			"<xsd:schema elementFormDefault=\"qualified\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://invoice\" xmlns:i=\"http://invoice\">\r\n" +
 			"	<xsd:complexType name=\"paymentType\">\r\n" +
@@ -78,7 +79,7 @@ public class XSDRenameExtensionsTest {
 			"	</xsd:simpleType>\r\n" +
 			"</xsd:schema>";
 
-		assertRename(xml, "newName", edits("newName", r(5, 23, 40), r(3, 39, 56))); 
+		assertRename(xml, "newName", edits("newName", r(5, 23, 40), r(3, 39, 56)));
 	}
 
 	private static Range r(int line, int startCharacter, int endCharacter) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExtensionsTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.lemminx.XMLAssert.d;
 import static org.eclipse.lemminx.XMLAssert.te;
 import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.xsd.participants.XSDErrorCode;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
  * XSD diagnostics tests which test the {@link XSDValidator}.
  *
  */
-public class XSDValidationExtensionsTest {
+public class XSDValidationExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void cos_all_limited_2() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExternalResourcesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDValidationExternalResourcesTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.lemminx.XMLAssert.testCodeActionsFor;
 
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lemminx.extensions.contentmodel.participants.ExternalResourceErrorCode;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * XSD file diagnostics.
  *
  */
-public class XSDValidationExternalResourcesTest {
+public class XSDValidationExternalResourcesTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void includeSchemaLocationDownloadDisabled() throws Exception {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.xsi;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.xsl.XSLURIResolverExtension;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * XSL completion tests which test the {@link XSLURIResolverExtension}.
  *
  */
-public class XSICompletionExtensionsTest {
+public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completion() throws BadLocationException {
@@ -37,8 +38,8 @@ public class XSICompletionExtensionsTest {
 		String xml = "<?xml version=\"1.0\"?>\r\n" + //
 				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=|>";
 		testCompletionFor(xml,
-				c("true", te(1, 71, 1, 71, "\"true\""), "\"true\""), 
-				c("false", te(1, 71, 1, 71, "\"false\""), "\"false\"")); 
+				c("true", te(1, 71, 1, 71, "\"true\""), "\"true\""),
+				c("false", te(1, 71, 1, 71, "\"false\""), "\"false\""));
 	}
 
 	@Test
@@ -47,8 +48,8 @@ public class XSICompletionExtensionsTest {
 		String xml = "<?xml version=\"1.0\"?>\r\n" + //
 				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"|\">";
 		testCompletionFor(xml,
-				c("true", te(1, 72, 1, 72, "true"), "true"), 
-				c("false", te(1, 72, 1, 72, "false"), "false")); 
+				c("true", te(1, 72, 1, 72, "true"), "true"),
+				c("false", te(1, 72, 1, 72, "false"), "false"));
 	}
 
 	@Test
@@ -58,8 +59,8 @@ public class XSICompletionExtensionsTest {
 				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" >\r\n" +
 				"  <a xsi:nil=|> </a> ";
 		testCompletionFor(xml,
-				c("true", te(2, 13, 2, 13, "\"true\""), "\"true\""), 
-				c("false", te(2, 13, 2, 13, "\"false\""), "\"false\"")); 
+				c("true", te(2, 13, 2, 13, "\"true\""), "\"true\""),
+				c("false", te(2, 13, 2, 13, "\"false\""), "\"false\""));
 	}
 
 	@Test
@@ -68,7 +69,7 @@ public class XSICompletionExtensionsTest {
 		String xml = "<?xml version=\"1.0\"?>\r\n" + //
 				"<project >\r\n" +
 				"  <a xsi:nil=|> </a> ";
-		testCompletionFor(xml); 
+		testCompletionFor(xml);
 	}
 
 	@Test
@@ -77,10 +78,10 @@ public class XSICompletionExtensionsTest {
 		String xml = "<?xml version=\"1.0\"?>\r\n" + //
 				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" >\r\n" +
 				"  <a xsi:nil=|> </a> ";
-				
+
 		testCompletionFor(xml, singleQuotesSharedSettings(),
-				c("true", te(2, 13, 2, 13, "\'true\'"), "\'true\'"), 
-				c("false", te(2, 13, 2, 13, "\'false\'"), "\'false\'")); 
+				c("true", te(2, 13, 2, 13, "\'true\'"), "\'true\'"),
+				c("false", te(2, 13, 2, 13, "\'false\'"), "\'false\'"));
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterExperimentalTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterExperimentalTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.xsi;
 
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.xsi.settings.XSISchemaLocationSplit;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XSI xsi:schemaLocation formatter tests
  *
  */
-public class XSIFormatterExperimentalTest {
+public class XSIFormatterExperimentalTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xsiSchemaLocationSplitNone() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSIFormatterTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.xsi;
 
 import static org.eclipse.lemminx.XMLAssert.assertFormat;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.xsi.settings.XSISchemaLocationSplit;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * XSI xsi:schemaLocation formatter tests
  *
  */
-public class XSIFormatterTest {
+public class XSIFormatterTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xsiSchemaLocationSplitNone() throws BadLocationException {
@@ -132,7 +133,7 @@ public class XSIFormatterTest {
 				"    xsi:schemaLocation=\"" + //
 				"</beans>";
 		assertFormat(content, content, settings);
-		
+
 		content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans\r\n" + //
 				"    xmlns=\"http://www.springframework.org/schema/beans\"\r\n" + //
@@ -174,7 +175,7 @@ public class XSIFormatterTest {
 				"</beans>";
 		assertFormat(content, expected, settings);
 	}
-	
+
 	private static SharedSettings createSettings() {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setInsertSpaces(true);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLCompletionExtensionsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.extensions.xsl;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lsp4j.CompletionItem;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XSL completion tests which test the {@link XSLURIResolverExtension}.
  *
  */
-public class XSLCompletionExtensionsTest {
+public class XSLCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void completion() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLValidationExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLValidationExtensionsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.extensions.xsl;
 
 import static org.eclipse.lemminx.XMLAssert.d;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSchemaErrorCode;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XSL completion tests which test the {@link XSLURIResolverExtension}.
  *
  */
-public class XSLValidationExtensionsTest {
+public class XSLValidationExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void xslValid() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/junit/CamelCaseDisplayNameGeneratorTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/junit/CamelCaseDisplayNameGeneratorTest.java
@@ -34,10 +34,10 @@ public class CamelCaseDisplayNameGeneratorTest {
     }
 
     @ParameterizedTest(name = "{index} => text={0}")
-    @CsvSource({ "ABCD, ABCD", 
-                 "AbCd, Ab Cd", 
-                 "abCd, ab Cd", 
-                 "aBCd, a BCd", 
+    @CsvSource({ "ABCD, ABCD",
+                 "AbCd, Ab Cd",
+                 "abCd, ab Cd",
+                 "aBCd, a BCd",
                  "a BC d, a BC d" })
     public void splitCamelCase(String text, String expectedResult) {
         assertEquals(expectedResult, nameGenerator.splitCamelCase(text));

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/AggregetedHoverValuesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/AggregetedHoverValuesTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.lemminx.utils.MarkupContentFactory.MARKDOWN_SEPARATOR;
 
 import org.apache.xerces.impl.XMLEntityManager;
 import org.apache.xerces.util.URI.MalformedURIException;
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -31,7 +32,7 @@ import org.junit.jupiter.api.Test;
  * XML aggregated hover values tests
  *
  */
-public class AggregetedHoverValuesTest {
+public class AggregetedHoverValuesTest extends AbstractCacheBasedTest {
 	private static final String TEST_FOR_TAG_HOVER = "test for tag hover";
 	private static final String TEST_FOR_ATTRIBUTENAME_HOVER = "test for attribute name hover";
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/DocumentLifecycleParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/DocumentLifecycleParticipantTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link IDocumentLifecycleParticipant}
  */
-public class DocumentLifecycleParticipantTest {
+public class DocumentLifecycleParticipantTest extends AbstractCacheBasedTest {
 
 	private static class CaptureDocumentLifecycleCalls implements IDocumentLifecycleParticipant {
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
@@ -89,7 +90,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author datho7561
  */
-public class ErrorParticipantLanguageServiceTest {
+public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest {
 
 	/**
 	 * Adds participants that throw runtime exceptions, as well as simple

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDisposeTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDisposeTest.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.services.extensions;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lsp4j.InitializeParams;
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +21,11 @@ import org.junit.jupiter.api.Test;
  * Ensures XML LS extensions are correctly unregistered when
  * {@code XMLExtensionRegistry.dispose()} is called. During extension
  * unregistration, the {@code IXMLExtension.stop()} function is called.
- * 
+ *
  * @author aobuchow
  *
  */
-public class ExtensionRegistryDisposeTest {
+public class ExtensionRegistryDisposeTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testExtensionRegistryDipose() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDoSaveTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ExtensionRegistryDoSaveTest.java
@@ -16,25 +16,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.function.Predicate;
 
-import com.google.gson.JsonObject;
-
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert.SettingsSaveContext;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.extensions.save.ISaveContext;
 import org.eclipse.lsp4j.InitializeParams;
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.JsonObject;
+
 /**
  * Ensures that {@code XMLExtensionsRegistry.doSave()} correctly captures the
  * initial LS configuration, and the configuration is correctly forwarded to
  * {@code IXMLExtension.doSave()} for registered extensions.
  */
-public class ExtensionRegistryDoSaveTest {
-	
+public class ExtensionRegistryDoSaveTest extends AbstractCacheBasedTest {
+
 	class RegistryTestExtension implements IXMLExtension {
-		
+
 		private ISaveContext context = null;
-		
+
 		@Override
 		public void start(InitializeParams params, XMLExtensionsRegistry registry) {
 		}
@@ -42,7 +43,7 @@ public class ExtensionRegistryDoSaveTest {
 		@Override
 		public void stop(XMLExtensionsRegistry registry) {
 		}
-		
+
 		@Override
 		public void doSave(ISaveContext context) {
 			this.context = context;
@@ -52,7 +53,7 @@ public class ExtensionRegistryDoSaveTest {
 			return context;
 		}
 	}
-	
+
 	private static class SaveFileContext implements ISaveContext {
 		@Override
 		public DOMDocument getDocument(String uri) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/HTMLCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/HTMLCompletionExtensionsTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.services.extensions;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.Test;
  * HTML language.
  *
  */
-public class HTMLCompletionExtensionsTest {
+public class HTMLCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testHTMLElementCompletion() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/HTMLHoverExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/HTMLHoverExtensionsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.extensions;
 
 import static org.eclipse.lemminx.XMLAssert.r;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.services.XMLLanguageService;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
  * language.
  *
  */
-public class HTMLHoverExtensionsTest {
+public class HTMLHoverExtensionsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testSingle() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/SymbolsProviderParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/SymbolsProviderParticipantTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.lemminx.XMLAssert.r;
 
 import java.util.Arrays;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.services.DocumentSymbolsResult;
@@ -30,9 +31,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link ISymbolsProviderParticipant} API.
- * 
+ *
  */
-public class SymbolsProviderParticipantTest {
+public class SymbolsProviderParticipantTest extends AbstractCacheBasedTest {
 
 	private static class ExtendedSymbolLanguageService extends XMLLanguageService {
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/WorkspaceServiceParticipantTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/WorkspaceServiceParticipantTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.Collections;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.eclipse.lemminx.XMLLanguageServer;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link IWorkspaceServiceParticipant}
  */
-public class WorkspaceServiceParticipantTest {
+public class WorkspaceServiceParticipantTest extends AbstractCacheBasedTest {
 
 	private static class CaptureWokspaceServiceCalls implements IWorkspaceServiceParticipant {
 
@@ -37,7 +38,7 @@ public class WorkspaceServiceParticipantTest {
 			this.didChangeWorkspaceFolders = params;
 		}
 	}
-	
+
 	private CaptureWokspaceServiceCalls workspaceServiceParticipant;
 	private XMLLanguageServer server;
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/commands/CommandServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/commands/CommandServiceTest.java
@@ -17,17 +17,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Collectors;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageServer;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test the XML Command service
- * 
+ *
  * @author Alex Boyko
  *
  */
-public class CommandServiceTest {
+public class CommandServiceTest extends AbstractCacheBasedTest {
 
 	private final MockXMLLanguageServer languageServer;
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/TextEditUtilsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/TextEditUtilsTest.java
@@ -16,17 +16,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.TextDocument;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link TextEditUtils}.
- * 
+ *
  * @author Angelo ZERR
  *
  */
-public class TextEditUtilsTest {
+public class TextEditUtilsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void textEdit() {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/XMLFormatterTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/XMLFormatterTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lemminx.services.format;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.assertFormat;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.EnforceQuoteStyle;
 import org.eclipse.lemminx.settings.QuoteStyle;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
  * XML formatter services tests
  *
  */
-public class XMLFormatterTest {
+public class XMLFormatterTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void closeStartTagMissing() throws BadLocationException {
@@ -2477,7 +2478,7 @@ public class XMLFormatterTest {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setEmptyElement(EmptyElements.expand);
 		settings.getFormattingSettings().setPreserveAttributeLineBreaks(false);
-		
+
 		String content = "<example att=\"hello\" />";
 		String expected = "<example att=\"hello\"></example>";
 		assertFormat(content, expected, settings);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterEmptyElementsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterEmptyElementsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with empty elements.
  *
  */
-public class XMLFormatterEmptyElementsTest {
+public class XMLFormatterEmptyElementsTest extends AbstractCacheBasedTest {
 
 	// ------------ Tests with format empty elements settings
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalIndentTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalIndentTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with indentation.
  *
  */
-public class XMLFormatterExperimentalIndentTest {
+public class XMLFormatterExperimentalIndentTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void startWithSpaces() throws BadLocationException {
@@ -35,7 +36,7 @@ public class XMLFormatterExperimentalIndentTest {
 				te(0, 0, 1, 7, ""));
 		assertFormat(expected, expected);
 	}
-	
+
 	@Test
 	public void oneElementsInSameLine() throws BadLocationException {
 		String content = "<a></a>";
@@ -138,7 +139,7 @@ public class XMLFormatterExperimentalIndentTest {
 		String expected = content;
 		assertFormat(content, expected);
 	}
-	
+
 	private static void assertFormat(String unformatted, String actual, TextEdit... expectedEdits)
 			throws BadLocationException {
 		assertFormat(unformatted, actual, new SharedSettings(), expectedEdits);

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterExperimentalTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests
  *
  */
-public class XMLFormatterExperimentalTest {
+public class XMLFormatterExperimentalTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void emptyXML() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterForDTDTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterForDTDTest.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.services.format.experimental;
 
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with DTD.
  *
  */
-public class XMLFormatterForDTDTest {
+public class XMLFormatterForDTDTest extends AbstractCacheBasedTest {
 
 	@Disabled
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterInsertFinalNewLineTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterInsertFinalNewLineTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with insert final new lines.
  *
  */
-public class XMLFormatterInsertFinalNewLineTest {
+public class XMLFormatterInsertFinalNewLineTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testTrimFinalNewlinesDefault() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterJoinCommentLinesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterJoinCommentLinesTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with join comment lines setting.
  *
  */
-public class XMLFormatterJoinCommentLinesTest {
+public class XMLFormatterJoinCommentLinesTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testJoinCommentLines() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterMaxLineWithTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterMaxLineWithTest.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.services.format.experimental;
 
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with max line width.
  *
  */
-public class XMLFormatterMaxLineWithTest {
+public class XMLFormatterMaxLineWithTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void splitText() throws BadLocationException {
@@ -46,7 +47,7 @@ public class XMLFormatterMaxLineWithTest {
 				te(0, 8, 0, 9, System.lineSeparator()));
 		assertFormat(expected, expected, 5);
 	}
-	
+
 	@Test
 	public void noSplit() throws BadLocationException {
 		String content = "<a>abcde fghi</a>";

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterMixedContentWithTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterMixedContentWithTest.java
@@ -11,6 +11,7 @@
 *******************************************************************************/
 package org.eclipse.lemminx.services.format.experimental;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with mixed content.
  *
  */
-public class XMLFormatterMixedContentWithTest {
+public class XMLFormatterMixedContentWithTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void mixedContent() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterSplitAttributesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterSplitAttributesTest.java
@@ -14,6 +14,7 @@ package org.eclipse.lemminx.services.format.experimental;
 import static java.lang.System.lineSeparator;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
  * XML experimental formatter services tests with split attributes.
  *
  */
-public class XMLFormatterSplitAttributesTest {
+public class XMLFormatterSplitAttributesTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void splitAttributesIndentSize0() throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/capabilities/XMLCapabilitiesTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/settings/capabilities/XMLCapabilitiesTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.MockXMLLanguageClient;
 import org.eclipse.lemminx.XMLTextDocumentService;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -48,7 +49,7 @@ import org.junit.jupiter.api.Test;
 /**
  * XMLCapabilityManagerTest
  */
-public class XMLCapabilitiesTest {
+public class XMLCapabilitiesTest extends AbstractCacheBasedTest {
 
 	private static final Either<Boolean, ?> TRUE = Either.forLeft(true);
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/FilesUtilsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/utils/FilesUtilsTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.eclipse.lemminx.AbstractCacheBasedTest;
 import org.eclipse.lemminx.utils.platform.Platform;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * FilesUtilsTest
  */
-public class FilesUtilsTest {
+public class FilesUtilsTest extends AbstractCacheBasedTest {
 
 	@Test
 	public void testFilesCachePathPreference() throws Exception {


### PR DESCRIPTION
Closes #1265
