### PR TITLE
XML references linked editing range should not work with DOM document

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/participants/XMLReferencesLinkedEditingRangesParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/references/participants/XMLReferencesLinkedEditingRangesParticipant.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.eclipse.lemminx.extensions.references.XMLReferencesPlugin;
 import org.eclipse.lemminx.extensions.references.search.SearchEngine;
+import org.eclipse.lemminx.extensions.references.search.SearchNode;
 import org.eclipse.lemminx.extensions.references.search.SearchQuery;
 import org.eclipse.lemminx.extensions.references.search.SearchQueryFactory;
 import org.eclipse.lemminx.services.extensions.ILinkedEditingRangesParticipant;
@@ -39,6 +40,11 @@ public class XMLReferencesLinkedEditingRangesParticipant implements ILinkedEditi
 	@Override
 	public void findLinkedEditingRanges(ILinkedEditingRangesRequest request, List<Range> ranges,
 			CancelChecker cancelChecker) {
+		if (request.getNode() == null || request.getNode().isOwnerDocument()) {
+			// Linked editing range should work only for attribute or text node
+			return;
+		}
+		
 		SearchQuery query = SearchQueryFactory.createToQuery(request.getNode(), request.getOffset(),
 				plugin.getReferencesSettings());
 		if (query == null) {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/references/XMLReferencesLinkedEditingRangesExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/references/XMLReferencesLinkedEditingRangesExtensionsTest.java
@@ -97,7 +97,6 @@ public class XMLReferencesLinkedEditingRangesExtensionsTest extends AbstractCach
 
 	@Test
 	public void docbookOnLinked() throws BadLocationException {
-		// highlighting on define/@name
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
 				// + "<!DOCTYPE book PUBLIC \"-//OASIS//DTD DocBook XML V4.4//EN\"
 				// \"http://www.docbook.org/xml/4.4/docbookx.dtd\">\r\n"
@@ -117,7 +116,6 @@ public class XMLReferencesLinkedEditingRangesExtensionsTest extends AbstractCach
 
 	@Test
 	public void docbookOnChapterId() throws BadLocationException {
-		// highlighting on define/@name
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
 				// + "<!DOCTYPE book PUBLIC \"-//OASIS//DTD DocBook XML V4.4//EN\"
 				// \"http://www.docbook.org/xml/4.4/docbookx.dtd\">\r\n"
@@ -135,6 +133,12 @@ public class XMLReferencesLinkedEditingRangesExtensionsTest extends AbstractCach
 				+ "</book>";
 		testLinkedEditingFor(xml, "file:///test/docbook.xml", //
 				le(r(4, 23, 4, 32), r(2, 17, 2, 26)));
+	}
+
+	@Test
+	public void noLinkedEditingRangeForDocument() throws BadLocationException {
+		String xml = "|<book />";
+		testLinkedEditingFor(xml, "file:///test/docbook.xml", null);
 	}
 
 	@Test


### PR DESCRIPTION
XML references linked editing range should not work with DOM document

Signed-off-by: azerr <azerr@redhat.com>