### PR TITLE
Bind to a schema from an empty document

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommand.java
@@ -40,10 +40,10 @@ import org.xml.sax.helpers.DefaultHandler;
 /**
  * XML Command "xml.associate.grammar.insert" to associate a grammar to a given
  * DOM document.
- * 
+ *
  * The command parameters {@link ExecuteCommandParams} must be filled with 3
  * parameters:
- * 
+ *
  * <ul>
  * <li>document URI (String) : the DOM document file URI to bind with a grammar.
  * </li>
@@ -52,7 +52,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * <li>binding type (String) : which can takes values "standard", "xml-model" to
  * know which binding type must be inserted in the DOM document.</li>
  * </ul>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -112,14 +112,14 @@ public class AssociateGrammarCommand extends AbstractDOMDocumentCommandHandler {
 					// Insert inside <foo /> ->
 					// xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance"
 					// xsi:noNamespaceSchemaLocation=\"xsd/tag.xsd\"
-					return NoGrammarConstraintsCodeAction.createXSINoNamespaceSchemaLocationEdit(grammarURI, document);
+					return NoGrammarConstraintsCodeAction.createXSINoNamespaceSchemaLocationEdit(grammarURI, document, sharedSettings);
 				}
 				// Insert inside <foo /> ->
 				// xmlns="team_namespace"
 				// xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 				// xsi:schemaLocation="team_namespace xsd/team.xsd"
 				return NoGrammarConstraintsCodeAction.createXSISchemaLocationEdit(grammarURI, targetNamespace,
-						document);
+						document, sharedSettings);
 			} else {
 				// DTD file
 				// Insert before <foo /> -> <!DOCTYPE foo SYSTEM "dtd/tag.dtd">

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommand.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/commands/CheckBoundGrammarCommand.java
@@ -12,7 +12,6 @@
 package org.eclipse.lemminx.extensions.contentmodel.commands;
 
 import org.eclipse.lemminx.dom.DOMDocument;
-import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.services.IXMLDocumentProvider;
 import org.eclipse.lemminx.services.extensions.commands.AbstractDOMDocumentCommandHandler;
 import org.eclipse.lemminx.settings.SharedSettings;
@@ -42,17 +41,13 @@ public class CheckBoundGrammarCommand extends AbstractDOMDocumentCommandHandler 
 	/**
 	 * Returns true if the given DOM document can be bound with a given grammar and
 	 * false otherwise.
-	 * 
+	 *
 	 * @param document the DOM document.
-	 * 
+	 *
 	 * @return true if the given DOM document can be bound with a given grammar and
 	 *         false otherwise.
 	 */
 	public static boolean canBindWithGrammar(DOMDocument document) {
-		DOMElement documentElement = document.getDocumentElement();
-		if (documentElement == null) {
-			return false;
-		}
 		return !document.hasGrammar();
 	}
 }

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCodeLensParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/ContentModelCodeLensParticipant.java
@@ -146,7 +146,12 @@ public class ContentModelCodeLensParticipant implements ICodeLensParticipant {
 			return;
 		}
 		String documentURI = document.getDocumentURI();
-		Range range = XMLPositionUtility.selectRootStartTag(document);
+		Range range;
+		if (document.getDocumentElement() != null) {
+			range = XMLPositionUtility.selectRootStartTag(document);
+		} else {
+			range = XMLPositionUtility.createRange(0, 0, document);
+		}
 
 		lenses.add(createAssociateLens(documentURI, "Bind to grammar/schema...", range));
 	}

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/GenerateXSINoNamespaceSchemaCodeActionResolver.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/GenerateXSINoNamespaceSchemaCodeActionResolver.java
@@ -22,14 +22,14 @@ import org.eclipse.lsp4j.TextDocumentEdit;
 
 /**
  * Code action resolver participant used to:
- * 
+ *
  * <ul>
  * <li>generate the XSD file for the given DOM document</li>
  * <li>generate the association xsi:noNamespaceSchemaLocation in the XML to bind
  * it with the generated XSD</li>
- * 
+ *
  * </ul>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -42,7 +42,7 @@ public class GenerateXSINoNamespaceSchemaCodeActionResolver
 	@Override
 	protected TextDocumentEdit createFileEdit(String grammarFileName, DOMDocument document,
 			SharedSettings sharedSettings) throws BadLocationException {
-		return createXSINoNamespaceSchemaLocationEdit(grammarFileName, document);
+		return createXSINoNamespaceSchemaLocationEdit(grammarFileName, document, sharedSettings);
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/commands/AssociateGrammarCommandTest.java
@@ -133,7 +133,7 @@ public class AssociateGrammarCommandTest extends AbstractCacheBasedTest {
 
 		assertEquals(actual, tde(xmlPath, 1, //
 				te(1, 0, 1, 0, "<?xml-model href=\"xsd/team.xsd\"?>\r\n"), //
-				te(1, 4, 1, 4, " xmlns=\"team_namespace\" ")));
+				te(1, 4, 1, 4, " xmlns=\"team_namespace\"")));
 	}
 
 	@Test

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeActionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/nogrammarconstraints/NoGrammarConstraintsCodeActionTest.java
@@ -11,9 +11,20 @@
 *******************************************************************************/
 package org.eclipse.lemminx.extensions.contentmodel.participants.codeactions.nogrammarconstraints;
 
+import static org.eclipse.lemminx.XMLAssert.te;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.XMLAssert;
+import org.eclipse.lemminx.commons.BadLocationException;
+import org.eclipse.lemminx.commons.TextDocument;
+import org.eclipse.lemminx.dom.DOMDocument;
+import org.eclipse.lemminx.dom.DOMParser;
+import org.eclipse.lemminx.services.XMLLanguageService;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -21,6 +32,12 @@ import org.junit.jupiter.api.Test;
  *
  */
 public class NoGrammarConstraintsCodeActionTest extends AbstractCacheBasedTest {
+
+	private static final String TEST_DOCUMENT_URI = "file:///test.xml";
+
+	private XMLLanguageService xmlLanguageService = new XMLLanguageService();
+
+	private SharedSettings sharedSettings = new SharedSettings();
 
 	@Test
 	public void generateGrammarURI() {
@@ -32,6 +49,152 @@ public class NoGrammarConstraintsCodeActionTest extends AbstractCacheBasedTest {
 	public void generateGrammarURIWithDot() {
 		String actual = NoGrammarConstraintsCodeAction.getGrammarURI("file:///C:/.project", "xsd");
 		assertEquals("file:///C:/.project.xsd", actual);
+	}
+
+	@Test
+	public void testAssociateWithXmlModelCodeAction() throws BadLocationException {
+		DOMDocument xmlDocument = getDOMDocument("");
+		TextDocumentEdit actual = NoGrammarConstraintsCodeAction.createXmlModelEdit("file:///my-schema.xsd", null,
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0, "<?xml-model href=\"file:///my-schema.xsd\"?>" + System.lineSeparator()),
+						te(0, 0, 0, 0, "<root-element></root-element>")),
+				actual);
+
+		xmlDocument = getDOMDocument("");
+		actual = NoGrammarConstraintsCodeAction.createXmlModelEdit("file:///my-schema.xsd", "https://google.ca",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0, "<?xml-model href=\"file:///my-schema.xsd\"?>" + System.lineSeparator()),
+						te(0, 0, 0, 0, "<root-element xmlns=\"https://google.ca\"></root-element>")),
+				actual);
+
+		xmlDocument = getDOMDocument("<root></root>");
+		actual = NoGrammarConstraintsCodeAction.createXmlModelEdit("file:///my-schema.xsd", "https://google.ca",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0, "<?xml-model href=\"file:///my-schema.xsd\"?>" + System.lineSeparator()),
+						te(0, 5, 0, 5, " xmlns=\"https://google.ca\"")),
+				actual);
+
+		xmlDocument = getDOMDocument("<root hjkl=\"hjkl\"></root>");
+		actual = NoGrammarConstraintsCodeAction.createXmlModelEdit("file:///my-schema.xsd", "https://google.ca",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0, "<?xml-model href=\"file:///my-schema.xsd\"?>" + System.lineSeparator()),
+						te(0, 5, 0, 5, " xmlns=\"https://google.ca\"")),
+				actual);
+
+		xmlDocument = getDOMDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		actual = NoGrammarConstraintsCodeAction.createXmlModelEdit("file:///my-schema.xsd", "https://google.ca",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 38, 0, 38, System.lineSeparator() + "<?xml-model href=\"file:///my-schema.xsd\"?>" + System.lineSeparator()),
+						te(0, 38, 0, 38, System.lineSeparator() + "<root-element xmlns=\"https://google.ca\"></root-element>")),
+				actual);
+	}
+
+	@Test
+	public void testAssociateWithDoctypeCodeAction() throws BadLocationException {
+		DOMDocument xmlDocument = getDOMDocument("");
+		TextDocumentEdit actual = NoGrammarConstraintsCodeAction.createDocTypeEdit("file:///my-schema.dtd", xmlDocument,
+				sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0,
+						"<!DOCTYPE root-element SYSTEM \"file:///my-schema.dtd\">" + System.lineSeparator()
+								+ "<root-element></root-element>")),
+				actual);
+
+		xmlDocument = getDOMDocument("<root></root>");
+		actual = NoGrammarConstraintsCodeAction.createDocTypeEdit("file:///my-schema.dtd", xmlDocument,
+				sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 0, 0, 0, "<!DOCTYPE root SYSTEM \"file:///my-schema.dtd\">" + System.lineSeparator())),
+				actual);
+
+		xmlDocument = getDOMDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		actual = NoGrammarConstraintsCodeAction.createDocTypeEdit("file:///my-schema.dtd", xmlDocument,
+				sharedSettings);
+		assertTextDocumentEdit(
+				tde(te(0, 38, 0, 38,
+						System.lineSeparator() + "<!DOCTYPE root-element SYSTEM \"file:///my-schema.dtd\">"
+								+ System.lineSeparator() + "<root-element></root-element>")),
+				actual);
+	}
+
+	@Test
+	public void testAssociateWithNoNamespaceSchemaLocationCodeAction() throws BadLocationException {
+		DOMDocument xmlDocument = getDOMDocument("");
+		TextDocumentEdit actual = NoGrammarConstraintsCodeAction
+				.createXSINoNamespaceSchemaLocationEdit("file:///my-schema.dtd", xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 0, 0, 0,
+				"<root-element xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + System.lineSeparator()
+						+ " xsi:noNamespaceSchemaLocation=\"file:///my-schema.dtd\"></root-element>")),
+				actual);
+
+		xmlDocument = getDOMDocument("<root></root>");
+		actual = NoGrammarConstraintsCodeAction.createXSINoNamespaceSchemaLocationEdit("file:///my-schema.dtd",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 5, 0, 5,
+				" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + System.lineSeparator()
+						+ " xsi:noNamespaceSchemaLocation=\"file:///my-schema.dtd\"")),
+				actual);
+
+		xmlDocument = getDOMDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		actual = NoGrammarConstraintsCodeAction.createXSINoNamespaceSchemaLocationEdit("file:///my-schema.dtd",
+				xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 38, 0, 38,
+				System.lineSeparator() + "<root-element xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+						+ System.lineSeparator()
+						+ " xsi:noNamespaceSchemaLocation=\"file:///my-schema.dtd\"></root-element>")),
+				actual);
+	}
+
+	@Test
+	public void testAssociateWithSchemaLocationCodeAction() throws BadLocationException {
+		DOMDocument xmlDocument = getDOMDocument("");
+		TextDocumentEdit actual = NoGrammarConstraintsCodeAction.createXSISchemaLocationEdit("file:///my-schema.dtd",
+				"https://google.ca", xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 0, 0, 0,
+				"<root-element xmlns=\"https://google.ca\"" + System.lineSeparator()
+						+ " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + System.lineSeparator()
+						+ " xsi:schemaLocation=\"https://google.ca file:///my-schema.dtd\"></root-element>")),
+				actual);
+
+		xmlDocument = getDOMDocument("<root></root>");
+		actual = NoGrammarConstraintsCodeAction.createXSISchemaLocationEdit("file:///my-schema.dtd",
+				"https://google.ca", xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 5, 0, 5,
+				" xmlns=\"https://google.ca\"" + System.lineSeparator()
+						+ " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + System.lineSeparator()
+						+ " xsi:schemaLocation=\"https://google.ca file:///my-schema.dtd\"")),
+				actual);
+
+		xmlDocument = getDOMDocument("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		actual = NoGrammarConstraintsCodeAction.createXSISchemaLocationEdit("file:///my-schema.dtd",
+				"https://google.ca", xmlDocument, sharedSettings);
+		assertTextDocumentEdit(tde(te(0, 38, 0, 38,
+				System.lineSeparator() + "<root-element xmlns=\"https://google.ca\"" + System.lineSeparator()
+						+ " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + System.lineSeparator()
+						+ " xsi:schemaLocation=\"https://google.ca file:///my-schema.dtd\"></root-element>")),
+				actual);
+	}
+
+	private DOMDocument getDOMDocument(String xml) {
+		TextDocument textDocument = new TextDocument(xml, TEST_DOCUMENT_URI);
+		return DOMParser.getInstance().parse(textDocument, xmlLanguageService.getResolverExtensionManager());
+	}
+
+	private static TextDocumentEdit tde(TextEdit... edits) {
+		return XMLAssert.tde(TEST_DOCUMENT_URI, 0, edits);
+	}
+
+	private static void assertTextDocumentEdit(TextDocumentEdit expected, TextDocumentEdit actual) {
+		Assertions.assertEquals(expected.getTextDocument().getUri(), actual.getTextDocument().getUri());
+		Assertions.assertEquals(expected.getEdits().size(), actual.getEdits().size());
+		for (int i = 0; i < expected.getEdits().size(); i++) {
+			Assertions.assertEquals(expected.getEdits().get(i), actual.getEdits().get(i));
+		}
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGCodeLensExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGCodeLensExtensionsTest.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.extensions.relaxng.grammar.rng;
 
 import static org.eclipse.lemminx.XMLAssert.cl;
 import static org.eclipse.lemminx.XMLAssert.r;
+import static org.eclipse.lemminx.client.ClientCommands.OPEN_BINDING_WIZARD;
 import static org.eclipse.lemminx.client.ClientCommands.OPEN_URI;
 import static org.eclipse.lemminx.client.ClientCommands.SHOW_REFERENCES;
 
@@ -84,13 +85,13 @@ public class RNGCodeLensExtensionsTest extends AbstractCacheBasedTest {
 	@Test
 	public void codeLensEmptyDocument() throws BadLocationException {
 		String xml = "";
-		XMLAssert.testCodeLensFor(xml);
+		XMLAssert.testCodeLensFor(xml, cl(r(0, 0, 0, 0), "Bind to grammar/schema...", OPEN_BINDING_WIZARD));
 	}
 
 	@Test
 	public void codeLensSpace() throws BadLocationException {
 		String xml = " ";
-		XMLAssert.testCodeLensFor(xml);
+		XMLAssert.testCodeLensFor(xml, cl(r(0, 0, 0, 0), "Bind to grammar/schema...", OPEN_BINDING_WIZARD));
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCodeLensExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCodeLensExtensionsTest.java
@@ -13,6 +13,7 @@ package org.eclipse.lemminx.extensions.xsd;
 
 import static org.eclipse.lemminx.XMLAssert.cl;
 import static org.eclipse.lemminx.XMLAssert.r;
+import static org.eclipse.lemminx.client.ClientCommands.OPEN_BINDING_WIZARD;
 import static org.eclipse.lemminx.client.ClientCommands.OPEN_URI;
 import static org.eclipse.lemminx.client.ClientCommands.SHOW_REFERENCES;
 
@@ -84,13 +85,13 @@ public class XSDCodeLensExtensionsTest extends AbstractCacheBasedTest {
 	@Test
 	public void codeLensEmptyDocument() throws BadLocationException {
 		String xml = "";
-		XMLAssert.testCodeLensFor(xml);
+		XMLAssert.testCodeLensFor(xml, cl(r(0, 0, 0, 0), "Bind to grammar/schema...", OPEN_BINDING_WIZARD));
 	}
 
 	@Test
 	public void codeLensSpace() throws BadLocationException {
 		String xml = " ";
-		XMLAssert.testCodeLensFor(xml);
+		XMLAssert.testCodeLensFor(xml, cl(r(0, 0, 0, 0), "Bind to grammar/schema...", OPEN_BINDING_WIZARD));
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
@@ -38,33 +38,25 @@ import static org.eclipse.lemminx.XMLAssert.testTypeDefinitionFor;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.lemminx.AbstractCacheBasedTest;
+import org.eclipse.lemminx.client.ClientCommands;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.dom.DOMAttr;
 import org.eclipse.lemminx.dom.DOMDocument;
-import org.eclipse.lemminx.dom.DOMNode;
 import org.eclipse.lemminx.extensions.contentmodel.participants.XMLSyntaxErrorCode;
 import org.eclipse.lemminx.extensions.contentmodel.settings.ContentModelSettings;
-import org.eclipse.lemminx.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lemminx.services.DocumentSymbolsResult;
 import org.eclipse.lemminx.services.SymbolInformationResult;
 import org.eclipse.lemminx.services.XMLLanguageService;
-import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionParticipant;
-import org.eclipse.lemminx.services.extensions.codeaction.ICodeActionRequest;
-import org.eclipse.lemminx.services.extensions.codelens.ICodeLensParticipant;
-import org.eclipse.lemminx.services.extensions.codelens.ICodeLensRequest;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionParticipant;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionRequest;
 import org.eclipse.lemminx.services.extensions.completion.ICompletionResponse;
-import org.eclipse.lemminx.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lemminx.services.extensions.format.IFormatterParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLSymbolFilter;
 import org.eclipse.lemminx.settings.XMLSymbolSettings;
 import org.eclipse.lemminx.utils.XMLBuilder;
-import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
@@ -76,11 +68,8 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.MarkupContent;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
-import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.jupiter.api.Test;
 
@@ -114,34 +103,18 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 		public ErrorParticipantLanguageService() {
 			super();
 
-			this.registerCodeActionParticipant(new ICodeActionParticipant() {
-				@Override
-				public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions,
-						CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerCodeActionParticipant((request, codeActions, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerCodeActionParticipant(new ICodeActionParticipant() {
-				@Override
-				public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions,
-						CancelChecker cancelChecker) {
-					Diagnostic diagnostic = request.getDiagnostic();
-					codeActions.add(ca(diagnostic, te(0, 0, 0, 0, "a")));
-				}
+			this.registerCodeActionParticipant((request, codeActions, cancelChecker) -> {
+				Diagnostic diagnostic = request.getDiagnostic();
+				codeActions.add(ca(diagnostic, te(0, 0, 0, 0, "a")));
 			});
 
-			this.registerCodeLensParticipant(new ICodeLensParticipant() {
-				@Override
-				public void doCodeLens(ICodeLensRequest request, List<CodeLens> lenses, CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerCodeLensParticipant((request, lenses, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerCodeLensParticipant(new ICodeLensParticipant() {
-				@Override
-				public void doCodeLens(ICodeLensRequest request, List<CodeLens> lenses, CancelChecker cancelChecker) {
-					lenses.add(TEST_CODE_LENS);
-				}
-			});
+			this.registerCodeLensParticipant((request, lenses, cancelChecker) -> lenses.add(TEST_CODE_LENS));
 
 			this.registerCompletionParticipant(new ICompletionParticipant() {
 
@@ -210,50 +183,24 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 
 			});
 
-			this.registerDefinitionParticipant(new IDefinitionParticipant() {
-				@Override
-				public void findDefinition(IDefinitionRequest request, List<LocationLink> locations,
-						CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerDefinitionParticipant((request, locations, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerDefinitionParticipant(new IDefinitionParticipant() {
-				@Override
-				public void findDefinition(IDefinitionRequest request, List<LocationLink> locations,
-						CancelChecker cancelChecker) {
-					locations.add(TEST_LOCATION_LINK);
-				}
-			});
+			this.registerDefinitionParticipant(
+					(request, locations, cancelChecker) -> locations.add(TEST_LOCATION_LINK));
 
-			this.registerDiagnosticsParticipant(new IDiagnosticsParticipant() {
-				@Override
-				public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
-						XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerDiagnosticsParticipant((xmlDocument, diagnostics, validationSettings, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerDiagnosticsParticipant(new IDiagnosticsParticipant() {
-				@Override
-				public void doDiagnostics(DOMDocument xmlDocument, List<Diagnostic> diagnostics,
-						XMLValidationSettings validationSettings, CancelChecker cancelChecker) {
-					diagnostics.add(TEST_DIAGNOSTIC);
-				}
-			});
+			this.registerDiagnosticsParticipant(
+					(xmlDocument, diagnostics, validationSettings, cancelChecker) -> diagnostics.add(TEST_DIAGNOSTIC));
 
-			this.registerDocumentLinkParticipant(new IDocumentLinkParticipant() {
-				@Override
-				public void findDocumentLinks(DOMDocument document, List<DocumentLink> links) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerDocumentLinkParticipant((document, links) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerDocumentLinkParticipant(new IDocumentLinkParticipant() {
-				@Override
-				public void findDocumentLinks(DOMDocument document, List<DocumentLink> links) {
-					links.add(new DocumentLink(TEST_DOCLINK.getRange(),
-							Paths.get(TEST_DOCLINK.getTarget()).toUri().toString()));
-
-				}
-			});
+			this.registerDocumentLinkParticipant(
+					(document, links) -> links.add(new DocumentLink(TEST_DOCLINK.getRange(),
+							Paths.get(TEST_DOCLINK.getTarget()).toUri().toString())));
 
 			this.registerFormatterParticipant(new IFormatterParticipant() {
 				@Override
@@ -263,20 +210,11 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 				}
 			});
 
-			this.registerHighlightingParticipant(new IHighlightingParticipant() {
-				@Override
-				public void findDocumentHighlights(DOMNode node, Position position, int offset,
-						List<DocumentHighlight> highlights, CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerHighlightingParticipant((node, position, offset, highlights, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerHighlightingParticipant(new IHighlightingParticipant() {
-				@Override
-				public void findDocumentHighlights(DOMNode node, Position position, int offset,
-						List<DocumentHighlight> highlights, CancelChecker cancelChecker) {
-					highlights.add(TEST_HIGHLIGHT);
-				}
-			});
+			this.registerHighlightingParticipant(
+					(node, position, offset, highlights, cancelChecker) -> highlights.add(TEST_HIGHLIGHT));
 
 			this.registerHoverParticipant(new IHoverParticipant() {
 
@@ -325,26 +263,14 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 
 			});
 
-			this.registerReferenceParticipant(new IReferenceParticipant() {
-				@Override
-				public void findReference(DOMDocument document, Position position, ReferenceContext context,
-						List<Location> locations, CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerReferenceParticipant((document, position, context, locations, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerReferenceParticipant(new IReferenceParticipant() {
-				@Override
-				public void findReference(DOMDocument document, Position position, ReferenceContext context,
-						List<Location> locations, CancelChecker cancelChecker) {
-					locations.add(TEST_LOCATION);
-				}
-			});
+			this.registerReferenceParticipant(
+					(document, position, context, locations, cancelChecker) -> locations.add(TEST_LOCATION));
 
-			this.registerRenameParticipant(new IRenameParticipant() {
-				@Override
-				public void doRename(IRenameRequest request, List<TextEdit> locations) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerRenameParticipant((request, locations) -> {
+				throw new RuntimeException("This participant is broken");
 			});
 
 			this.registerSymbolsProviderParticipant(new ISymbolsProviderParticipant() {
@@ -408,20 +334,11 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 
 			});
 
-			this.registerTypeDefinitionParticipant(new ITypeDefinitionParticipant() {
-				@Override
-				public void findTypeDefinition(ITypeDefinitionRequest request, List<LocationLink> locations,
-						CancelChecker cancelChecker) {
-					throw new RuntimeException("This participant is broken");
-				}
+			this.registerTypeDefinitionParticipant((request, locations, cancelChecker) -> {
+				throw new RuntimeException("This participant is broken");
 			});
-			this.registerTypeDefinitionParticipant(new ITypeDefinitionParticipant() {
-				@Override
-				public void findTypeDefinition(ITypeDefinitionRequest request, List<LocationLink> locations,
-						CancelChecker cancelChecker) {
-					locations.add(TEST_LOCATION_LINK);
-				}
-			});
+			this.registerTypeDefinitionParticipant(
+					(request, locations, cancelChecker) -> locations.add(TEST_LOCATION_LINK));
 
 		}
 
@@ -439,7 +356,8 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 	@Test
 	public void testCodeLens() throws BadLocationException {
 		testCodeLensFor("", null, new ErrorParticipantLanguageService(),
-				ErrorParticipantLanguageService.TEST_CODE_LENS);
+				ErrorParticipantLanguageService.TEST_CODE_LENS,
+				cl(r(0, 0, 0, 0), "Bind to grammar/schema...", ClientCommands.OPEN_BINDING_WIZARD));
 	}
 
 	@Test


### PR DESCRIPTION
Allows you to use the code action to bind to a schema when a document doesn't have a root element. Also, the bind schema CodeLens is shown when the document doesn't have a root element.

It generates an element `placeholder-element-name` when the binding
strategy requires a root element to function (eg. `schemaLocation`, `noNamespaceSchemaLocation`). It also uses `placeholder-element-name` when binding to a `.dtd` using a DOCTYPE declaration.

Closes redhat-developer/vscode-xml#819

Signed-off-by: David Thompson <davthomp@redhat.com>
