### PR TITLE
Ensure xml.format.emptyElements respects grammar constraints

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMElementDeclaration.java
@@ -119,6 +119,13 @@ public interface CMElementDeclaration {
 	boolean isEmpty();
 
 	/**
+	 * Returns true if the element can have an explicit null value assigned to it.
+	 * 
+	 * @return true if the element can have an explicit null value assigned to it.
+	 */
+	boolean isNillable();
+
+	/**
 	 * Return the enumeration values.
 	 * 
 	 * @return the enumeration values.

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
@@ -129,6 +129,12 @@ public class CMDTDElementDeclaration extends XMLElementDecl implements CMElement
 	}
 
 	@Override
+	public boolean isNillable() {
+		// implement later, return false
+		return false;
+	}
+
+	@Override
 	public Collection<String> getEnumerationValues() {
 		return Collections.emptyList();
 	}
@@ -158,8 +164,8 @@ public class CMDTDElementDeclaration extends XMLElementDecl implements CMElement
 	}
 
 	@Override
-	public boolean isOptional(String childElementName){
-		//implement later, return false
+	public boolean isOptional(String childElementName) {
+		// implement later, return false
 		return false;
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -313,29 +313,29 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 	}
 
 	public boolean isOptional(String childElementName) {
-		if (elementOptionality == null){
+		if (elementOptionality == null) {
 			this.elementOptionality = new HashMap<String, Boolean>();
 			XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 			switch (typeDefinition.getTypeCategory()) {
-				case XSTypeDefinition.SIMPLE_TYPE:
-					break;
-				case XSTypeDefinition.COMPLEX_TYPE:
-					XSParticle particle = ((XSComplexTypeDefinition) typeDefinition).getParticle();
-					if (particle != null) {
-						XSObjectList objectList = ((XSModelGroup) particle.getTerm()).getParticles();
-						for (int i = 0; i < objectList.getLength(); i++) {
-							XSParticle xp = (XSParticle) objectList.item(i);
-							XSTerm t = xp.getTerm();
-							if (t instanceof XSElementDeclaration) {
-								if (xp != null) {
-									elementOptionality.put(t.getName(), xp.getMinOccurs() == 0);
-								}
+			case XSTypeDefinition.SIMPLE_TYPE:
+				break;
+			case XSTypeDefinition.COMPLEX_TYPE:
+				XSParticle particle = ((XSComplexTypeDefinition) typeDefinition).getParticle();
+				if (particle != null) {
+					XSObjectList objectList = ((XSModelGroup) particle.getTerm()).getParticles();
+					for (int i = 0; i < objectList.getLength(); i++) {
+						XSParticle xp = (XSParticle) objectList.item(i);
+						XSTerm t = xp.getTerm();
+						if (t instanceof XSElementDeclaration) {
+							if (xp != null) {
+								elementOptionality.put(t.getName(), xp.getMinOccurs() == 0);
 							}
 						}
 					}
+				}
 			}
 		}
-		Boolean isOptional =  elementOptionality.get(childElementName);
+		Boolean isOptional = elementOptionality.get(childElementName);
 		return (isOptional != null) ? isOptional : false;
 	}
 
@@ -410,13 +410,13 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 			if (((XSComplexTypeDecl) typeDefinition).getDerivationMethod() == XSConstants.DERIVATION_EXTENSION) {
 				XSObjectListImpl allAnnotations = new XSObjectListImpl();
 				XSTypeDefinition baseType = ((XSComplexTypeDecl) typeDefinition).getBaseType();
-				//Get annotations for current type
+				// Get annotations for current type
 				for (Object xsObject : annotation.toArray()) {
 					if (((XSObject) xsObject) != null) {
 						allAnnotations.addXSObject((XSObject) xsObject);
 					}
 				}
-				//Get annotations for base type
+				// Get annotations for base type
 				for (Object xsObject : getElementAnnotations(baseType).toArray()) {
 					if (((XSObject) xsObject) != null) {
 						allAnnotations.addXSObject((XSObject) xsObject);
@@ -465,6 +465,11 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 			return complexTypeDefinition.getContentType() == XSComplexTypeDefinition.CONTENTTYPE_EMPTY;
 		}
 		return false;
+	}
+
+	@Override
+	public boolean isNillable() {
+		return elementDeclaration == null ? false : elementDeclaration.getNillable();
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/format/IFormatterParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/format/IFormatterParticipant.java
@@ -83,4 +83,18 @@ public interface IFormatterParticipant {
 			XMLFormattingConstraints parentConstraints, SharedSettings sharedSettings) {
 		return null;
 	}
+
+	/**
+	 * Returns true if the given element can be collapsed according to grammar
+	 * constraints.
+	 * 
+	 * @param element        the DOM element.
+	 * @param sharedSettings the shared settings.
+	 * 
+	 * @return true if the given element can be collapsed according to grammar
+	 *         constraints.
+	 */
+	default boolean shouldCollapseEmptyElement(DOMElement element, SharedSettings sharedSettings) {
+		return true;
+	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentNew.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/format/XMLFormatterDocumentNew.java
@@ -44,7 +44,7 @@ import org.w3c.dom.Text;
  * update spaces / indent.
  * 
  * @author Angelo ZERR
- *
+ * 
  */
 public class XMLFormatterDocumentNew {
 
@@ -511,10 +511,10 @@ public class XMLFormatterDocumentNew {
 
 	/**
 	 * Returns the format element category of the given DOM element.
-	 * 
+	 *
 	 * @param element           the DOM element.
 	 * @param parentConstraints the parent constraints.
-	 * 
+	 *
 	 * @return the format element category of the given DOM element.
 	 */
 	public FormatElementCategory getFormatElementCategory(DOMElement element,
@@ -580,7 +580,16 @@ public class XMLFormatterDocumentNew {
 		}
 	}
 
-	public String getIndentSpaces(int level, boolean addLineSeparator) {
+	public boolean shouldCollapseEmptyElement(DOMElement element, SharedSettings sharedSettings) {
+		for (IFormatterParticipant participant : formatterParticipants) {
+			if (!participant.shouldCollapseEmptyElement(element, sharedSettings)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private String getIndentSpaces(int level, boolean addLineSeparator) {
 		StringBuilder spaces = new StringBuilder();
 		if (addLineSeparator) {
 			spaces.append(lineDelimiter);
@@ -601,10 +610,10 @@ public class XMLFormatterDocumentNew {
 	/**
 	 * Return the expected indent spaces and new lines with the specified number of
 	 * new lines.
-	 *
+	 * 
 	 * @param level        the indent level.
 	 * @param newLineCount the number of new lines to be added.
-	 *
+	 * 
 	 * @return the expected indent spaces and new lines with the specified number of
 	 *         new lines.
 	 */

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterPreserveAttributeLineBreaksTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/format/experimental/XMLFormatterPreserveAttributeLineBreaksTest.java
@@ -198,6 +198,7 @@ public class XMLFormatterPreserveAttributeLineBreaksTest {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setPreserveAttributeLineBreaks(true);
 		settings.getFormattingSettings().setEmptyElement(EmptyElements.collapse);
+		settings.getFormattingSettings().setGrammarAwareFormatting(false);
 
 		String content = "<a>\n" + //
 				"<b attr=\"value\" attr=\"value\"\n" + //
@@ -221,6 +222,7 @@ public class XMLFormatterPreserveAttributeLineBreaksTest {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setPreserveAttributeLineBreaks(true);
 		settings.getFormattingSettings().setEmptyElement(EmptyElements.collapse);
+		settings.getFormattingSettings().setGrammarAwareFormatting(false);
 
 		String content = "<a>\n" + //
 				"<b attr=\"value\" attr=\"value\"\n" + //
@@ -247,6 +249,7 @@ public class XMLFormatterPreserveAttributeLineBreaksTest {
 		SharedSettings settings = new SharedSettings();
 		settings.getFormattingSettings().setPreserveAttributeLineBreaks(true);
 		settings.getFormattingSettings().setEmptyElement(EmptyElements.collapse);
+		settings.getFormattingSettings().setGrammarAwareFormatting(false);
 
 		String content = "<a>\n" + //
 				"</a>";

--- a/org.eclipse.lemminx/src/test/resources/xsd/isEmpty.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/isEmpty.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="root">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="empty" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/org.eclipse.lemminx/src/test/resources/xsd/nil.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/nil.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="nillable" type="xs:integer" nillable="true" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fixes #492 

Signed-off-by: Jessica He <jhe@redhat.com>