### PR TITLE
Log file handler at level from "log.level"

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/logs/LogHelper.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/logs/LogHelper.java
@@ -59,7 +59,7 @@ public class LogHelper {
 			if (!StringUtils.isBlank(path)) {
 				createDirectoryPath(path);
 				try {
-					FileHandler fh = LogHelper.getFileHandler(path);
+					FileHandler fh = getFileHandler(path);
 					logger.addHandler(fh);
 				} catch (SecurityException | IOException e) {
 					logger.warning("Error at creation of FileHandler for logging");
@@ -123,7 +123,7 @@ public class LogHelper {
 			FileHandler fh = null;
 			fh = new FileHandler(filePath, true);
 			fh.setFormatter(new SimpleFormatter());
-			fh.setLevel(Level.INFO);
+			fh.setLevel(getLogLevel());
 			return fh;
 		}
 		throw new IOException("Cannot write file since it cannot be written to");


### PR DESCRIPTION
Since all we can do with java.util.logging is to use this particular FileHandler, it doesn't do any good to set the `log.level` property to a specific value but then to hard-code this FileHandler to `setLevel(Level.INFO)`.   We might as well set the level set via the `log.level` sysprop.