### PR TITLE
Fix surround tag in empty document

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
@@ -35,7 +35,7 @@ import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 /**
  * XML Command "xml.refactor.surround.with" to support surround:
- * 
+ *
  * <ul>
  * <li>Surround with Tags (Wrap)</li>
  * <li>Surround with Comments</li>
@@ -180,6 +180,14 @@ public class SurroundWithCommand extends AbstractDOMDocumentCommandHandler {
 		DOMElement parentElement = node.isElement() ? (DOMElement) node : node.getParentElement();
 		Collection<CMDocument> cmDocuments = parentElement != null ? contentModelManager.findCMDocument(parentElement)
 				: contentModelManager.findCMDocument(node.getOwnerDocument(), null);
+		if (parentElement == null) {
+			return cmDocuments.stream() //
+					.flatMap(cmDocument -> cmDocument.getElements().stream()) //
+					.map(decl -> decl.getName(prefix)) //
+					.distinct() //
+					.sorted() //
+					.collect(Collectors.toList());
+		}
 		for (CMDocument cmDocument : cmDocuments) {
 			CMElementDeclaration elementDeclaration = cmDocument.findCMElement(parentElement);
 			if (elementDeclaration != null) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java
@@ -1811,10 +1811,17 @@ public class XMLAssert {
 		selectionRange.setParent(sr(ranges.subList(1, ranges.size())));
 		return selectionRange;
 	}
-	
+
 	public static void assertSurroundWith(String xml, SurroundWithKind kind, boolean snippetsSupported,
+	String expected) throws BadLocationException, InterruptedException, ExecutionException  {
+		assertSurroundWith(xml, kind, snippetsSupported, (service) -> {}, "src/test/resources/test.xml", expected);
+	}
+
+	public static void assertSurroundWith(String xml, SurroundWithKind kind, boolean snippetsSupported, Consumer<XMLLanguageService> configuration, String uri,
 			String expected) throws BadLocationException, InterruptedException, ExecutionException {
 		MockXMLLanguageServer languageServer = new MockXMLLanguageServer();
+
+		configuration.accept(languageServer.getXMLLanguageService());
 
 		int rangeStart = xml.indexOf('|');
 		int rangeEnd = xml.lastIndexOf('|');
@@ -1830,7 +1837,7 @@ public class XMLAssert {
 		Position endPos = rangeStart == rangeEnd ? startPos : document.positionAt(rangeEnd - 1);
 		Range selection = new Range(startPos, endPos);
 
-		TextDocumentIdentifier xmlIdentifier = languageServer.didOpen("src/test/resources/test.xml", x.toString());
+		TextDocumentIdentifier xmlIdentifier = languageServer.didOpen(uri, x.toString());
 
 		// Execute surround with tags command
 		SurroundWithResponse response = (SurroundWithResponse) languageServer


### PR DESCRIPTION
- Fill in grammar when invoking surround tag in an empty document
- Fix NPE that prevented surround tags from working in empty documents that are linked to a grammar with file association

Closes #1395

Signed-off-by: David Thompson <davthomp@redhat.com>
