### PR TITLE
Surround with tags with adjust don't show the allowed elements in completion

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithCommand.java
@@ -140,7 +140,7 @@ public class SurroundWithCommand extends AbstractDOMDocumentCommandHandler {
 				}
 				break;
 			default:
-				List<String> tags = getTags(node, prefix, offset);
+				List<String> tags = getTags(node, prefix, offset, adjusted);
 				String tag = tags.isEmpty() ? "" : tags.get(0);
 
 				// Start tag
@@ -176,8 +176,8 @@ public class SurroundWithCommand extends AbstractDOMDocumentCommandHandler {
 		return new SurroundWithResponse(start, end);
 	}
 
-	private List<String> getTags(DOMNode node, String prefix, int offset) {
-		DOMElement parentElement = node.isElement() ? (DOMElement) node : node.getParentElement();
+	private List<String> getTags(DOMNode node, String prefix, int offset, boolean adjusted) {
+		DOMElement parentElement = node.isElement() && !adjusted ? (DOMElement) node : node.getParentElement();
 		Collection<CMDocument> cmDocuments = parentElement != null ? contentModelManager.findCMDocument(parentElement)
 				: contentModelManager.findCMDocument(node.getOwnerDocument(), null);
 		if (parentElement == null) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithTagsCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/SurroundWithTagsCommandTest.java
@@ -111,7 +111,7 @@ public class SurroundWithTagsCommandTest extends BaseFileTempTest {
 	}
 
 	@Test
-	public void surroundEmptySelectionInStartTag2() throws Exception {
+	public void surroundEmptySelectionInNestedStartTag() throws Exception {
 		String xml = "<foo>\r\n" + //
 				"	<b|ar></bar>\r\n" + //
 				"</foo>";
@@ -133,7 +133,7 @@ public class SurroundWithTagsCommandTest extends BaseFileTempTest {
 	}
 
 	@Test
-	public void surroundEmptySelectionInEndTag2() throws Exception {
+	public void surroundEmptySelectionInNestedEndTag() throws Exception {
 		String xml = "<foo>\r\n" + //
 				"	<bar></b|ar>\r\n" + //
 				"</foo>";
@@ -175,6 +175,51 @@ public class SurroundWithTagsCommandTest extends BaseFileTempTest {
 		assertSurroundWith(xml, SurroundWithKind.tags, true, expected);
 	}
 
+	@Test
+	public void surroundSelectionWithRNG() throws Exception {
+		String xml = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\"\r\n"
+				+ "  datatypeLibrary=\"http://www.w3.org/2001/XMLSchema-datatypes\">\r\n"
+				+ "  \r\n"
+				+ "  <start>\r\n"
+				+ "      |<ref name=\"foo\" />\r\n"
+				+ "      <ref name=\"bar\" />|\r\n"
+				+ "  </start>\r\n"
+				+ "\r\n"
+				+ "</grammar>";
+		String expected = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\"\r\n"
+				+ "  datatypeLibrary=\"http://www.w3.org/2001/XMLSchema-datatypes\">\r\n"
+				+ "  \r\n"
+				+ "  <start>\r\n"
+				+ "      <${1|attribute,choice,data,element,empty,externalRef,grammar,group,interleave,list,mixed,notAllowed,oneOrMore,optional,parentRef,ref,text,value,zeroOrMore|}><ref name=\"foo\" />\r\n"
+				+ "      <ref name=\"bar\" /></${1:attribute}>$0\r\n"
+				+ "  </start>\r\n"
+				+ "\r\n"
+				+ "</grammar>";
+		assertSurroundWith(xml, SurroundWithKind.tags, true, expected);
+	}
+	
+	@Test
+	public void surroundEmptySelectionInStartTagWithRNG() throws Exception {
+		String xml = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\"\r\n"
+				+ "  datatypeLibrary=\"http://www.w3.org/2001/XMLSchema-datatypes\">\r\n"
+				+ "  \r\n"
+				+ "  <start>\r\n"
+				+ "      <re|f name=\"foo\" />\r\n"
+				+ "      <ref name=\"bar\" />\r\n"
+				+ "  </start>\r\n"
+				+ "\r\n"
+				+ "</grammar>";
+		String expected = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\"\r\n"
+				+ "  datatypeLibrary=\"http://www.w3.org/2001/XMLSchema-datatypes\">\r\n"
+				+ "  \r\n"
+				+ "  <start>\r\n"
+				+ "      <${1|attribute,choice,data,element,empty,externalRef,grammar,group,interleave,list,mixed,notAllowed,oneOrMore,optional,parentRef,ref,text,value,zeroOrMore|}><ref name=\"foo\" /></${1:attribute}>$0\r\n"
+				+ "      <ref name=\"bar\" />\r\n"
+				+ "  </start>\r\n"
+				+ "\r\n"
+				+ "</grammar>";
+		assertSurroundWith(xml, SurroundWithKind.tags, true, expected);
+	}
 	private static XMLFileAssociation[] createXSDAssociationsNoNamespaceSchemaLocationLike(String baseSystemId) {
 		XMLFileAssociation resources = new XMLFileAssociation();
 		resources.setPattern("**/*resources*.xml");


### PR DESCRIPTION
Surround with tags with adjust don't show the allowed elements in completion

Signed-off-by: azerr <azerr@redhat.com>

Takes this rng file sample and execute surround with tag in ref start tag element, the generated start/tag is empty although it should show choice, attributes, etc:

```xml
<grammar xmlns="http://relaxng.org/ns/structure/1.0"
  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
  
  <start>
      <re|f name="foo" />
  </start>

</grammar>
```

This PR fixes this problem.