### PR TITLE
Referenced RelaxNG schema not found via XML catalog

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/jing/SchemaProvider.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/jing/SchemaProvider.java
@@ -88,7 +88,7 @@ public class SchemaProvider {
 			throws MalformedURIException, IOException {
 		XMLInputSource source = entityResolver.resolveEntity(description);
 		return source.getByteStream() != null ? new InputSource(source.getByteStream())
-				: new InputSource(description.getExpandedSystemId());
+				: new InputSource(source.getSystemId());
 	}
 
 	private static SchemaReader getSchemaReader(String systemId) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsWithCatalogTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsWithCatalogTest.java
@@ -36,4 +36,16 @@ public class RelaxNGDiagnosticsWithCatalogTest extends AbstractCacheBasedTest {
 				d(0, 1, 4, RelaxNGErrorCode.incomplete_element_required_element_missing));
 	}
 
+	@Test
+	public void unknown_element() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<?xml-model href=\"http://canonical-uri/schema.rng\" type=\"application/xml\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>\r\n"
+				+ //
+				"<test> \r\n" + //
+				"    <valid>I am valid element</valid>\r\n" + //
+				"    <invalid>I am invalid b element</invalid>\r\n" + // <-- element "invalid" not allowed anywhere; expected the element end-tag or element "valid"
+				"</test>";
+		testDiagnosticsFor(xml, "src/test/resources/relaxng/catalog-relaxng.xml", //
+				d(4, 5, 12, RelaxNGErrorCode.unknown_element));
+	}
 }

--- a/org.eclipse.lemminx/src/test/resources/relaxng/catalog-relaxng.xml
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/catalog-relaxng.xml
@@ -2,5 +2,7 @@
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 
 	<uri name="http://www.tei-c.org/ns/1.0" uri="tei_all.rng" />
+    
+    <rewriteURI uriStartString="http://canonical-uri/" rewritePrefix="./"/>
 
 </catalog>

--- a/org.eclipse.lemminx/src/test/resources/relaxng/schema.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/schema.rng
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" 
+         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" 
+         ns="">
+    <start>
+        <element name="test">
+            <zeroOrMore>
+                <element name="valid">
+                    <text/>
+                </element>
+            </zeroOrMore>
+        </element>
+    </start>
+</grammar>


### PR DESCRIPTION
Referenced RelaxNG schema not found via XML catalog

Fixes https://github.com/redhat-developer/vscode-xml/issues/804

Signed-off-by: azerr <azerr@redhat.com>