### PR TITLE
Adjust selection range for wrap element when empty selection is in start or end tag.

### DIFF
--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCDATACommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCDATACommandTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import static org.eclipse.lemminx.XMLAssert.assertSurroundWith;
+
+import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
+import org.eclipse.lemminx.extensions.contentmodel.commands.SurroundWithCommand.SurroundWithKind;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests with {@link SurroundWithCommand} command with CDATA.
+ *
+ */
+public class SurroundWithCDATACommandTest extends BaseFileTempTest {
+
+	// --------------- Surround with CDATA
+
+	@Test
+	public void surroundInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome te|xt\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<![CDATA[ome te]]>$0xt\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.cdata, true, expected);
+	}
+
+	@Test
+	public void surroundInStartTag() throws Exception {
+		String xml = "<fo|o>\r\n" + //
+				"	som|e text\r\n" + //
+				"</foo>";
+		String expected = "<fo<![CDATA[o>\r\n" + //
+				"	som]]>$0e text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.cdata, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome text\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<![CDATA[$1]]>$0ome text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.cdata, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInStartTag() throws Exception {
+		String xml = "<f|oo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>";
+		String expected = "<![CDATA[$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>]]>$0";
+		assertSurroundWith(xml, SurroundWithKind.cdata, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInEndTag() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</fo|o>";
+		String expected = "<![CDATA[$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>]]>$0";
+		assertSurroundWith(xml, SurroundWithKind.cdata, true, expected);
+	}
+
+}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommentsCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommentsCommandTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.extensions.contentmodel.commands;
+
+import static org.eclipse.lemminx.XMLAssert.assertSurroundWith;
+
+import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
+import org.eclipse.lemminx.extensions.contentmodel.commands.SurroundWithCommand.SurroundWithKind;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests with {@link SurroundWithCommand} command with Comments.
+ *
+ */
+public class SurroundWithCommentsCommandTest extends BaseFileTempTest {
+
+	// --------------- Surround with Comments
+
+	@Test
+	public void surroundInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome te|xt\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<!--ome te-->$0xt\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.comments, true, expected);
+	}
+
+	@Test
+	public void surroundInStartTag() throws Exception {
+		String xml = "<fo|o>\r\n" + //
+				"	som|e text\r\n" + //
+				"</foo>";
+		String expected = "<fo<!--o>\r\n" + //
+				"	som-->$0e text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.comments, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInText() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	s|ome text\r\n" + //
+				"</foo>";
+		String expected = "<foo>\r\n" + //
+				"	s<!--$1-->$0ome text\r\n" + //
+				"</foo>";
+		assertSurroundWith(xml, SurroundWithKind.comments, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInStartTag() throws Exception {
+		String xml = "<f|oo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>";
+		String expected = "<!--$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>-->$0";
+		assertSurroundWith(xml, SurroundWithKind.comments, true, expected);
+	}
+
+	@Test
+	public void surroundEmptySelectionInEndTag() throws Exception {
+		String xml = "<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</fo|o>";
+		String expected = "<!--$1<foo>\r\n" + //
+				"	some text\r\n" + //
+				"</foo>-->$0";
+		assertSurroundWith(xml, SurroundWithKind.comments, true, expected);
+	}
+
+}


### PR DESCRIPTION
Adjust selection range for wrap element when empty selection is in start or end tag.

Signed-off-by: azerr <azerr@redhat.com>