### PR TITLE
RNG attribute completion doesn't generate the proper prefix if the namespace is not declared

### DIFF
--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGAttributeDeclaration.java
@@ -14,6 +14,7 @@ package com.thaiopensource.relaxng.pattern;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.lemminx.dom.DOMElement;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMAttributeDeclaration;
 import org.eclipse.lemminx.extensions.contentmodel.model.CMElementDeclaration;
 import org.eclipse.lemminx.services.extensions.ISharedSettingsRequest;
@@ -38,12 +39,35 @@ public class CMRelaxNGAttributeDeclaration implements CMAttributeDeclaration {
 
 	private final CMRelaxNGElementDeclaration cmElement;
 	private final AttributePattern pattern;
+
+	private String prefix;
+
+	private boolean computedPrefix;
+
 	private boolean required;
 	private List<String> values;
 
 	public CMRelaxNGAttributeDeclaration(CMRelaxNGElementDeclaration element, AttributePattern pattern) {
 		this.cmElement = element;
 		this.pattern = pattern;
+		this.computedPrefix = false;
+	}
+
+	@Override
+	public String getPrefix() {
+		String namespaceURI = getNamespace();
+		if (namespaceURI == null) {
+			return null;
+		}
+		if (computedPrefix) {
+			return prefix;
+		}
+		DOMElement element = ((CMRelaxNGElementDeclaration) getOwnerElementDeclaration()).getDOMElement();
+		if (element != null) {
+			prefix = element.getPrefix(namespaceURI);
+		}
+		computedPrefix = true;
+		return prefix;
 	}
 
 	@Override
@@ -60,7 +84,7 @@ public class CMRelaxNGAttributeDeclaration implements CMAttributeDeclaration {
 	public CMElementDeclaration getOwnerElementDeclaration() {
 		return cmElement;
 	}
-	
+
 	Name getJingName() {
 		NameClass nameClass = pattern.getNameClass();
 		if (nameClass instanceof SimpleNameClass) {

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGDocument.java
@@ -193,7 +193,7 @@ public class CMRelaxNGDocument implements CMDocument {
 	}
 
 	private DOMRange getDeclaredTypeRange(DOMNode originNode, Locator locator) {
-		DOMNode node = findNode(locator);
+		DOMNode node = findNodeAt(locator);
 		if (node == null) {
 			return null;
 		}
@@ -207,7 +207,7 @@ public class CMRelaxNGDocument implements CMDocument {
 		return null;
 	}
 
-	private DOMDocument getDocument(String systemId) {
+	public DOMDocument getDocument(String systemId) {
 		DOMDocument document = documents.get(systemId);
 		if (document != null) {
 			return document;
@@ -236,7 +236,7 @@ public class CMRelaxNGDocument implements CMDocument {
 	}
 
 	public String getDocumentation(Locator locator, String value) {
-		DOMNode node = findNode(locator);
+		DOMNode node = findNodeAt(locator);
 		if (node == null) {
 			return null;
 		}
@@ -289,7 +289,7 @@ public class CMRelaxNGDocument implements CMDocument {
 		return null;
 	}
 
-	DOMNode findNode(Locator locator) {
+	DOMNode findNodeAt(Locator locator) {
 		if (locator == null) {
 			return null;
 		}

--- a/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/com/thaiopensource/relaxng/pattern/CMRelaxNGElementDeclaration.java
@@ -60,6 +60,8 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 
 	private Set<String> possibleRequiredElementNames;
 
+	private DOMElement domElement;
+
 	CMRelaxNGElementDeclaration(CMRelaxNGDocument document, ElementPattern pattern) {
 		this.cmDocument = document;
 		this.pattern = pattern;
@@ -81,9 +83,9 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public String getPrefix(String namespaceURI) {
-		DOMNode node = cmDocument.findNode(pattern.getLocator());
-		if (node != null && node.isElement()) {
-			return ((DOMElement) node).getPrefix(namespaceURI);
+		DOMElement element = getDOMElement();
+		if (element != null) {
+			return element.getPrefix(namespaceURI);
 		}
 		return null;
 	}
@@ -94,6 +96,17 @@ public class CMRelaxNGElementDeclaration implements CMElementDeclaration {
 			return ((SimpleNameClass) nameClass).getName();
 		}
 		return null;
+	}
+
+	public DOMElement getDOMElement() {
+		if (domElement != null) {
+			return domElement;
+		}
+		DOMNode node = cmDocument.findNodeAt(pattern.getLocator());
+		if (node != null && node.isElement()) {
+			domElement = (DOMElement) node;
+		}
+		return domElement;
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/contentmodel/model/CMAttributeDeclaration.java
@@ -24,6 +24,8 @@ import org.eclipse.lemminx.utils.StringUtils;
  */
 public interface CMAttributeDeclaration {
 
+	String getPrefix();
+	
 	/**
 	 * Returns the declared attribute local name.
 	 * 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/dtd/contentmodel/CMDTDAttributeDeclaration.java
@@ -36,13 +36,18 @@ public class CMDTDAttributeDeclaration extends XMLAttributeDecl implements CMAtt
 	}
 
 	@Override
+	public String getPrefix() {
+		return super.name.prefix;
+	}
+
+	@Override
 	public String getLocalName() {
 		return super.name.localpart;
 	}
 
 	@Override
 	public String getNamespace() {
-		return null;
+		return super.name.uri;
 	}
 
 	@Override

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDAttributeDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDAttributeDeclaration.java
@@ -50,6 +50,11 @@ public class CMXSDAttributeDeclaration implements CMAttributeDeclaration {
 	}
 
 	@Override
+	public String getPrefix() {
+		return null;
+	}
+
+	@Override
 	public String getLocalName() {
 		return getAttrDeclaration().getName();
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/completion/XMLCompletionBasedOnRelaxNGTest.java
@@ -20,6 +20,8 @@ import static org.eclipse.lemminx.XMLAssert.REGION_SNIPPETS;
 import static org.eclipse.lemminx.XMLAssert.c;
 import static org.eclipse.lemminx.XMLAssert.te;
 
+import java.util.Arrays;
+
 import org.eclipse.lemminx.XMLAssert;
 import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.extensions.contentmodel.BaseFileTempTest;
@@ -154,6 +156,57 @@ public class XMLCompletionBasedOnRelaxNGTest extends BaseFileTempTest {
 						CDATA_SNIPPETS /* CDATA snippets */ , //
 				c("child", te(2, 0, 2, 1, "<child myvx:type=\"\"></child>"), "<child"));
 	}
+
+	@Test
+	public void completionOnAttributes() throws BadLocationException {
+		// completion on <|
+		String xml = "<?xml-model href=\"docbook.rng\"?>\r\n"
+				+ "<book xmlns=\"http://docbook.org/ns/docbook\">\r\n"
+				+ "	<acknowledgements |></acknowledgements>	\r\n"
+				+ "</book>";
+		testCompletionFor(xml, //
+				30, //
+				c("role", te(2, 19, 2, 19, "role=\"\""), "role"), //
+				c("xlink:actuate", te(2, 19, 2, 19, "xlink:actuate=\"\""),
+						Arrays.asList(te(1, 43, 1, 43, " xmlns:xlink=\"http://www.w3.org/1999/xlink\"")), //
+						"xlink:actuate"));
+	}
+
+	@Test
+	public void completionOnAttributesWithPrefix() throws BadLocationException {
+		// completion on <|
+		String xml = "<?xml-model href=\"docbook.rng\"?>\r\n"
+				+ "<book xmlns=\"http://docbook.org/ns/docbook\">\r\n"
+				+ "	<acknowledgements |></acknowledgements>	\r\n"
+				+ "</book>";
+		testCompletionFor(xml, //
+				30, //
+				c("xlink:actuate", te(2, 19, 2, 19, "xlink:actuate=\"\""),
+						Arrays.asList(te(1, 43, 1, 43, " xmlns:xlink=\"http://www.w3.org/1999/xlink\"")), //
+						"xlink:actuate"));
+		
+		xml = "<?xml-model href=\"docbook.rng\"?>\r\n"
+				+ "<book xmlns=\"http://docbook.org/ns/docbook\" >\r\n"
+				+ "	<acknowledgements |></acknowledgements>	\r\n"
+				+ "</book>";
+		testCompletionFor(xml, //
+				30, //
+				c("xlink:actuate", te(2, 19, 2, 19, "xlink:actuate=\"\""),
+						Arrays.asList(te(1, 43, 1, 43, " xmlns:xlink=\"http://www.w3.org/1999/xlink\"")), //
+						"xlink:actuate"));
+		
+		xml = "<?xml-model href=\"docbook.rng\"?>\r\n"
+				+ "<book\r\n"
+				+ "	<acknowledgements |></acknowledgements>	\r\n"
+				+ "</book>";
+		testCompletionFor(xml, //
+				30, //
+				c("xlink:actuate", te(2, 19, 2, 19, "xlink:actuate=\"\""),
+						Arrays.asList(te(1, 5, 1, 5, " xmlns:xlink=\"http://www.w3.org/1999/xlink\"")), //
+						"xlink:actuate"));
+	}
+
+	// role,xml:id,version,xml:lang,xml:base,remap,xreflabel,revisionflag,dir,arch,audience,condition,conformance,os,revision,security,userlevel,vendor,wordsize,annotations,linkend,xlink:href,xlink:type,xlink:role,xlink:arcrole,xlink:title,xlink:show,xlink:actuate,label,status
 
 	private static void testCompletionFor(String value, Integer expectedCount, CompletionItem... expectedItems)
 			throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/resources/relaxng/docbook.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/docbook.rng
@@ -1,0 +1,15292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svg="http://www.w3.org/2000/svg" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:db="http://docbook.org/ns/docbook" xmlns:ctrl="http://nwalsh.com/xmlns/schema-control/" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes" ns="http://docbook.org/ns/docbook">
+  <s:ns prefix="a" uri="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+  <s:ns prefix="ctrl" uri="http://nwalsh.com/xmlns/schema-control/"/>
+  <s:ns prefix="db" uri="http://docbook.org/ns/docbook"/>
+  <s:ns prefix="dbx" uri="http://sourceforge.net/projects/docbook/defguide/schema/extra-markup"/>
+  <s:ns prefix="html" uri="http://www.w3.org/1999/xhtml"/>
+  <s:ns prefix="mml" uri="http://www.w3.org/1998/Math/MathML"/>
+  <s:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
+  <s:ns prefix="s" uri="http://www.ascc.net/xml/schematron"/>
+  <s:ns prefix="svg" uri="http://www.w3.org/2000/svg"/>
+  <s:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+<!-- DocBook V5.0CR5-->
+<!-- See http://docbook.org/ns/docbook -->
+<!--
+    This file is part of DocBook V5.0
+    
+    Copyright 1992-2008 HaL Computer Systems, Inc.,
+    O'Reilly & Associates, Inc., ArborText, Inc., Fujitsu Software
+    Corporation, Norman Walsh, Sun Microsystems, Inc., and the
+    Organization for the Advancement of Structured Information
+    Standards (OASIS).
+    
+    Release: $Id: docbook.rnc 7661 2008-02-06 13:52:59Z nwalsh $
+    
+    Permission to use, copy, modify and distribute the DocBook schema
+    and its accompanying documentation for any purpose and without fee
+    is hereby granted in perpetuity, provided that the above copyright
+    notice and this paragraph appear in all copies. The copyright
+    holders make no representation about the suitability of the schema
+    for any purpose. It is provided "as is" without expressed or implied
+    warranty.
+    
+    If you modify the DocBook schema in any way, label your schema as a
+    variant of DocBook. See the reference documentation
+    (http://docbook.org/tdg5/en/html/ch05.html#s-notdocbook)
+    for more information.
+    
+    Please direct all questions, bug reports, or suggestions for changes
+    to the docbook@lists.oasis-open.org mailing list. For more
+    information, see http://www.oasis-open.org/docbook/.
+    
+    ======================================================================
+  -->
+  <start>
+    <choice>
+      <choice>
+        <ref name="db.set"/>
+        <ref name="db.book"/>
+        <ref name="db.divisions"/>
+        <ref name="db.components"/>
+        <ref name="db.navigation.components"/>
+        <ref name="db.section"/>
+        <ref name="db.para"/>
+      </choice>
+      <choice>
+        <ref name="db.sect1"/>
+        <ref name="db.sect2"/>
+        <ref name="db.sect3"/>
+        <ref name="db.sect4"/>
+        <ref name="db.sect5"/>
+      </choice>
+      <choice>
+        <ref name="db.refentry"/>
+        <ref name="db.refsection"/>
+      </choice>
+      <choice>
+        <ref name="db.refsect1"/>
+        <ref name="db.refsect2"/>
+        <ref name="db.refsect3"/>
+      </choice>
+      <ref name="db.setindex"/>
+    </choice>
+  </start>
+  <div>
+    <define name="db._any.attribute">
+      <attribute>
+        <a:documentation>Any attribute including in any attribute in any namespace.</a:documentation>
+        <anyName/>
+      </attribute>
+    </define>
+    <define name="db._any">
+      <element>
+        <a:documentation>Any element from almost any namespace</a:documentation>
+        <anyName>
+          <except>
+            <nsName/>
+            <nsName ns="http://www.w3.org/1999/xhtml"/>
+          </except>
+        </anyName>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._any.attribute"/>
+            <text/>
+            <ref name="db._any"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.arch.attribute">
+    <attribute name="arch">
+      <a:documentation>Designates the computer or chip architecture to which the element applies</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.audience.attribute">
+    <attribute name="audience">
+      <a:documentation>Designates the intended audience to which the element applies, for example, system administrators, programmers, or new users.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.condition.attribute">
+    <attribute name="condition">
+      <a:documentation>provides a standard place for application-specific effectivity</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.conformance.attribute">
+    <attribute name="conformance">
+      <a:documentation>Indicates standards conformance characteristics of the element</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.os.attribute">
+    <attribute name="os">
+      <a:documentation>Indicates the operating system to which the element is applicable</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.revision.attribute">
+    <attribute name="revision">
+      <a:documentation>Indicates the editorial revision to which the element belongs</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.security.attribute">
+    <attribute name="security">
+      <a:documentation>Indicates something about the security level associated with the element to which it applies</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.userlevel.attribute">
+    <attribute name="userlevel">
+      <a:documentation>Indicates the level of user experience for which the element applies</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.vendor.attribute">
+    <attribute name="vendor">
+      <a:documentation>Indicates the computer vendor to which the element applies.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.wordsize.attribute">
+    <attribute name="wordsize">
+      <a:documentation>Indicates the word size (width in bits) of the computer architecture to which the element applies</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.effectivity.attributes">
+    <interleave>
+      <optional>
+        <ref name="db.arch.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.audience.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.condition.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.conformance.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.os.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.revision.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.security.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.userlevel.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.vendor.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.wordsize.attribute"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.endterm.attribute">
+    <attribute name="endterm">
+      <a:documentation>Points to the element whose content is to be used as the text of the link</a:documentation>
+      <data type="IDREF"/>
+    </attribute>
+  </define>
+  <define name="db.linkend.attribute">
+    <attribute name="linkend">
+      <a:documentation>Points to an internal link target by identifying the value of its xml:id attribute</a:documentation>
+      <data type="IDREF"/>
+    </attribute>
+  </define>
+  <define name="db.linkends.attribute">
+    <attribute name="linkends">
+      <a:documentation>Points to one or more internal link targets by identifying the value of their xml:id attributes</a:documentation>
+      <data type="IDREFS"/>
+    </attribute>
+  </define>
+  <define name="db.xlink.href.attribute">
+    <attribute name="xlink:href">
+      <a:documentation>Identifies a link target with a URI</a:documentation>
+      <data type="anyURI"/>
+    </attribute>
+  </define>
+  <define name="db.xlink.type.attribute">
+    <attribute name="xlink:type">
+      <a:documentation>Identifies the XLink link type</a:documentation>
+      <value>simple</value>
+      <a:documentation>An XLink simple link</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.xlink.role.attribute">
+    <attribute name="xlink:role">
+      <a:documentation>Identifies the XLink role of the link</a:documentation>
+      <data type="anyURI"/>
+    </attribute>
+  </define>
+  <define name="db.xlink.arcrole.attribute">
+    <attribute name="xlink:arcrole">
+      <a:documentation>Identifies the XLink arcrole of the link</a:documentation>
+      <data type="anyURI"/>
+    </attribute>
+  </define>
+  <define name="db.xlink.title.attribute">
+    <optional>
+      <attribute name="xlink:title">
+        <a:documentation>Identifies the XLink title of the link</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.xlink.show.enumeration">
+    <choice>
+      <value>new</value>
+      <a:documentation>An application traversing to the ending resource should load it in a new window, frame, pane, or other relevant presentation context.</a:documentation>
+      <value>replace</value>
+      <a:documentation>An application traversing to the ending resource should load the resource in the same window, frame, pane, or other relevant presentation context in which the starting resource was loaded.</a:documentation>
+      <value>embed</value>
+      <a:documentation>An application traversing to the ending resource should load its presentation in place of the presentation of the starting resource.</a:documentation>
+      <value>other</value>
+      <a:documentation>The behavior of an application traversing to the ending resource is unconstrained by XLink. The application should look for other markup present in the link to determine the appropriate behavior.</a:documentation>
+      <value>none</value>
+      <a:documentation>The behavior of an application traversing to the ending resource is unconstrained by this specification. No other markup is present to help the application determine the appropriate behavior.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.xlink.show.attribute">
+    <attribute name="xlink:show">
+      <a:documentation>Identifies the XLink show behavior of the link</a:documentation>
+      <ref name="db.xlink.show.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.xlink.actuate.enumeration">
+    <choice>
+      <value>onLoad</value>
+      <a:documentation>An application should traverse to the ending resource immediately on loading the starting resource.</a:documentation>
+      <value>onRequest</value>
+      <a:documentation>An application should traverse from the starting resource to the ending resource only on a post-loading event triggered for the purpose of traversal.</a:documentation>
+      <value>other</value>
+      <a:documentation>The behavior of an application traversing to the ending resource is unconstrained by this specification. The application should look for other markup present in the link to determine the appropriate behavior.</a:documentation>
+      <value>none</value>
+      <a:documentation>The behavior of an application traversing to the ending resource is unconstrained by this specification. No other markup is present to help the application determine the appropriate behavior.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.xlink.actuate.attribute">
+    <attribute name="xlink:actuate">
+      <a:documentation>Identifies the XLink actuate behavior of the link</a:documentation>
+      <ref name="db.xlink.actuate.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.href.attributes">
+    <interleave>
+      <ref name="db.xlink.href.attribute"/>
+      <optional>
+        <ref name="db.xlink.type.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xlink.role.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xlink.arcrole.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xlink.title.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xlink.show.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xlink.actuate.attribute"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.xml.id.attribute">
+    <attribute name="xml:id">
+      <a:documentation>Identifies the unique ID value of the element</a:documentation>
+      <data type="ID"/>
+    </attribute>
+  </define>
+  <define name="db.version.attribute">
+    <attribute name="version">
+      <a:documentation>Specifies the DocBook version of the element and its descendants</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.xml.lang.attribute">
+    <attribute name="xml:lang">
+      <a:documentation>Specifies the natural language of the element and its descendants</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.xml.base.attribute">
+    <attribute name="xml:base">
+      <a:documentation>Specifies the base URI of the element and its descendants</a:documentation>
+      <data type="anyURI"/>
+    </attribute>
+  </define>
+  <define name="db.remap.attribute">
+    <attribute name="remap">
+      <a:documentation>Provides the name or similar semantic identifier assigned to the content in some previous markup scheme</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.xreflabel.attribute">
+    <attribute name="xreflabel">
+      <a:documentation>Provides the text that is to be generated for a cross reference to the element</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.xrefstyle.attribute">
+    <attribute name="xrefstyle">
+      <a:documentation>Specifies a keyword or keywords identifying additional style information</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.revisionflag.enumeration">
+    <choice>
+      <value>changed</value>
+      <a:documentation>The element has been changed.</a:documentation>
+      <value>added</value>
+      <a:documentation>The element is new (has been added to the document).</a:documentation>
+      <value>deleted</value>
+      <a:documentation>The element has been deleted.</a:documentation>
+      <value>off</value>
+      <a:documentation>Explicitly turns off revision markup for this element.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.revisionflag.attribute">
+    <attribute name="revisionflag">
+      <a:documentation>Identifies the revision status of the element</a:documentation>
+      <ref name="db.revisionflag.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.dir.enumeration">
+    <choice>
+      <value>ltr</value>
+      <a:documentation>Left-to-right text</a:documentation>
+      <value>rtl</value>
+      <a:documentation>Right-to-left text</a:documentation>
+      <value>lro</value>
+      <a:documentation>Left-to-right override</a:documentation>
+      <value>rlo</value>
+      <a:documentation>Right-to-left override</a:documentation>
+    </choice>
+  </define>
+  <define name="db.dir.attribute">
+    <attribute name="dir">
+      <a:documentation>Identifies the direction of text in an element</a:documentation>
+      <ref name="db.dir.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.common.base.attributes">
+    <interleave>
+      <optional>
+        <ref name="db.version.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xml.lang.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xml.base.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.remap.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.xreflabel.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.revisionflag.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.dir.attribute"/>
+      </optional>
+      <ref name="db.effectivity.attributes"/>
+    </interleave>
+  </define>
+  <define name="db.common.attributes">
+    <interleave>
+      <optional>
+        <ref name="db.xml.id.attribute"/>
+      </optional>
+      <ref name="db.common.base.attributes"/>
+      <optional>
+        <ref name="db.annotations.attribute"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.common.idreq.attributes">
+    <interleave>
+      <ref name="db.xml.id.attribute"/>
+      <ref name="db.common.base.attributes"/>
+      <optional>
+        <ref name="db.annotations.attribute"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.common.linking.attributes">
+    <optional>
+      <choice>
+        <ref name="db.linkend.attribute"/>
+        <ref name="db.href.attributes"/>
+      </choice>
+    </optional>
+  </define>
+  <define name="db.common.req.linking.attributes">
+    <choice>
+      <ref name="db.linkend.attribute"/>
+      <ref name="db.href.attributes"/>
+    </choice>
+  </define>
+  <define name="db.common.data.attributes">
+    <optional>
+      <attribute name="format">
+        <a:documentation>Specifies the format of the data</a:documentation>
+      </attribute>
+    </optional>
+    <choice>
+      <attribute name="fileref">
+        <a:documentation>Indentifies the location of the data by URI</a:documentation>
+        <data type="anyURI"/>
+      </attribute>
+      <attribute name="entityref">
+        <a:documentation>Identifies the location of the data by external identifier (entity name)</a:documentation>
+        <data type="ENTITY"/>
+      </attribute>
+    </choice>
+  </define>
+  <define name="db.verbatim.continuation.enumeration">
+    <choice>
+      <value>continues</value>
+      <a:documentation>Line numbering continues from the immediately preceding element with the same name.</a:documentation>
+      <value>restarts</value>
+      <a:documentation>Line numbering restarts (begins at 1, usually).</a:documentation>
+    </choice>
+  </define>
+  <define name="db.verbatim.continuation.attribute">
+    <attribute name="continuation">
+      <a:documentation>Determines whether line numbering continues from the previous element or restarts.</a:documentation>
+      <ref name="db.verbatim.continuation.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.verbatim.linenumbering.enumeration">
+    <choice>
+      <value>numbered</value>
+      <a:documentation>Lines are numbered.</a:documentation>
+      <value>unnumbered</value>
+      <a:documentation>Lines are not numbered.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.verbatim.linenumbering.attribute">
+    <attribute name="linenumbering">
+      <a:documentation>Determines whether lines are numbered.</a:documentation>
+      <ref name="db.verbatim.linenumbering.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.verbatim.startinglinenumber.attribute">
+    <attribute name="startinglinenumber">
+      <a:documentation>Specifies the initial line number.</a:documentation>
+      <data type="integer"/>
+    </attribute>
+  </define>
+  <define name="db.verbatim.language.attribute">
+    <attribute name="language">
+      <a:documentation>Identifies the language (i.e. programming language) of the verbatim content.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.verbatim.xml.space.attribute">
+    <attribute name="xml:space">
+      <a:documentation>Can be used to indicate explicitly that whitespace in the verbatim environment is preserved. Whitespace must always be preserved in verbatim environments whether this attribute is specified or not.</a:documentation>
+      <value>preserve</value>
+      <a:documentation>Whitespace must be preserved.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.verbatim.attributes">
+    <interleave>
+      <optional>
+        <ref name="db.verbatim.continuation.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.verbatim.linenumbering.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.verbatim.startinglinenumber.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.verbatim.language.attribute"/>
+      </optional>
+      <optional>
+        <ref name="db.verbatim.xml.space.attribute"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.label.attribute">
+    <attribute name="label">
+      <a:documentation>Specifies an identifying string for presentation purposes</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.width.characters.attribute">
+    <attribute name="width">
+      <a:documentation>Specifies the width (in characters) of the element</a:documentation>
+      <data type="nonNegativeInteger"/>
+    </attribute>
+  </define>
+  <define name="db.spacing.enumeration">
+    <choice>
+      <value>compact</value>
+      <a:documentation>The spacing should be "compact".</a:documentation>
+      <value>normal</value>
+      <a:documentation>The spacing should be "normal".</a:documentation>
+    </choice>
+  </define>
+  <define name="db.spacing.attribute">
+    <attribute name="spacing">
+      <a:documentation>Specifies (a hint about) the spacing of the content</a:documentation>
+      <ref name="db.spacing.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.pgwide.enumeration">
+    <choice>
+      <value>0</value>
+      <a:documentation>The element should be rendered in the current text flow (with the flow column width).</a:documentation>
+      <value>1</value>
+      <a:documentation>The element should be rendered across the full text page.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.pgwide.attribute">
+    <attribute name="pgwide">
+      <a:documentation>Indicates if the element is rendered across the column or the page</a:documentation>
+      <ref name="db.pgwide.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.language.attribute">
+    <attribute name="language">
+      <a:documentation>Identifies the language (i.e. programming language) of the content.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.performance.enumeration">
+    <choice>
+      <value>optional</value>
+      <a:documentation>The content describes an optional step or steps.</a:documentation>
+      <value>required</value>
+      <a:documentation>The content describes a required step or steps.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.performance.attribute">
+    <attribute name="performance">
+      <a:documentation>Specifies if the content is required or optional.</a:documentation>
+      <ref name="db.performance.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.floatstyle.attribute">
+    <attribute name="floatstyle">
+      <a:documentation>Specifies style information to be used when rendering the float</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.width.attribute">
+    <attribute name="width">
+      <a:documentation>Specifies the width of the element</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.depth.attribute">
+    <attribute name="depth">
+      <a:documentation>Specifies the depth of the element</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.contentwidth.attribute">
+    <attribute name="contentwidth">
+      <a:documentation>Specifies the width of the content rectangle</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.contentdepth.attribute">
+    <attribute name="contentdepth">
+      <a:documentation>Specifies the depth of the content rectangle</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.scalefit.enumeration">
+    <choice>
+      <value>0</value>
+      <a:documentation>False (do not scale-to-fit; anamorphic scaling may occur)</a:documentation>
+      <value>1</value>
+      <a:documentation>True (scale-to-fit; anamorphic scaling is forbidden)</a:documentation>
+    </choice>
+  </define>
+  <define name="db.scale.attribute">
+    <attribute name="scale">
+      <a:documentation>Specifies the scaling factor</a:documentation>
+      <data type="positiveInteger"/>
+    </attribute>
+  </define>
+  <define name="db.halign.enumeration">
+    <choice>
+      <value>center</value>
+      <a:documentation>Centered horizontally</a:documentation>
+      <value>char</value>
+      <a:documentation>Aligned horizontally on the specified character</a:documentation>
+      <value>justify</value>
+      <a:documentation>Fully justified (left and right margins or edges)</a:documentation>
+      <value>left</value>
+      <a:documentation>Left aligned</a:documentation>
+      <value>right</value>
+      <a:documentation>Right aligned</a:documentation>
+    </choice>
+  </define>
+  <define name="db.valign.enumeration">
+    <choice>
+      <value>bottom</value>
+      <a:documentation>Aligned on the bottom of the region</a:documentation>
+      <value>middle</value>
+      <a:documentation>Centered vertically</a:documentation>
+      <value>top</value>
+      <a:documentation>Aligned on the top of the region</a:documentation>
+    </choice>
+  </define>
+  <define name="db.biblio.class.enumeration">
+    <choice>
+      <value>doi</value>
+      <a:documentation>A document object identifier.</a:documentation>
+      <value>isbn</value>
+      <a:documentation>An international standard book number.</a:documentation>
+      <value>isrn</value>
+      <a:documentation>An international standard technical report number (ISO 10444).</a:documentation>
+      <value>issn</value>
+      <a:documentation>An international standard serial number.</a:documentation>
+      <value>libraryofcongress</value>
+      <a:documentation>A Library of Congress reference number.</a:documentation>
+      <value>pubsnumber</value>
+      <a:documentation>A publication number (an internal number or possibly organizational standard).</a:documentation>
+      <value>uri</value>
+      <a:documentation>A Uniform Resource Identifier</a:documentation>
+    </choice>
+  </define>
+  <define name="db.biblio.class-enum.attribute">
+    <optional>
+      <attribute name="class">
+        <a:documentation>Identifies the kind of bibliographic identifier</a:documentation>
+        <ref name="db.biblio.class.enumeration"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.biblio.class-other.attribute">
+    <attribute name="otherclass">
+      <a:documentation>Identifies the nature of the non-standard bibliographic identifier</a:documentation>
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <define name="db.biblio.class-other.attributes">
+    <interleave>
+      <attribute name="class">
+        <a:documentation>Identifies the kind of bibliographic identifier</a:documentation>
+        <value>other</value>
+        <a:documentation>Indicates that the identifier is some 'other' kind.</a:documentation>
+      </attribute>
+      <ref name="db.biblio.class-other.attribute"/>
+    </interleave>
+  </define>
+  <define name="db.biblio.class.attribute">
+    <choice>
+      <ref name="db.biblio.class-enum.attribute"/>
+      <ref name="db.biblio.class-other.attributes"/>
+    </choice>
+  </define>
+  <define name="db.ubiq.inlines">
+    <choice>
+      <choice>
+        <ref name="db.inlinemediaobject"/>
+        <ref name="db.remark"/>
+        <ref name="db.superscript"/>
+        <ref name="db.subscript"/>
+        <ref name="db.link.inlines"/>
+        <ref name="db.alt"/>
+      </choice>
+      <ref name="db.annotation"/>
+      <ref name="db.indexterm"/>
+    </choice>
+  </define>
+  <define name="db._text">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="db.ubiq.inlines"/>
+        <ref name="db._phrase"/>
+        <ref name="db.replaceable"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="db._title">
+    <interleave>
+      <optional>
+        <ref name="db.title"/>
+      </optional>
+      <optional>
+        <ref name="db.titleabbrev"/>
+      </optional>
+      <optional>
+        <ref name="db.subtitle"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db._title.req">
+    <interleave>
+      <ref name="db.title"/>
+      <optional>
+        <ref name="db.titleabbrev"/>
+      </optional>
+      <optional>
+        <ref name="db.subtitle"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db._title.only">
+    <interleave>
+      <optional>
+        <ref name="db.title"/>
+      </optional>
+      <optional>
+        <ref name="db.titleabbrev"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db._title.onlyreq">
+    <interleave>
+      <ref name="db.title"/>
+      <optional>
+        <ref name="db.titleabbrev"/>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db._info">
+    <choice>
+      <group>
+        <ref name="db._title"/>
+        <optional>
+          <ref name="db.titleforbidden.info"/>
+        </optional>
+      </group>
+      <optional>
+        <ref name="db.info"/>
+      </optional>
+    </choice>
+  </define>
+  <define name="db._info.title.req">
+    <choice>
+      <group>
+        <ref name="db._title.req"/>
+        <optional>
+          <ref name="db.titleforbidden.info"/>
+        </optional>
+      </group>
+      <ref name="db.titlereq.info"/>
+    </choice>
+  </define>
+  <define name="db._info.title.only">
+    <choice>
+      <group>
+        <ref name="db._title.only"/>
+        <optional>
+          <ref name="db.titleforbidden.info"/>
+        </optional>
+      </group>
+      <ref name="db.titleonly.info"/>
+    </choice>
+  </define>
+  <define name="db._info.title.onlyreq">
+    <choice>
+      <group>
+        <ref name="db._title.onlyreq"/>
+        <optional>
+          <ref name="db.titleforbidden.info"/>
+        </optional>
+      </group>
+      <ref name="db.titleonlyreq.info"/>
+    </choice>
+  </define>
+  <define name="db._info.title.forbidden">
+    <optional>
+      <ref name="db.titleforbidden.info"/>
+    </optional>
+  </define>
+  <define name="db.all.inlines">
+    <choice>
+      <text/>
+      <ref name="db.ubiq.inlines"/>
+      <ref name="db.general.inlines"/>
+      <ref name="db.domain.inlines"/>
+      <ref name="db.extension.inlines"/>
+    </choice>
+  </define>
+  <define name="db.general.inlines">
+    <choice>
+      <ref name="db.publishing.inlines"/>
+      <ref name="db.product.inlines"/>
+      <ref name="db.bibliography.inlines"/>
+      <ref name="db.graphic.inlines"/>
+      <ref name="db.indexing.inlines"/>
+      <ref name="db.link.inlines"/>
+    </choice>
+  </define>
+  <define name="db.domain.inlines">
+    <choice>
+      <ref name="db.technical.inlines"/>
+      <ref name="db.math.inlines"/>
+      <ref name="db.markup.inlines"/>
+      <ref name="db.gui.inlines"/>
+      <ref name="db.keyboard.inlines"/>
+      <ref name="db.os.inlines"/>
+      <ref name="db.programming.inlines"/>
+      <ref name="db.error.inlines"/>
+    </choice>
+  </define>
+  <define name="db.technical.inlines">
+    <choice>
+      <choice>
+        <ref name="db.replaceable"/>
+        <ref name="db.package"/>
+        <ref name="db.parameter"/>
+      </choice>
+      <ref name="db.termdef"/>
+      <ref name="db.nonterminal"/>
+      <choice>
+        <ref name="db.systemitem"/>
+        <ref name="db.option"/>
+        <ref name="db.optional"/>
+        <ref name="db.property"/>
+      </choice>
+    </choice>
+  </define>
+  <define name="db.product.inlines">
+    <choice>
+      <ref name="db.trademark"/>
+      <choice>
+        <ref name="db.productnumber"/>
+        <ref name="db.productname"/>
+        <ref name="db.database"/>
+        <ref name="db.application"/>
+        <ref name="db.hardware"/>
+      </choice>
+    </choice>
+  </define>
+  <define name="db.bibliography.inlines">
+    <choice>
+      <ref name="db.citation"/>
+      <ref name="db.citerefentry"/>
+      <ref name="db.citetitle"/>
+      <ref name="db.citebiblioid"/>
+      <ref name="db.author"/>
+      <ref name="db.person"/>
+      <ref name="db.personname"/>
+      <ref name="db.org"/>
+      <ref name="db.orgname"/>
+      <ref name="db.editor"/>
+      <ref name="db.jobtitle"/>
+    </choice>
+  </define>
+  <define name="db.publishing.inlines">
+    <choice>
+      <choice>
+        <ref name="db.abbrev"/>
+        <ref name="db.acronym"/>
+        <ref name="db.date"/>
+        <ref name="db.emphasis"/>
+        <ref name="db.footnote"/>
+        <ref name="db.footnoteref"/>
+        <ref name="db.foreignphrase"/>
+        <ref name="db.phrase"/>
+        <ref name="db.quote"/>
+        <ref name="db.subscript"/>
+        <ref name="db.superscript"/>
+        <ref name="db.wordasword"/>
+      </choice>
+      <ref name="db.glossary.inlines"/>
+      <ref name="db.coref"/>
+    </choice>
+  </define>
+  <define name="db.graphic.inlines">
+    <ref name="db.inlinemediaobject"/>
+  </define>
+  <define name="db.indexing.inlines">
+    <choice>
+      <notAllowed/>
+      <ref name="db.indexterm"/>
+    </choice>
+  </define>
+  <define name="db.link.inlines">
+    <choice>
+      <choice>
+        <ref name="db.xref"/>
+        <ref name="db.link"/>
+        <ref name="db.olink"/>
+        <ref name="db.anchor"/>
+      </choice>
+      <ref name="db.biblioref"/>
+    </choice>
+  </define>
+  <define name="db.extension.inlines">
+    <notAllowed/>
+  </define>
+  <define name="db.nopara.blocks">
+    <choice>
+      <choice>
+        <ref name="db.list.blocks"/>
+        <ref name="db.formal.blocks"/>
+        <ref name="db.informal.blocks"/>
+        <ref name="db.publishing.blocks"/>
+        <ref name="db.graphic.blocks"/>
+        <ref name="db.technical.blocks"/>
+        <ref name="db.verbatim.blocks"/>
+        <ref name="db.bridgehead"/>
+        <ref name="db.remark"/>
+        <ref name="db.revhistory"/>
+      </choice>
+      <ref name="db.indexterm"/>
+      <ref name="db.synopsis.blocks"/>
+      <ref name="db.admonition.blocks"/>
+    </choice>
+  </define>
+  <define name="db.para.blocks">
+    <choice>
+      <ref name="db.anchor"/>
+      <ref name="db.para"/>
+      <ref name="db.formalpara"/>
+      <ref name="db.simpara"/>
+    </choice>
+  </define>
+  <define name="db.all.blocks">
+    <choice>
+      <choice>
+        <ref name="db.nopara.blocks"/>
+        <ref name="db.para.blocks"/>
+        <ref name="db.extension.blocks"/>
+      </choice>
+      <ref name="db.annotation"/>
+    </choice>
+  </define>
+  <define name="db.formal.blocks">
+    <choice>
+      <choice>
+        <ref name="db.example"/>
+        <ref name="db.figure"/>
+        <ref name="db.table"/>
+      </choice>
+      <ref name="db.equation"/>
+    </choice>
+  </define>
+  <define name="db.informal.blocks">
+    <choice>
+      <choice>
+        <ref name="db.informalexample"/>
+        <ref name="db.informalfigure"/>
+        <ref name="db.informaltable"/>
+      </choice>
+      <ref name="db.informalequation"/>
+    </choice>
+  </define>
+  <define name="db.publishing.blocks">
+    <choice>
+      <ref name="db.sidebar"/>
+      <ref name="db.blockquote"/>
+      <ref name="db.address"/>
+      <ref name="db.epigraph"/>
+    </choice>
+  </define>
+  <define name="db.graphic.blocks">
+    <choice>
+      <ref name="db.mediaobject"/>
+      <ref name="db.screenshot"/>
+    </choice>
+  </define>
+  <define name="db.technical.blocks">
+    <choice>
+      <ref name="db.procedure"/>
+      <ref name="db.task"/>
+      <choice>
+        <ref name="db.productionset"/>
+        <ref name="db.constraintdef"/>
+      </choice>
+      <ref name="db.msgset"/>
+    </choice>
+  </define>
+  <define name="db.list.blocks">
+    <choice>
+      <choice>
+        <ref name="db.itemizedlist"/>
+        <ref name="db.orderedlist"/>
+        <ref name="db.procedure"/>
+        <ref name="db.simplelist"/>
+        <ref name="db.variablelist"/>
+        <ref name="db.segmentedlist"/>
+      </choice>
+      <ref name="db.glosslist"/>
+      <ref name="db.bibliolist"/>
+      <ref name="db.calloutlist"/>
+      <ref name="db.qandaset"/>
+    </choice>
+  </define>
+  <define name="db.verbatim.blocks">
+    <choice>
+      <choice>
+        <ref name="db.screen"/>
+        <ref name="db.literallayout"/>
+      </choice>
+      <choice>
+        <ref name="db.programlistingco"/>
+        <ref name="db.screenco"/>
+      </choice>
+      <choice>
+        <ref name="db.programlisting"/>
+        <ref name="db.synopsis"/>
+      </choice>
+    </choice>
+  </define>
+  <define name="db.extension.blocks">
+    <notAllowed/>
+  </define>
+  <define name="db.info.extension">
+    <ref name="db._any"/>
+  </define>
+  <define name="db.info.elements">
+    <choice>
+      <choice>
+        <ref name="db.abstract"/>
+        <ref name="db.address"/>
+        <ref name="db.artpagenums"/>
+        <ref name="db.author"/>
+        <ref name="db.authorgroup"/>
+        <ref name="db.authorinitials"/>
+        <ref name="db.bibliocoverage"/>
+        <ref name="db.biblioid"/>
+        <ref name="db.bibliosource"/>
+        <ref name="db.collab"/>
+        <ref name="db.confgroup"/>
+        <ref name="db.contractsponsor"/>
+        <ref name="db.contractnum"/>
+        <ref name="db.copyright"/>
+        <ref name="db.cover"/>
+        <ref name="db.date"/>
+        <ref name="db.edition"/>
+        <ref name="db.editor"/>
+        <ref name="db.issuenum"/>
+        <ref name="db.keywordset"/>
+        <ref name="db.legalnotice"/>
+        <ref name="db.mediaobject"/>
+        <ref name="db.org"/>
+        <ref name="db.orgname"/>
+        <ref name="db.othercredit"/>
+        <ref name="db.pagenums"/>
+        <ref name="db.printhistory"/>
+        <ref name="db.pubdate"/>
+        <ref name="db.publisher"/>
+        <ref name="db.publishername"/>
+        <ref name="db.releaseinfo"/>
+        <ref name="db.revhistory"/>
+        <ref name="db.seriesvolnums"/>
+        <ref name="db.subjectset"/>
+        <ref name="db.volumenum"/>
+        <ref name="db.info.extension"/>
+      </choice>
+      <ref name="db.annotation"/>
+      <ref name="db.extendedlink"/>
+      <choice>
+        <ref name="db.bibliomisc"/>
+        <ref name="db.bibliomset"/>
+        <ref name="db.bibliorelation"/>
+        <ref name="db.biblioset"/>
+      </choice>
+      <ref name="db.itermset"/>
+      <choice>
+        <ref name="db.productname"/>
+        <ref name="db.productnumber"/>
+      </choice>
+    </choice>
+  </define>
+  <define name="db.bibliographic.elements">
+    <choice>
+      <ref name="db.info.elements"/>
+      <ref name="db.publishing.inlines"/>
+      <ref name="db.citerefentry"/>
+      <ref name="db.citetitle"/>
+      <ref name="db.citebiblioid"/>
+      <ref name="db.person"/>
+      <ref name="db.personblurb"/>
+      <ref name="db.personname"/>
+      <ref name="db.subtitle"/>
+      <ref name="db.title"/>
+      <ref name="db.titleabbrev"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.title.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.title.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.title.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.title">
+      <element name="title">
+        <a:documentation>The text of the title of a section of a document or of a formal block-level element</a:documentation>
+        <ref name="db.title.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.titleabbrev.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.titleabbrev.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.titleabbrev.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.titleabbrev">
+      <element name="titleabbrev">
+        <a:documentation>The abbreviation of a title</a:documentation>
+        <ref name="db.titleabbrev.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.subtitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.subtitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.subtitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.subtitle">
+      <element name="subtitle">
+        <a:documentation>The subtitle of a document</a:documentation>
+        <ref name="db.subtitle.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.info.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.info.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.info.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.info">
+      <element name="info">
+        <a:documentation>A wrapper for information about a component or other block</a:documentation>
+        <ref name="db.info.attlist"/>
+        <interleave>
+          <ref name="db._title"/>
+          <zeroOrMore>
+            <ref name="db.info.elements"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.titlereq.info.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.titlereq.info.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.titlereq.info.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.titlereq.info">
+      <element name="info">
+        <a:documentation>A wrapper for information about a component or other block with a required title</a:documentation>
+        <ref name="db.titlereq.info.attlist"/>
+        <interleave>
+          <ref name="db._title.req"/>
+          <zeroOrMore>
+            <ref name="db.info.elements"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.titleonly.info.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.titleonly.info.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.titleonly.info.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.titleonly.info">
+      <element name="info">
+        <a:documentation>A wrapper for information about a component or other block with only a title</a:documentation>
+        <ref name="db.titleonly.info.attlist"/>
+        <interleave>
+          <ref name="db._title.only"/>
+          <zeroOrMore>
+            <ref name="db.info.elements"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.titleonlyreq.info.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.titleonlyreq.info.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.titleonlyreq.info.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.titleonlyreq.info">
+      <element name="info">
+        <a:documentation>A wrapper for information about a component or other block with only a required title</a:documentation>
+        <ref name="db.titleonlyreq.info.attlist"/>
+        <interleave>
+          <ref name="db._title.onlyreq"/>
+          <zeroOrMore>
+            <ref name="db.info.elements"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.titleforbidden.info.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.titleforbidden.info.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.titleforbidden.info.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.titleforbidden.info">
+      <element name="info">
+        <a:documentation>A wrapper for information about a component or other block without a title</a:documentation>
+        <ref name="db.titleforbidden.info.attlist"/>
+        <zeroOrMore>
+          <ref name="db.info.elements"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.subjectset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.subjectset.scheme.attribute">
+      <attribute name="scheme">
+        <a:documentation>Identifies the controlled vocabulary used by this set's terms</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.subjectset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.subjectset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.subjectset.scheme.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.subjectset">
+      <element name="subjectset">
+        <a:documentation>A set of terms describing the subject matter of a document</a:documentation>
+        <ref name="db.subjectset.attlist"/>
+        <oneOrMore>
+          <ref name="db.subject"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.subject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.subject.weight.attribute">
+      <attribute name="weight">
+        <a:documentation>Specifies a ranking for this subject relative to other subjects in the same set</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.subject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.subject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.subject.weight.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.subject">
+      <element name="subject">
+        <a:documentation>One of a group of terms describing the subject matter of a document</a:documentation>
+        <ref name="db.subject.attlist"/>
+        <oneOrMore>
+          <ref name="db.subjectterm"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.subjectterm.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.subjectterm.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.subjectterm.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.subjectterm">
+      <element name="subjectterm">
+        <a:documentation>A term in a group of terms describing the subject matter of a document</a:documentation>
+        <ref name="db.subjectterm.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.keywordset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keywordset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keywordset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.keywordset">
+      <element name="keywordset">
+        <a:documentation>A set of keywords describing the content of a document</a:documentation>
+        <ref name="db.keywordset.attlist"/>
+        <oneOrMore>
+          <ref name="db.keyword"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.keyword.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keyword.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keyword.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.keyword">
+      <element name="keyword">
+        <a:documentation>One of a set of keywords describing the content of a document</a:documentation>
+        <ref name="db.keyword.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <define name="db.table.choice">
+    <choice>
+      <notAllowed/>
+      <ref name="db.cals.table"/>
+      <ref name="db.html.table"/>
+    </choice>
+  </define>
+  <define name="db.informaltable.choice">
+    <choice>
+      <notAllowed/>
+      <ref name="db.cals.informaltable"/>
+      <ref name="db.html.informaltable"/>
+    </choice>
+  </define>
+  <define name="db.table">
+    <ref name="db.table.choice"/>
+  </define>
+  <define name="db.informaltable">
+    <ref name="db.informaltable.choice"/>
+  </define>
+  <div>
+    <define name="db.procedure.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.procedure.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.procedure.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.procedure.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.procedure">
+      <element name="procedure">
+        <a:documentation>A list of operations to be performed in a well-defined sequence</a:documentation>
+        <ref name="db.procedure.attlist"/>
+        <ref name="db.procedure.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.step"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.step.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.step.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.step.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.performance.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.step.info">
+      <ref name="db._info.title.only"/>
+    </define>
+<!--
+
+      This content model is blocks*, step|stepalternatives, blocks* but
+      expressed this way it avoids UPA issues in XSD and DTD versions
+    -->
+    <define name="db.step">
+      <element name="step">
+        <a:documentation>A unit of action in a procedure</a:documentation>
+        <ref name="db.step.attlist"/>
+        <ref name="db.step.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <choice>
+                <ref name="db.substeps"/>
+                <ref name="db.stepalternatives"/>
+              </choice>
+              <zeroOrMore>
+                <ref name="db.all.blocks"/>
+              </zeroOrMore>
+            </optional>
+          </group>
+          <group>
+            <choice>
+              <ref name="db.substeps"/>
+              <ref name="db.stepalternatives"/>
+            </choice>
+            <zeroOrMore>
+              <ref name="db.all.blocks"/>
+            </zeroOrMore>
+          </group>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.stepalternatives.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.stepalternatives.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.stepalternatives.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.performance.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.stepalternatives.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.stepalternatives">
+      <element name="stepalternatives">
+        <a:documentation>Alternative steps in a procedure</a:documentation>
+        <ref name="db.stepalternatives.attlist"/>
+        <ref name="db.stepalternatives.info"/>
+        <oneOrMore>
+          <ref name="db.step"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.substeps.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.substeps.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.substeps.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.performance.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.substeps">
+      <element name="substeps">
+        <a:documentation>A wrapper for steps that occur within steps in a procedure</a:documentation>
+        <ref name="db.substeps.attlist"/>
+        <oneOrMore>
+          <ref name="db.step"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.sidebar.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sidebar.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sidebar.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.sidebar.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.sidebar">
+      <element name="sidebar">
+        <a:documentation>A portion of a document that is isolated from the main narrative flow</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:sidebar">
+            <s:assert test="not(.//db:sidebar)">sidebar must not occur in the descendants of sidebar</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sidebar.attlist"/>
+        <ref name="db.sidebar.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.abstract.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.abstract.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.abstract.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.abstract.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.abstract">
+      <element name="abstract">
+        <a:documentation>A summary</a:documentation>
+        <ref name="db.abstract.attlist"/>
+        <ref name="db.abstract.info"/>
+        <oneOrMore>
+          <ref name="db.para.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.personblurb.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.personblurb.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.personblurb.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.personblurb.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.personblurb">
+      <element name="personblurb">
+        <a:documentation>A short description or note about a person</a:documentation>
+        <ref name="db.personblurb.attlist"/>
+        <ref name="db.personblurb.info"/>
+        <oneOrMore>
+          <ref name="db.para.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.blockquote.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.blockquote.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.blockquote.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.blockquote.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.blockquote">
+      <element name="blockquote">
+        <a:documentation>A quotation set off from the main text</a:documentation>
+        <ref name="db.blockquote.attlist"/>
+        <ref name="db.blockquote.info"/>
+        <optional>
+          <ref name="db.attribution"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.attribution.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.attribution.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.attribution.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.attribution">
+      <element name="attribution">
+        <a:documentation>The source of a block quote or epigraph</a:documentation>
+        <ref name="db.attribution.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.person"/>
+            <ref name="db.personname"/>
+            <ref name="db.citetitle"/>
+            <ref name="db.citation"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bridgehead.renderas.enumeration">
+      <choice>
+        <value>sect1</value>
+        <a:documentation>Render as a first-level section</a:documentation>
+        <value>sect2</value>
+        <a:documentation>Render as a second-level section</a:documentation>
+        <value>sect3</value>
+        <a:documentation>Render as a third-level section</a:documentation>
+        <value>sect4</value>
+        <a:documentation>Render as a fourth-level section</a:documentation>
+        <value>sect5</value>
+        <a:documentation>Render as a fifth-level section</a:documentation>
+      </choice>
+    </define>
+    <define name="db.bridgehead.renderas-enum.attribute">
+      <optional>
+        <attribute name="renderas">
+          <a:documentation>Indicates how the bridge head should be rendered</a:documentation>
+          <ref name="db.bridgehead.renderas.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.bridgehead.renderas-other.attribute">
+      <attribute name="otherrenderas">
+        <a:documentation>Identifies the nature of the non-standard rendering</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.bridgehead.renderas-other.attributes">
+      <interleave>
+        <attribute name="renderas">
+          <a:documentation>Indicates how the bridge head should be rendered</a:documentation>
+          <value>other</value>
+          <a:documentation>Identifies a non-standard rendering</a:documentation>
+        </attribute>
+        <ref name="db.bridgehead.renderas-other.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.bridgehead.renderas.attribute">
+      <choice>
+        <ref name="db.bridgehead.renderas-enum.attribute"/>
+        <ref name="db.bridgehead.renderas-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.bridgehead.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bridgehead.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bridgehead.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.bridgehead.renderas.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.bridgehead">
+      <element name="bridgehead">
+        <a:documentation>A free-floating heading</a:documentation>
+        <ref name="db.bridgehead.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.remark.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.remark.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.remark.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.remark">
+      <element name="remark">
+        <a:documentation>A remark (or comment) intended for presentation in a draft manuscript</a:documentation>
+        <ref name="db.remark.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.epigraph.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.epigraph.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.epigraph.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.epigraph.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.epigraph">
+      <element name="epigraph">
+        <a:documentation>A short inscription at the beginning of a document or component</a:documentation>
+        <ref name="db.epigraph.attlist"/>
+        <ref name="db.epigraph.info"/>
+        <optional>
+          <ref name="db.attribution"/>
+        </optional>
+        <oneOrMore>
+          <choice>
+            <ref name="db.para.blocks"/>
+            <ref name="db.literallayout"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.footnote.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.footnote.label.attribute">
+      <attribute name="label">
+        <a:documentation>Identifies the desired footnote mark</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.footnote.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.footnote.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.footnote.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.footnote">
+      <element name="footnote">
+        <a:documentation>A footnote</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:footnote)">footnote must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:indexterm)">indexterm must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:sidebar)">sidebar must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:task)">task must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:epigraph)">epigraph must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:footnote">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of footnote</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.footnote.attlist"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.formalpara.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.formalpara.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.formalpara.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.formalpara.info">
+      <ref name="db._info.title.onlyreq"/>
+    </define>
+    <define name="db.formalpara">
+      <element name="formalpara">
+        <a:documentation>A paragraph with a title</a:documentation>
+        <ref name="db.formalpara.attlist"/>
+        <ref name="db.formalpara.info"/>
+        <zeroOrMore>
+          <ref name="db.indexing.inlines"/>
+        </zeroOrMore>
+        <ref name="db.para"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.para.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.para.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.para.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.para.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.para">
+      <element name="para">
+        <a:documentation>A paragraph</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:para">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.para.attlist"/>
+        <ref name="db.para.info"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.all.inlines"/>
+            <ref name="db.nopara.blocks"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.simpara.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.simpara.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.simpara.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.simpara.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.simpara">
+      <element name="simpara">
+        <a:documentation>A paragraph that contains only text and inline markup, no block elements</a:documentation>
+        <ref name="db.simpara.attlist"/>
+        <ref name="db.simpara.info"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.itemizedlist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.itemizedlist.mark.attribute">
+      <attribute name="mark">
+        <a:documentation>Identifies the type of mark to be used on items in this list</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.itemizedlist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.itemizedlist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.spacing.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.itemizedlist.mark.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.itemizedlist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.itemizedlist">
+      <element name="itemizedlist">
+        <a:documentation>A list in which each entry is marked with a bullet or other dingbat</a:documentation>
+        <ref name="db.itemizedlist.attlist"/>
+        <ref name="db.itemizedlist.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.listitem"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.orderedlist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.orderedlist.continuation.enumeration">
+      <choice>
+        <value>continues</value>
+        <a:documentation>Specifies that numbering should begin where the preceding list left off</a:documentation>
+        <value>restarts</value>
+        <a:documentation>Specifies that numbering should begin again at 1</a:documentation>
+      </choice>
+    </define>
+    <define name="db.orderedlist.continuation.attribute">
+      <attribute name="continuation">
+        <a:documentation>Indicates how list numbering should begin relative to the immediately preceding list</a:documentation>
+        <ref name="db.orderedlist.continuation.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.orderedlist.startingnumber.attribute">
+      <attribute name="startingnumber">
+        <a:documentation>Specifies the initial line number.</a:documentation>
+        <data type="integer"/>
+      </attribute>
+    </define>
+    <define name="db.orderedlist.inheritnum.enumeration">
+      <choice>
+        <value>ignore</value>
+        <a:documentation>Specifies that numbering should ignore list nesting</a:documentation>
+        <value>inherit</value>
+        <a:documentation>Specifies that numbering should inherit from outer-level lists</a:documentation>
+      </choice>
+    </define>
+    <define name="db.orderedlist.inheritnum.attribute">
+      <attribute name="inheritnum">
+        <a:documentation>Indicates whether or not item numbering should be influenced by list nesting</a:documentation>
+        <ref name="db.orderedlist.inheritnum.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.orderedlist.numeration.enumeration">
+      <choice>
+        <value>arabic</value>
+        <a:documentation>Specifies Arabic numeration (1, 2, 3, …)</a:documentation>
+        <value>upperalpha</value>
+        <a:documentation>Specifies upper-case alphabetic numeration (A, B, C, …)</a:documentation>
+        <value>loweralpha</value>
+        <a:documentation>Specifies lower-case alphabetic numeration (a, b, c, …)</a:documentation>
+        <value>upperroman</value>
+        <a:documentation>Specifies upper-case Roman numeration (I, II, III, …)</a:documentation>
+        <value>lowerroman</value>
+        <a:documentation>Specifies lower-case Roman numeration (i, ii, iii …)</a:documentation>
+      </choice>
+    </define>
+    <define name="db.orderedlist.numeration.attribute">
+      <attribute name="numeration">
+        <a:documentation>Indicates the desired numeration</a:documentation>
+        <ref name="db.orderedlist.numeration.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.orderedlist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.orderedlist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.spacing.attribute"/>
+        </optional>
+        <optional>
+          <choice>
+            <ref name="db.orderedlist.continuation.attribute"/>
+            <ref name="db.orderedlist.startingnumber.attribute"/>
+          </choice>
+        </optional>
+        <optional>
+          <ref name="db.orderedlist.inheritnum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.orderedlist.numeration.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.orderedlist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.orderedlist">
+      <element name="orderedlist">
+        <a:documentation>A list in which each entry is marked with a sequentially incremented label</a:documentation>
+        <ref name="db.orderedlist.attlist"/>
+        <ref name="db.orderedlist.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.listitem"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.listitem.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.listitem.override.attribute">
+      <attribute name="override">
+        <a:documentation>Specifies the keyword for the type of mark that should be used on this
+ item, instead of the mark that would be used by default</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.listitem.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.listitem.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.listitem.override.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.listitem">
+      <element name="listitem">
+        <a:documentation>A wrapper for the elements of a list item</a:documentation>
+        <ref name="db.listitem.attlist"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.segmentedlist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.segmentedlist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.segmentedlist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.segmentedlist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.segmentedlist">
+      <element name="segmentedlist">
+        <a:documentation>A segmented list, a list of sets of elements</a:documentation>
+        <ref name="db.segmentedlist.attlist"/>
+        <ref name="db.segmentedlist.info"/>
+        <oneOrMore>
+          <ref name="db.segtitle"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="db.seglistitem"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.segtitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.segtitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.segtitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.segtitle">
+      <element name="segtitle">
+        <a:documentation>The title of an element of a list item in a segmented list</a:documentation>
+        <ref name="db.segtitle.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seglistitem.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seglistitem.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seglistitem.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.seglistitem">
+      <element name="seglistitem">
+        <a:documentation>A list item in a segmented list</a:documentation>
+        <s:pattern name="Cardinality of segments and titles">
+          <s:rule context="db:seglistitem">
+            <s:assert test="count(db:seg) = count(../db:segtitle)">The number of seg elements must be the same as the number of segtitle elements in the parent segmentedlist</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.seglistitem.attlist"/>
+        <oneOrMore>
+          <ref name="db.seg"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seg.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seg.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seg.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.seg">
+      <element name="seg">
+        <a:documentation>An element of a list item in a segmented list</a:documentation>
+        <ref name="db.seg.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.simplelist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.simplelist.type.enumeration">
+      <choice>
+        <value>horiz</value>
+        <a:documentation>A tabular presentation in row-major order.</a:documentation>
+        <value>vert</value>
+        <a:documentation>A tabular presentation in column-major order.</a:documentation>
+        <value>inline</value>
+        <a:documentation>An inline presentation, usually a comma-delimited list.</a:documentation>
+      </choice>
+    </define>
+    <define name="db.simplelist.type.attribute">
+      <attribute name="type" a:defaultValue="vert">
+        <a:documentation>Specifies the type of list presentation.</a:documentation>
+        <ref name="db.simplelist.type.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.simplelist.columns.attribute">
+      <attribute name="columns">
+        <a:documentation>Specifies the number of columns for horizontal or vertical presentation</a:documentation>
+        <data type="integer"/>
+      </attribute>
+    </define>
+    <define name="db.simplelist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.simplelist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.simplelist.type.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.simplelist.columns.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.simplelist">
+      <element name="simplelist">
+        <a:documentation>An undecorated list of single words or short phrases</a:documentation>
+        <ref name="db.simplelist.attlist"/>
+        <oneOrMore>
+          <ref name="db.member"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.member.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.member.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.member.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.member">
+      <element name="member">
+        <a:documentation>An element of a simple list</a:documentation>
+        <ref name="db.member.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.variablelist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.variablelist.termlength.attribute">
+      <attribute name="termlength">
+        <a:documentation>Indicates a length beyond which the presentation system may consider a term too long and select an alternate presentation for that term, item, or list</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.variablelist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.variablelist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.spacing.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.variablelist.termlength.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.variablelist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.variablelist">
+      <element name="variablelist">
+        <a:documentation>A list in which each entry is composed of a set of one or more terms and an associated description</a:documentation>
+        <ref name="db.variablelist.attlist"/>
+        <ref name="db.variablelist.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.varlistentry"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.varlistentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.varlistentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.varlistentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.varlistentry">
+      <element name="varlistentry">
+        <a:documentation>A wrapper for a set of terms and the associated description in a variable list</a:documentation>
+        <ref name="db.varlistentry.attlist"/>
+        <oneOrMore>
+          <ref name="db.term"/>
+        </oneOrMore>
+        <ref name="db.listitem"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.term.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.term.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.term.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.term">
+      <element name="term">
+        <a:documentation>The word or phrase being defined or described in a variable list</a:documentation>
+        <ref name="db.term.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.example.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.example.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.example.width.attribute">
+      <ref name="db.width.characters.attribute"/>
+    </define>
+    <define name="db.example.pgwide.attribute">
+      <ref name="db.pgwide.attribute"/>
+    </define>
+    <define name="db.example.floatstyle.attribute">
+      <ref name="db.floatstyle.attribute"/>
+    </define>
+    <define name="db.example.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.example.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.example.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.example.floatstyle.attribute"/>
+        </optional>
+        <optional>
+          <choice>
+            <ref name="db.example.width.attribute"/>
+            <ref name="db.example.pgwide.attribute"/>
+          </choice>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.example.info">
+      <ref name="db._info.title.onlyreq"/>
+    </define>
+    <define name="db.example">
+      <element name="example">
+        <a:documentation>A formal example, with a title</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:example">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of example</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.example.attlist"/>
+        <ref name="db.example.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.informalexample.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.informalexample.width.attribute">
+      <ref name="db.width.characters.attribute"/>
+    </define>
+    <define name="db.informalexample.floatstyle.attribute">
+      <ref name="db.floatstyle.attribute"/>
+    </define>
+    <define name="db.informalexample.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.informalexample.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.informalexample.floatstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.informalexample.width.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.informalexample.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.informalexample">
+      <element name="informalexample">
+        <a:documentation>A displayed example without a title</a:documentation>
+        <ref name="db.informalexample.attlist"/>
+        <ref name="db.informalexample.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <define name="db.verbatim.inlines">
+    <choice>
+      <choice>
+        <ref name="db.all.inlines"/>
+        <ref name="db.lineannotation"/>
+      </choice>
+      <ref name="db.co"/>
+    </choice>
+  </define>
+  <define name="db.verbatim.contentmodel">
+    <ref name="db._info.title.forbidden"/>
+    <choice>
+      <ref name="db.textobject"/>
+      <zeroOrMore>
+        <ref name="db.verbatim.inlines"/>
+      </zeroOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.literallayout.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.literallayout.class.enumeration">
+      <choice>
+        <value>monospaced</value>
+        <a:documentation>The literal layout should be formatted with a monospaced font</a:documentation>
+        <value>normal</value>
+        <a:documentation>The literal layout should be formatted with the current font</a:documentation>
+      </choice>
+    </define>
+    <define name="db.literallayout.class.attribute">
+      <attribute name="class">
+        <a:documentation>Specifies the class of literal layout</a:documentation>
+        <ref name="db.literallayout.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.literallayout.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.literallayout.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+        <optional>
+          <ref name="db.literallayout.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.literallayout">
+      <element name="literallayout">
+        <a:documentation>A block of text in which line breaks and white space are to be reproduced faithfully</a:documentation>
+        <ref name="db.literallayout.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.screen.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.screen.width.attribute">
+      <ref name="db.width.characters.attribute"/>
+    </define>
+    <define name="db.screen.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.screen.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+        <optional>
+          <ref name="db.screen.width.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.screen">
+      <element name="screen">
+        <a:documentation>Text that a user sees or might see on a computer screen</a:documentation>
+        <ref name="db.screen.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.screenshot.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.screenshot.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.screenshot.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.screenshot.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.screenshot">
+      <element name="screenshot">
+        <a:documentation>A representation of what the user sees or might see on a computer screen</a:documentation>
+        <ref name="db.screenshot.attlist"/>
+        <ref name="db.screenshot.info"/>
+        <ref name="db.mediaobject"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.figure.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.figure.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.figure.pgwide.attribute">
+      <ref name="db.pgwide.attribute"/>
+    </define>
+    <define name="db.figure.floatstyle.attribute">
+      <ref name="db.floatstyle.attribute"/>
+    </define>
+    <define name="db.figure.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.figure.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.figure.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.figure.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.figure.floatstyle.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.figure.info">
+      <ref name="db._info.title.onlyreq"/>
+    </define>
+    <define name="db.figure">
+      <element name="figure">
+        <a:documentation>A formal figure, generally an illustration, with a title</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:figure">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of figure</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.figure.attlist"/>
+        <ref name="db.figure.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.informalfigure.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.informalfigure.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.informalfigure.pgwide.attribute">
+      <ref name="db.pgwide.attribute"/>
+    </define>
+    <define name="db.informalfigure.floatstyle.attribute">
+      <ref name="db.floatstyle.attribute"/>
+    </define>
+    <define name="db.informalfigure.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.informalfigure.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.informalfigure.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.informalfigure.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.informalfigure.floatstyle.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.informalfigure.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.informalfigure">
+      <element name="informalfigure">
+        <a:documentation>A untitled figure</a:documentation>
+        <ref name="db.informalfigure.attlist"/>
+        <ref name="db.informalfigure.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <define name="db.mediaobject.content">
+    <choice>
+      <choice>
+        <ref name="db.videoobject"/>
+        <ref name="db.audioobject"/>
+        <ref name="db.imageobject"/>
+        <ref name="db.textobject"/>
+      </choice>
+      <ref name="db.imageobjectco"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.mediaobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.mediaobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.mediaobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.mediaobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.mediaobject">
+      <element name="mediaobject">
+        <a:documentation>A displayed media object (video, audio, image, etc.)</a:documentation>
+        <ref name="db.mediaobject.attlist"/>
+        <ref name="db.mediaobject.info"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.mediaobject.content"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.inlinemediaobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.inlinemediaobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.inlinemediaobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.inlinemediaobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.inlinemediaobject">
+      <element name="inlinemediaobject">
+        <a:documentation>An inline media object (video, audio, image, and so on)</a:documentation>
+        <ref name="db.inlinemediaobject.attlist"/>
+        <ref name="db.inlinemediaobject.info"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.mediaobject.content"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.videoobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.videoobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.videoobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.videoobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.videoobject">
+      <element name="videoobject">
+        <a:documentation>A wrapper for video data and its associated meta-information</a:documentation>
+        <ref name="db.videoobject.attlist"/>
+        <ref name="db.videoobject.info"/>
+        <ref name="db.videodata"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.audioobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.audioobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.audioobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.audioobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.audioobject">
+      <element name="audioobject">
+        <a:documentation>A wrapper for audio data and its associated meta-information</a:documentation>
+        <ref name="db.audioobject.attlist"/>
+        <ref name="db.audioobject.info"/>
+        <ref name="db.audiodata"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.imageobject.content">
+    <choice>
+      <ref name="db.imagedata"/>
+      <ref name="db.imagedata.mathml"/>
+      <ref name="db.imagedata.svg"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.imageobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.imageobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.imageobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.imageobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.imageobject">
+      <element name="imageobject">
+        <a:documentation>A wrapper for image data and its associated meta-information</a:documentation>
+        <ref name="db.imageobject.attlist"/>
+        <ref name="db.imageobject.info"/>
+        <ref name="db.imageobject.content"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.textobject.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.textobject.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.textobject.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.textobject.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.textobject">
+      <element name="textobject">
+        <a:documentation>A wrapper for a text description of an object and its associated meta-information</a:documentation>
+        <ref name="db.textobject.attlist"/>
+        <ref name="db.textobject.info"/>
+        <choice>
+          <ref name="db.phrase"/>
+          <ref name="db.textdata"/>
+          <oneOrMore>
+            <ref name="db.all.blocks"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.videodata.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.videodata.align.enumeration">
+      <ref name="db.halign.enumeration"/>
+    </define>
+    <define name="db.videodata.align.attribute">
+      <attribute name="align">
+        <a:documentation>Specifies the (horizontal) alignment of the video data</a:documentation>
+        <ref name="db.videodata.align.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.videodata.valign.enumeration">
+      <ref name="db.valign.enumeration"/>
+    </define>
+    <define name="db.videodata.valign.attribute">
+      <attribute name="valign">
+        <a:documentation>Specifies the vertical alignment of the video data</a:documentation>
+        <ref name="db.videodata.valign.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.videodata.width.attribute">
+      <ref name="db.width.attribute"/>
+    </define>
+    <define name="db.videodata.depth.attribute">
+      <ref name="db.depth.attribute"/>
+    </define>
+    <define name="db.videodata.contentwidth.attribute">
+      <ref name="db.contentwidth.attribute"/>
+    </define>
+    <define name="db.videodata.contentdepth.attribute">
+      <ref name="db.contentdepth.attribute"/>
+    </define>
+    <define name="db.videodata.scalefit.enumeration">
+      <ref name="db.scalefit.enumeration"/>
+    </define>
+    <define name="db.videodata.scalefit.attribute">
+      <attribute name="scalefit">
+        <a:documentation>Determines if anamorphic scaling is forbidden</a:documentation>
+        <ref name="db.videodata.scalefit.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.videodata.scale.attribute">
+      <ref name="db.scale.attribute"/>
+    </define>
+    <define name="db.videodata.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.videodata.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.data.attributes"/>
+        <optional>
+          <ref name="db.videodata.align.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.valign.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.width.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.contentwidth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.scalefit.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.scale.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.depth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.videodata.contentdepth.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.videodata.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.videodata">
+      <element name="videodata">
+        <a:documentation>Pointer to external video data</a:documentation>
+        <ref name="db.videodata.attlist"/>
+        <ref name="db.videodata.info"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.audiodata.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.audiodata.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.audiodata.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.data.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.audiodata.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.audiodata">
+      <element name="audiodata">
+        <a:documentation>Pointer to external audio data</a:documentation>
+        <ref name="db.audiodata.attlist"/>
+        <ref name="db.audiodata.info"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.imagedata.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.imagedata.align.enumeration">
+      <ref name="db.halign.enumeration"/>
+    </define>
+    <define name="db.imagedata.align.attribute">
+      <attribute name="align">
+        <a:documentation>Specifies the (horizontal) alignment of the image data</a:documentation>
+        <ref name="db.imagedata.align.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.imagedata.valign.enumeration">
+      <ref name="db.valign.enumeration"/>
+    </define>
+    <define name="db.imagedata.valign.attribute">
+      <attribute name="valign">
+        <a:documentation>Specifies the vertical alignment of the image data</a:documentation>
+        <ref name="db.imagedata.valign.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.imagedata.width.attribute">
+      <ref name="db.width.attribute"/>
+    </define>
+    <define name="db.imagedata.depth.attribute">
+      <ref name="db.depth.attribute"/>
+    </define>
+    <define name="db.imagedata.contentwidth.attribute">
+      <ref name="db.contentwidth.attribute"/>
+    </define>
+    <define name="db.imagedata.contentdepth.attribute">
+      <ref name="db.contentdepth.attribute"/>
+    </define>
+    <define name="db.imagedata.scalefit.enumeration">
+      <ref name="db.scalefit.enumeration"/>
+    </define>
+    <define name="db.imagedata.scalefit.attribute">
+      <attribute name="scalefit">
+        <a:documentation>Determines if anamorphic scaling is forbidden</a:documentation>
+        <ref name="db.imagedata.scalefit.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.imagedata.scale.attribute">
+      <ref name="db.scale.attribute"/>
+    </define>
+    <define name="db.imagedata.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.imagedata.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.data.attributes"/>
+        <optional>
+          <ref name="db.imagedata.align.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.valign.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.width.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentwidth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scalefit.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scale.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.depth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentdepth.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.imagedata.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.imagedata">
+      <element name="imagedata">
+        <a:documentation>Pointer to external image data</a:documentation>
+        <ref name="db.imagedata.attlist"/>
+        <ref name="db.imagedata.info"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.textdata.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.textdata.encoding.attribute">
+      <attribute name="encoding">
+        <a:documentation>Identifies the encoding of the text in the external file</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.textdata.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.textdata.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.data.attributes"/>
+        <optional>
+          <ref name="db.textdata.encoding.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.textdata.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.textdata">
+      <element name="textdata">
+        <a:documentation>Pointer to external text data</a:documentation>
+        <ref name="db.textdata.attlist"/>
+        <ref name="db.textdata.info"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.caption.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.caption.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.caption.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.caption.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.caption">
+      <element name="caption">
+        <a:documentation>A caption</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:sidebar)">sidebar must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:task)">task must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.caption.attlist"/>
+        <ref name="db.caption.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.address.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.address.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.address.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.address">
+      <element name="address">
+        <a:documentation>A real-world address, generally a postal address</a:documentation>
+        <ref name="db.address.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.personname"/>
+            <ref name="db.pob"/>
+            <ref name="db.street"/>
+            <ref name="db.city"/>
+            <ref name="db.state"/>
+            <ref name="db.postcode"/>
+            <ref name="db.country"/>
+            <ref name="db.phone"/>
+            <ref name="db.fax"/>
+            <ref name="db.email"/>
+            <ref name="db.uri"/>
+            <ref name="db.otheraddr"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.street.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.street.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.street.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.street">
+      <element name="street">
+        <a:documentation>A street address in an address</a:documentation>
+        <ref name="db.street.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.pob.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.pob.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.pob.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.pob">
+      <element name="pob">
+        <a:documentation>A post office box in an address</a:documentation>
+        <ref name="db.pob.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.postcode.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.postcode.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.postcode.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.postcode">
+      <element name="postcode">
+        <a:documentation>A postal code in an address</a:documentation>
+        <ref name="db.postcode.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.city.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.city.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.city.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.city">
+      <element name="city">
+        <a:documentation>The name of a city in an address</a:documentation>
+        <ref name="db.city.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.state.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.state.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.state.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.state">
+      <element name="state">
+        <a:documentation>A state or province in an address</a:documentation>
+        <ref name="db.state.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.country.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.country.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.country.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.country">
+      <element name="country">
+        <a:documentation>The name of a country</a:documentation>
+        <ref name="db.country.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.phone.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.phone.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.phone.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.phone">
+      <element name="phone">
+        <a:documentation>A telephone number</a:documentation>
+        <ref name="db.phone.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.fax.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.fax.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.fax.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.fax">
+      <element name="fax">
+        <a:documentation>A fax number</a:documentation>
+        <ref name="db.fax.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.otheraddr.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.otheraddr.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.otheraddr.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.otheraddr">
+      <element name="otheraddr">
+        <a:documentation>Uncategorized information in address</a:documentation>
+        <ref name="db.otheraddr.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.affiliation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.affiliation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.affiliation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.affiliation">
+      <element name="affiliation">
+        <a:documentation>The institutional affiliation of an individual</a:documentation>
+        <ref name="db.affiliation.attlist"/>
+        <optional>
+          <ref name="db.shortaffil"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.jobtitle"/>
+        </zeroOrMore>
+        <choice>
+          <optional>
+            <ref name="db.org"/>
+          </optional>
+          <group>
+            <optional>
+              <ref name="db.orgname"/>
+            </optional>
+            <zeroOrMore>
+              <ref name="db.orgdiv"/>
+            </zeroOrMore>
+            <zeroOrMore>
+              <ref name="db.address"/>
+            </zeroOrMore>
+          </group>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.shortaffil.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.shortaffil.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.shortaffil.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.shortaffil">
+      <element name="shortaffil">
+        <a:documentation>A brief description of an affiliation</a:documentation>
+        <ref name="db.shortaffil.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.jobtitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.jobtitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.jobtitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.jobtitle">
+      <element name="jobtitle">
+        <a:documentation>The title of an individual in an organization</a:documentation>
+        <ref name="db.jobtitle.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.orgname.class.enumeration">
+      <choice>
+        <value>consortium</value>
+        <a:documentation>A consortium</a:documentation>
+        <value>corporation</value>
+        <a:documentation>A corporation</a:documentation>
+        <value>informal</value>
+        <a:documentation>An informal organization</a:documentation>
+        <value>nonprofit</value>
+        <a:documentation>A non-profit organization</a:documentation>
+      </choice>
+    </define>
+    <define name="db.orgname.class-enum.attribute">
+      <attribute name="class">
+        <a:documentation>Specifies the nature of the organization</a:documentation>
+        <ref name="db.orgname.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.orgname.class-other.attributes">
+      <attribute name="class">
+        <a:documentation>Specifies the nature of the organization</a:documentation>
+        <value>other</value>
+        <a:documentation>Indicates a non-standard organization class</a:documentation>
+      </attribute>
+      <attribute name="otherclass">
+        <a:documentation>Identifies the non-standard nature of the organization</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.orgname.class.attribute">
+      <choice>
+        <ref name="db.orgname.class-enum.attribute"/>
+        <ref name="db.orgname.class-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.orgname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.orgname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.orgname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.orgname.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.orgname">
+      <element name="orgname">
+        <a:documentation>The name of an organization</a:documentation>
+        <ref name="db.orgname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.orgdiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.orgdiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.orgdiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.orgdiv">
+      <element name="orgdiv">
+        <a:documentation>A division of an organization</a:documentation>
+        <ref name="db.orgdiv.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.artpagenums.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.artpagenums.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.artpagenums.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.artpagenums">
+      <element name="artpagenums">
+        <a:documentation>The page numbers of an article as published</a:documentation>
+        <ref name="db.artpagenums.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.personname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.personname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.personname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.personname">
+      <element name="personname">
+        <a:documentation>The personal name of an individual</a:documentation>
+        <ref name="db.personname.attlist"/>
+        <choice>
+          <ref name="db._text"/>
+          <oneOrMore>
+            <choice>
+              <ref name="db.honorific"/>
+              <ref name="db.firstname"/>
+              <ref name="db.surname"/>
+              <ref name="db.lineage"/>
+              <ref name="db.othername"/>
+            </choice>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <define name="db.person.author.contentmodel">
+    <ref name="db.personname"/>
+    <zeroOrMore>
+      <choice>
+        <ref name="db.personblurb"/>
+        <ref name="db.affiliation"/>
+        <ref name="db.email"/>
+        <ref name="db.uri"/>
+        <ref name="db.address"/>
+        <ref name="db.contrib"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="db.org.author.contentmodel">
+    <ref name="db.orgname"/>
+    <zeroOrMore>
+      <choice>
+        <ref name="db.orgdiv"/>
+        <ref name="db.affiliation"/>
+        <ref name="db.email"/>
+        <ref name="db.uri"/>
+        <ref name="db.address"/>
+        <ref name="db.contrib"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="db.credit.contentmodel">
+    <choice>
+      <ref name="db.person.author.contentmodel"/>
+      <ref name="db.org.author.contentmodel"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.author.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.author.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.author.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.author">
+      <element name="author">
+        <a:documentation>The name of an individual author</a:documentation>
+        <ref name="db.author.attlist"/>
+        <ref name="db.credit.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.authorgroup.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.authorgroup.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.authorgroup.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.authorgroup">
+      <element name="authorgroup">
+        <a:documentation>Wrapper for author information when a document has multiple authors or collabarators</a:documentation>
+        <ref name="db.authorgroup.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.author"/>
+            <ref name="db.editor"/>
+            <ref name="db.othercredit"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.collab.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.collab.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.collab.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.collab">
+      <element name="collab">
+        <a:documentation>Identifies a collaborator</a:documentation>
+        <ref name="db.collab.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.person"/>
+            <ref name="db.personname"/>
+            <ref name="db.org"/>
+            <ref name="db.orgname"/>
+          </choice>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.affiliation"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.authorinitials.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.authorinitials.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.authorinitials.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.authorinitials">
+      <element name="authorinitials">
+        <a:documentation>The initials or other short identifier for an author</a:documentation>
+        <ref name="db.authorinitials.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.person.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.person.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.person.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.person">
+      <element name="person">
+        <a:documentation>A person and associated metadata</a:documentation>
+        <ref name="db.person.attlist"/>
+        <ref name="db.personname"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.address"/>
+            <ref name="db.affiliation"/>
+            <ref name="db.email"/>
+            <ref name="db.uri"/>
+            <ref name="db.personblurb"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.org.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.org.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.org.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.org">
+      <element name="org">
+        <a:documentation>An organization and associated metadata</a:documentation>
+        <ref name="db.org.attlist"/>
+        <ref name="db.orgname"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.address"/>
+            <ref name="db.affiliation"/>
+            <ref name="db.email"/>
+            <ref name="db.uri"/>
+            <ref name="db.orgdiv"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.confgroup.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.confgroup.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.confgroup.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.confgroup">
+      <element name="confgroup">
+        <a:documentation>A wrapper for document meta-information about a conference</a:documentation>
+        <ref name="db.confgroup.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.confdates"/>
+            <ref name="db.conftitle"/>
+            <ref name="db.confnum"/>
+            <ref name="db.confsponsor"/>
+            <ref name="db.address"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.confdates.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.confdates.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.confdates.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.confdates">
+      <element name="confdates">
+        <a:documentation>The dates of a conference for which a document was written</a:documentation>
+        <ref name="db.confdates.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.conftitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.conftitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.conftitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.conftitle">
+      <element name="conftitle">
+        <a:documentation>The title of a conference for which a document was written</a:documentation>
+        <ref name="db.conftitle.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.confnum.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.confnum.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.confnum.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.confnum">
+      <element name="confnum">
+        <a:documentation>An identifier, frequently numerical, associated with a conference for which a document was written</a:documentation>
+        <ref name="db.confnum.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.confsponsor.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.confsponsor.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.confsponsor.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.confsponsor">
+      <element name="confsponsor">
+        <a:documentation>The sponsor of a conference for which a document was written</a:documentation>
+        <ref name="db.confsponsor.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.contractnum.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.contractnum.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.contractnum.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.contractnum">
+      <element name="contractnum">
+        <a:documentation>The contract number of a document</a:documentation>
+        <ref name="db.contractnum.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.contractsponsor.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.contractsponsor.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.contractsponsor.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.contractsponsor">
+      <element name="contractsponsor">
+        <a:documentation>The sponsor of a contract</a:documentation>
+        <ref name="db.contractsponsor.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.copyright.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.copyright.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.copyright.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.copyright">
+      <element name="copyright">
+        <a:documentation>Copyright information about a document</a:documentation>
+        <ref name="db.copyright.attlist"/>
+        <oneOrMore>
+          <ref name="db.year"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.holder"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.year.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.year.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.year.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.year">
+      <element name="year">
+        <a:documentation>The year of publication of a document</a:documentation>
+        <ref name="db.year.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.holder.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.holder.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.holder.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.holder">
+      <element name="holder">
+        <a:documentation>The name of the individual or organization that holds a copyright</a:documentation>
+        <ref name="db.holder.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.cover.contentmodel">
+    <choice>
+      <choice>
+        <ref name="db.para.blocks"/>
+        <ref name="db.extension.blocks"/>
+        <ref name="db.list.blocks"/>
+        <ref name="db.informal.blocks"/>
+        <ref name="db.publishing.blocks"/>
+        <ref name="db.graphic.blocks"/>
+        <ref name="db.technical.blocks"/>
+        <ref name="db.verbatim.blocks"/>
+        <ref name="db.bridgehead"/>
+        <ref name="db.remark"/>
+        <ref name="db.revhistory"/>
+      </choice>
+      <ref name="db.synopsis.blocks"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.cover.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cover.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cover.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.cover">
+      <element name="cover">
+        <a:documentation>Additional content for the cover of a publication</a:documentation>
+        <ref name="db.cover.attlist"/>
+        <oneOrMore>
+          <ref name="db.cover.contentmodel"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.date.contentmodel">
+    <choice>
+      <data type="date"/>
+      <data type="dateTime"/>
+      <data type="gYearMonth"/>
+      <data type="gYear"/>
+      <text/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.date.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.date.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.date.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.date">
+      <element name="date">
+        <a:documentation>The date of publication or revision of a document</a:documentation>
+        <ref name="db.date.attlist"/>
+        <ref name="db.date.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.edition.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.edition.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.edition.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.edition">
+      <element name="edition">
+        <a:documentation>The name or number of an edition of a document</a:documentation>
+        <ref name="db.edition.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.editor.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.editor.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.editor.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.editor">
+      <element name="editor">
+        <a:documentation>The name of the editor of a document</a:documentation>
+        <ref name="db.editor.attlist"/>
+        <ref name="db.credit.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.biblioid.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.biblioid.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.biblioid.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.biblio.class.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.biblioid">
+      <element name="biblioid">
+        <a:documentation>An identifier for a document</a:documentation>
+        <ref name="db.biblioid.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.citebiblioid.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.citebiblioid.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.citebiblioid.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.biblio.class.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.citebiblioid">
+      <element name="citebiblioid">
+        <a:documentation>A citation of a bibliographic identifier</a:documentation>
+        <ref name="db.citebiblioid.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliosource.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliosource.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliosource.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.biblio.class.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.bibliosource">
+      <element name="bibliosource">
+        <a:documentation>The source of a document</a:documentation>
+        <ref name="db.bibliosource.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliorelation.type.enumeration">
+      <choice>
+        <value>hasformat</value>
+        <a:documentation>The described resource pre-existed the referenced resource, which is essentially the same intellectual content presented in another format</a:documentation>
+        <value>haspart</value>
+        <a:documentation>The described resource includes the referenced resource either physically or logically</a:documentation>
+        <value>hasversion</value>
+        <a:documentation>The described resource has a version, edition, or adaptation, namely, the referenced resource</a:documentation>
+        <value>isformatof</value>
+        <a:documentation>The described resource is the same intellectual content of the referenced resource, but presented in another format</a:documentation>
+        <value>ispartof</value>
+        <a:documentation>The described resource is a physical or logical part of the referenced resource</a:documentation>
+        <value>isreferencedby</value>
+        <a:documentation>The described resource is referenced, cited, or otherwise pointed to by the referenced resource</a:documentation>
+        <value>isreplacedby</value>
+        <a:documentation>The described resource is supplanted, displaced, or superceded by the referenced resource</a:documentation>
+        <value>isrequiredby</value>
+        <a:documentation>The described resource is required by the referenced resource, either physically or logically</a:documentation>
+        <value>isversionof</value>
+        <a:documentation>The described resource is a version, edition, or adaptation of the referenced resource; changes in version imply substantive changes in content rather than differences in format</a:documentation>
+        <value>references</value>
+        <a:documentation>The described resource references, cites, or otherwise points to the referenced resource</a:documentation>
+        <value>replaces</value>
+        <a:documentation>The described resource supplants, displaces, or supersedes the referenced resource</a:documentation>
+        <value>requires</value>
+        <a:documentation>The described resource requires the referenced resource to support its function, delivery, or coherence of content</a:documentation>
+      </choice>
+    </define>
+    <define name="db.bibliorelation.type-enum.attribute">
+      <optional>
+        <attribute name="type">
+          <a:documentation>Identifies the type of relationship</a:documentation>
+          <ref name="db.bibliorelation.type.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.bibliorelation.type-other.attributes">
+      <optional>
+        <attribute name="type">
+          <a:documentation>Identifies the type of relationship</a:documentation>
+          <value>othertype</value>
+          <a:documentation>The described resource has a non-standard relationship with the referenced resource</a:documentation>
+        </attribute>
+      </optional>
+      <attribute name="othertype">
+        <a:documentation>A keyword that identififes the type of the non-standard relationship</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.bibliorelation.type.attribute">
+      <choice>
+        <ref name="db.bibliorelation.type-enum.attribute"/>
+        <ref name="db.bibliorelation.type-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.bibliorelation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliorelation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliorelation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.biblio.class.attribute"/>
+        <ref name="db.bibliorelation.type.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.bibliorelation">
+      <element name="bibliorelation">
+        <a:documentation>The relationship of a document to another</a:documentation>
+        <ref name="db.bibliorelation.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliocoverage.spacial.enumeration">
+      <choice>
+        <value>dcmipoint</value>
+        <a:documentation>The DCMI Point identifies a point in space using its geographic coordinates</a:documentation>
+        <value>iso3166</value>
+        <a:documentation>ISO 3166 Codes for the representation of names of countries</a:documentation>
+        <value>dcmibox</value>
+        <a:documentation>The DCMI Box identifies a region of space using its geographic limits</a:documentation>
+        <value>tgn</value>
+        <a:documentation>The Getty Thesaurus of Geographic Names</a:documentation>
+      </choice>
+    </define>
+    <define name="db.bibliocoverage.spatial-enum.attribute">
+      <optional>
+        <attribute name="spatial">
+          <a:documentation>Specifies the type of spatial coverage</a:documentation>
+          <ref name="db.bibliocoverage.spacial.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.bibliocoverage.spatial-other.attributes">
+      <optional>
+        <attribute name="spatial">
+          <a:documentation>Specifies the type of spatial coverage</a:documentation>
+          <value>otherspatial</value>
+          <a:documentation>Identifies a non-standard type of coverage</a:documentation>
+        </attribute>
+      </optional>
+      <attribute name="otherspatial">
+        <a:documentation>A keyword that identifies the type of non-standard coverage</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.bibliocoverage.spatial.attribute">
+      <choice>
+        <ref name="db.bibliocoverage.spatial-enum.attribute"/>
+        <ref name="db.bibliocoverage.spatial-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.bibliocoverage.temporal.enumeration">
+      <choice>
+        <value>dcmiperiod</value>
+        <a:documentation>A specification of the limits of a time interval</a:documentation>
+        <value>w3c-dtf</value>
+        <a:documentation>W3C Encoding rules for dates and times—a profile based on ISO 8601</a:documentation>
+      </choice>
+    </define>
+    <define name="db.bibliocoverage.temporal-enum.attribute">
+      <optional>
+        <attribute name="temporal">
+          <a:documentation>Specifies the type of temporal coverage</a:documentation>
+          <ref name="db.bibliocoverage.temporal.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.bibliocoverage.temporal-other.attributes">
+      <optional>
+        <attribute name="temporal">
+          <a:documentation>Specifies the type of temporal coverage</a:documentation>
+          <value>othertemporal</value>
+          <a:documentation>Specifies a non-standard type of coverage</a:documentation>
+        </attribute>
+      </optional>
+      <attribute name="othertemporal">
+        <a:documentation>A keyword that identifies the type of non-standard coverage</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.bibliocoverage.temporal.attribute">
+      <choice>
+        <ref name="db.bibliocoverage.temporal-enum.attribute"/>
+        <ref name="db.bibliocoverage.temporal-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.bibliocoverage.coverage.attrib">
+      <interleave>
+        <ref name="db.bibliocoverage.spatial.attribute"/>
+        <ref name="db.bibliocoverage.temporal.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.bibliocoverage.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliocoverage.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliocoverage.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.bibliocoverage.coverage.attrib"/>
+      </interleave>
+    </define>
+    <define name="db.bibliocoverage">
+      <element name="bibliocoverage">
+        <a:documentation>The spatial or temporal coverage of a document</a:documentation>
+        <ref name="db.bibliocoverage.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.legalnotice.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.legalnotice.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.legalnotice.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.legalnotice.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.legalnotice">
+      <element name="legalnotice">
+        <a:documentation>A statement of legal obligations or requirements</a:documentation>
+        <ref name="db.legalnotice.attlist"/>
+        <ref name="db.legalnotice.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.othercredit.class.enumeration">
+      <choice>
+        <value>copyeditor</value>
+        <a:documentation>A copy editor</a:documentation>
+        <value>graphicdesigner</value>
+        <a:documentation>A graphic designer</a:documentation>
+        <value>other</value>
+        <a:documentation>Some other contributor</a:documentation>
+        <value>productioneditor</value>
+        <a:documentation>A production editor</a:documentation>
+        <value>technicaleditor</value>
+        <a:documentation>A technical editor</a:documentation>
+        <value>translator</value>
+        <a:documentation>A translator</a:documentation>
+      </choice>
+    </define>
+    <define name="db.othercredit.class-enum.attribute">
+      <optional>
+        <attribute name="class">
+          <a:documentation>Identifies the nature of the contributor</a:documentation>
+          <ref name="db.othercredit.class.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.othercredit.class-other.attribute">
+      <attribute name="otherclass">
+        <a:documentation>Identifies the nature of the non-standard contribution</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </define>
+    <define name="db.othercredit.class-other.attributes">
+      <interleave>
+        <attribute name="class">
+          <a:documentation>Identifies the nature of the contributor</a:documentation>
+          <value>other</value>
+          <a:documentation>Identifies a non-standard contribution</a:documentation>
+        </attribute>
+        <ref name="db.othercredit.class-other.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.othercredit.class.attribute">
+      <choice>
+        <ref name="db.othercredit.class-enum.attribute"/>
+        <ref name="db.othercredit.class-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.othercredit.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.othercredit.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.othercredit.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.othercredit.class.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.othercredit">
+      <element name="othercredit">
+        <a:documentation>A person or entity, other than an author or editor, credited in a document</a:documentation>
+        <ref name="db.othercredit.attlist"/>
+        <ref name="db.credit.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.pagenums.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.pagenums.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.pagenums.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.pagenums">
+      <element name="pagenums">
+        <a:documentation>The numbers of the pages in a book, for use in a bibliographic entry</a:documentation>
+        <ref name="db.pagenums.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.contrib.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.contrib.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.contrib.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.contrib">
+      <element name="contrib">
+        <a:documentation>A summary of the contributions made to a document by a credited source</a:documentation>
+        <ref name="db.contrib.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.honorific.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.honorific.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.honorific.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.honorific">
+      <element name="honorific">
+        <a:documentation>The title of a person</a:documentation>
+        <ref name="db.honorific.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.firstname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.firstname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.firstname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.firstname">
+      <element name="firstname">
+        <a:documentation>The first name of a person</a:documentation>
+        <ref name="db.firstname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.surname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.surname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.surname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.surname">
+      <element name="surname">
+        <a:documentation>A family name; in western cultures the last name</a:documentation>
+        <ref name="db.surname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.lineage.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.lineage.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.lineage.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.lineage">
+      <element name="lineage">
+        <a:documentation>The portion of a person's name indicating a relationship to ancestors</a:documentation>
+        <ref name="db.lineage.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.othername.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.othername.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.othername.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.othername">
+      <element name="othername">
+        <a:documentation>A component of a persons name that is not a first name, surname, or lineage</a:documentation>
+        <ref name="db.othername.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.printhistory.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.printhistory.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.printhistory.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.printhistory">
+      <element name="printhistory">
+        <a:documentation>The printing history of a document</a:documentation>
+        <ref name="db.printhistory.attlist"/>
+        <oneOrMore>
+          <ref name="db.para.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.pubdate.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.pubdate.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.pubdate.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.pubdate">
+      <element name="pubdate">
+        <a:documentation>The date of publication of a document</a:documentation>
+        <ref name="db.pubdate.attlist"/>
+        <ref name="db.date.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.publisher.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.publisher.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.publisher.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.publisher">
+      <element name="publisher">
+        <a:documentation>The publisher of a document</a:documentation>
+        <ref name="db.publisher.attlist"/>
+        <ref name="db.publishername"/>
+        <zeroOrMore>
+          <ref name="db.address"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.publishername.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.publishername.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.publishername.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.publishername">
+      <element name="publishername">
+        <a:documentation>The name of the publisher of a document</a:documentation>
+        <ref name="db.publishername.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.releaseinfo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.releaseinfo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.releaseinfo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.releaseinfo">
+      <element name="releaseinfo">
+        <a:documentation>Information about a particular release of a document</a:documentation>
+        <ref name="db.releaseinfo.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.revhistory.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.revhistory.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.revhistory.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.revhistory.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.revhistory">
+      <element name="revhistory">
+        <a:documentation>A history of the revisions to a document</a:documentation>
+        <ref name="db.revhistory.attlist"/>
+        <ref name="db.revhistory.info"/>
+        <oneOrMore>
+          <ref name="db.revision"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.revision.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.revision.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.revision.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.revision">
+      <element name="revision">
+        <a:documentation>An entry describing a single revision in the history of the revisions to a document</a:documentation>
+        <ref name="db.revision.attlist"/>
+        <optional>
+          <ref name="db.revnumber"/>
+        </optional>
+        <ref name="db.date"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.authorinitials"/>
+            <ref name="db.author"/>
+          </choice>
+        </zeroOrMore>
+        <optional>
+          <choice>
+            <ref name="db.revremark"/>
+            <ref name="db.revdescription"/>
+          </choice>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.revnumber.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.revnumber.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.revnumber.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.revnumber">
+      <element name="revnumber">
+        <a:documentation>A document revision number</a:documentation>
+        <ref name="db.revnumber.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.revremark.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.revremark.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.revremark.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.revremark">
+      <element name="revremark">
+        <a:documentation>A description of a revision to a document</a:documentation>
+        <ref name="db.revremark.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.revdescription.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.revdescription.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.revdescription.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.revdescription">
+      <element name="revdescription">
+        <a:documentation>A extended description of a revision to a document</a:documentation>
+        <ref name="db.revdescription.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seriesvolnums.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seriesvolnums.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seriesvolnums.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.seriesvolnums">
+      <element name="seriesvolnums">
+        <a:documentation>Numbers of the volumes in a series of books</a:documentation>
+        <ref name="db.seriesvolnums.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.volumenum.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.volumenum.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.volumenum.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.volumenum">
+      <element name="volumenum">
+        <a:documentation>The volume number of a document in a set (as of books in a set or articles in a journal)</a:documentation>
+        <ref name="db.volumenum.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.issuenum.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.issuenum.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.issuenum.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.issuenum">
+      <element name="issuenum">
+        <a:documentation>The number of an issue of a journal</a:documentation>
+        <ref name="db.issuenum.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.package.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.package.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.package.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.package">
+      <element name="package">
+        <a:documentation>A software or application package</a:documentation>
+        <ref name="db.package.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.email.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.email.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.email.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.email">
+      <element name="email">
+        <a:documentation>An email address</a:documentation>
+        <ref name="db.email.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.lineannotation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.lineannotation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.lineannotation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.lineannotation">
+      <element name="lineannotation">
+        <a:documentation>A comment on a line in a verbatim listing</a:documentation>
+        <ref name="db.lineannotation.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.parameter.class.enumeration">
+      <choice>
+        <value>command</value>
+        <a:documentation>A command</a:documentation>
+        <value>function</value>
+        <a:documentation>A function</a:documentation>
+        <value>option</value>
+        <a:documentation>An option</a:documentation>
+      </choice>
+    </define>
+    <define name="db.parameter.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of parameter</a:documentation>
+        <ref name="db.parameter.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.parameter.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.parameter.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.parameter.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.parameter.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.parameter">
+      <element name="parameter">
+        <a:documentation>A value or a symbolic reference to a value</a:documentation>
+        <ref name="db.parameter.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.replaceable.inlines">
+    <choice>
+      <ref name="db._text"/>
+      <ref name="db.co"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.replaceable.class.enumeration">
+      <choice>
+        <value>command</value>
+        <a:documentation>A command</a:documentation>
+        <value>function</value>
+        <a:documentation>A function</a:documentation>
+        <value>option</value>
+        <a:documentation>An option</a:documentation>
+        <value>parameter</value>
+        <a:documentation>A parameter</a:documentation>
+      </choice>
+    </define>
+    <define name="db.replaceable.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the nature of the replaceable text</a:documentation>
+        <ref name="db.replaceable.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.replaceable.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.replaceable.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.replaceable.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.replaceable.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.replaceable">
+      <element name="replaceable">
+        <a:documentation>Content that may or must be replaced by the user</a:documentation>
+        <ref name="db.replaceable.attlist"/>
+        <zeroOrMore>
+          <ref name="db.replaceable.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.uri.type.attribute">
+      <optional>
+        <attribute name="type">
+          <a:documentation>Identifies the type of URI specified</a:documentation>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.uri.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.uri.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.uri.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.uri.type.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.uri">
+      <element name="uri">
+        <a:documentation>A Uniform Resource Identifier</a:documentation>
+        <ref name="db.uri.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.abbrev.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.abbrev.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.abbrev.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.abbrev">
+      <element name="abbrev">
+        <a:documentation>An abbreviation, especially one followed by a period</a:documentation>
+        <ref name="db.abbrev.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+            <ref name="db.trademark"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.acronym.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.acronym.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.acronym.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.acronym">
+      <element name="acronym">
+        <a:documentation>An often pronounceable word made from the initial (or selected) letters of a name or phrase</a:documentation>
+        <ref name="db.acronym.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+            <ref name="db.trademark"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.citation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.citation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.citation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.citation">
+      <element name="citation">
+        <a:documentation>An inline bibliographic reference to another published work</a:documentation>
+        <ref name="db.citation.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.citerefentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.citerefentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.citerefentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.citerefentry">
+      <element name="citerefentry">
+        <a:documentation>A citation to a reference page</a:documentation>
+        <ref name="db.citerefentry.attlist"/>
+        <ref name="db.refentrytitle"/>
+        <optional>
+          <ref name="db.manvolnum"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refentrytitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refentrytitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refentrytitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refentrytitle">
+      <element name="refentrytitle">
+        <a:documentation>The title of a reference page</a:documentation>
+        <ref name="db.refentrytitle.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.manvolnum.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.manvolnum.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.manvolnum.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.manvolnum">
+      <element name="manvolnum">
+        <a:documentation>A reference volume number</a:documentation>
+        <ref name="db.manvolnum.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.citetitle.pubwork.enumeration">
+      <choice>
+        <value>article</value>
+        <a:documentation>An article</a:documentation>
+        <value>bbs</value>
+        <a:documentation>A bulletin board system</a:documentation>
+        <value>book</value>
+        <a:documentation>A book</a:documentation>
+        <value>cdrom</value>
+        <a:documentation>A CD-ROM</a:documentation>
+        <value>chapter</value>
+        <a:documentation>A chapter (as of a book)</a:documentation>
+        <value>dvd</value>
+        <a:documentation>A DVD</a:documentation>
+        <value>emailmessage</value>
+        <a:documentation>An email message</a:documentation>
+        <value>gopher</value>
+        <a:documentation>A gopher page</a:documentation>
+        <value>journal</value>
+        <a:documentation>A journal</a:documentation>
+        <value>manuscript</value>
+        <a:documentation>A manuscript</a:documentation>
+        <value>newsposting</value>
+        <a:documentation>A posting to a newsgroup</a:documentation>
+        <value>part</value>
+        <a:documentation>A part (as of a book)</a:documentation>
+        <value>refentry</value>
+        <a:documentation>A reference entry</a:documentation>
+        <value>section</value>
+        <a:documentation>A section (as of a book or article)</a:documentation>
+        <value>series</value>
+        <a:documentation>A series</a:documentation>
+        <value>set</value>
+        <a:documentation>A set (as of books)</a:documentation>
+        <value>webpage</value>
+        <a:documentation>A web page</a:documentation>
+        <value>wiki</value>
+        <a:documentation>A wiki page</a:documentation>
+      </choice>
+    </define>
+    <define name="db.citetitle.pubwork.attribute">
+      <attribute name="pubwork">
+        <a:documentation>Identifies the nature of the publication being cited</a:documentation>
+        <ref name="db.citetitle.pubwork.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.citetitle.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.citetitle.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.citetitle.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.citetitle.pubwork.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.citetitle">
+      <element name="citetitle">
+        <a:documentation>The title of a cited work</a:documentation>
+        <ref name="db.citetitle.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.emphasis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.emphasis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.emphasis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.emphasis">
+      <element name="emphasis">
+        <a:documentation>Emphasized text</a:documentation>
+        <ref name="db.emphasis.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db._emphasis">
+      <element name="emphasis">
+        <a:documentation>A limited span of emphasized text</a:documentation>
+        <ref name="db.emphasis.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db._emphasis"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.foreignphrase.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.foreignphrase.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.foreignphrase.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.foreignphrase">
+      <element name="foreignphrase">
+        <a:documentation>A word or phrase in a language other than the primary language of the document</a:documentation>
+        <ref name="db.foreignphrase.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="db.general.inlines"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.phrase.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.phrase.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.phrase.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.phrase">
+      <element name="phrase">
+        <a:documentation>A span of text</a:documentation>
+        <ref name="db.phrase.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db._phrase">
+      <element name="phrase">
+        <a:documentation>A limited span of text</a:documentation>
+        <ref name="db.phrase.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.quote.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.quote.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.quote.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.quote">
+      <element name="quote">
+        <a:documentation>An inline quotation</a:documentation>
+        <ref name="db.quote.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.subscript.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.subscript.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.subscript.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.subscript">
+      <element name="subscript">
+        <a:documentation>A subscript (as in H2
+O, the molecular formula for water)</a:documentation>
+        <ref name="db.subscript.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.superscript.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.superscript.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.superscript.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.superscript">
+      <element name="superscript">
+        <a:documentation>A superscript (as in x^2, the mathematical notation for x multiplied by itself)</a:documentation>
+        <ref name="db.superscript.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.trademark.class.enumeration">
+      <choice>
+        <value>copyright</value>
+        <a:documentation>A copyright</a:documentation>
+        <value>registered</value>
+        <a:documentation>A registered copyright</a:documentation>
+        <value>service</value>
+        <a:documentation>A service</a:documentation>
+        <value>trade</value>
+        <a:documentation>A trademark</a:documentation>
+      </choice>
+    </define>
+    <define name="db.trademark.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of trade mark</a:documentation>
+        <ref name="db.trademark.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.trademark.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.trademark.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.trademark.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.trademark.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.trademark">
+      <element name="trademark">
+        <a:documentation>A trademark</a:documentation>
+        <ref name="db.trademark.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.wordasword.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.wordasword.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.wordasword.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.wordasword">
+      <element name="wordasword">
+        <a:documentation>A word meant specifically as a word and not representing anything else</a:documentation>
+        <ref name="db.wordasword.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.footnoteref.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.footnoteref.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.footnoteref.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.footnoteref.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.linkend.attribute"/>
+        <optional>
+          <ref name="db.footnoteref.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.footnoteref">
+      <element name="footnoteref">
+        <a:documentation>A cross reference to a footnote (a footnote mark)</a:documentation>
+        <s:pattern name="Footnote reference type constraint">
+          <s:rule context="db:footnoteref">
+            <s:assert test="local-name(//*[@xml:id=current()/@linkend]) = 'footnote' and namespace-uri(//*[@xml:id=current()/@linkend]) = 'http://docbook.org/ns/docbook'">@linkend on footnoteref must point to a footnote.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.footnoteref.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.xref.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.xref.xrefstyle.attribute">
+      <ref name="db.xrefstyle.attribute"/>
+    </define>
+    <define name="db.xref.endterm.attribute">
+      <ref name="db.endterm.attribute"/>
+    </define>
+    <define name="db.xref.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.xref.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.req.linking.attributes"/>
+        <optional>
+          <ref name="db.xref.xrefstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xref.endterm.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.xref">
+      <element name="xref">
+        <a:documentation>A cross reference to another part of the document</a:documentation>
+        <ref name="db.xref.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.link.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.link.xrefstyle.attribute">
+      <ref name="db.xrefstyle.attribute"/>
+    </define>
+    <define name="db.link.endterm.attribute">
+      <ref name="db.endterm.attribute"/>
+    </define>
+    <define name="db.link.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.link.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.req.linking.attributes"/>
+        <optional>
+          <ref name="db.link.xrefstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.link.endterm.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.link">
+      <element name="link">
+        <a:documentation>A hypertext link</a:documentation>
+        <ref name="db.link.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.olink.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.olink.xrefstyle.attribute">
+      <ref name="db.xrefstyle.attribute"/>
+    </define>
+    <define name="db.olink.localinfo.attribute">
+      <attribute name="localinfo">
+        <a:documentation>Holds additional information that may be used by the applicatoin when resolving the link</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.olink.targetdoc.attribute">
+      <attribute name="targetdoc">
+        <a:documentation>Specifies the URI of the document in which the link target appears</a:documentation>
+        <data type="anyURI"/>
+      </attribute>
+    </define>
+    <define name="db.olink.targetptr.attribute">
+      <attribute name="targetptr">
+        <a:documentation>Specifies the location of the link target in the document</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.olink.type.attribute">
+      <attribute name="type">
+        <a:documentation>Identifies application-specific customization of the link behavior</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.olink.attlist">
+      <interleave>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.olink.targetdoc.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.olink.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.olink.xrefstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.olink.localinfo.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.olink.targetptr.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.olink.type.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.olink">
+      <element name="olink">
+        <a:documentation>A link that addresses its target indirectly</a:documentation>
+        <ref name="db.olink.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.anchor.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.anchor.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.anchor.role.attribute"/>
+        </optional>
+        <ref name="db.common.idreq.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.anchor">
+      <element name="anchor">
+        <a:documentation>A spot in the document</a:documentation>
+        <ref name="db.anchor.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.alt.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.alt.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.alt.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.alt">
+      <element name="alt">
+        <a:documentation>A text-only annotation, often used for accessibility</a:documentation>
+        <ref name="db.alt.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="db.inlinemediaobject"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.status.attribute">
+    <attribute name="status">
+      <a:documentation>Identifies the editorial or publication status of the element on which it occurs</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.toplevel.sections">
+    <choice>
+      <choice>
+        <group>
+          <oneOrMore>
+            <ref name="db.section"/>
+          </oneOrMore>
+          <zeroOrMore>
+            <ref name="db.simplesect"/>
+          </zeroOrMore>
+        </group>
+        <oneOrMore>
+          <ref name="db.simplesect"/>
+        </oneOrMore>
+      </choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.sect1"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.simplesect"/>
+        </zeroOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="db.refentry"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.toplevel.blocks.or.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.toplevel.sections"/>
+        </optional>
+      </group>
+      <ref name="db.toplevel.sections"/>
+    </choice>
+  </define>
+  <define name="db.recursive.sections">
+    <choice>
+      <choice>
+        <group>
+          <oneOrMore>
+            <ref name="db.section"/>
+          </oneOrMore>
+          <zeroOrMore>
+            <ref name="db.simplesect"/>
+          </zeroOrMore>
+        </group>
+        <oneOrMore>
+          <ref name="db.simplesect"/>
+        </oneOrMore>
+      </choice>
+      <oneOrMore>
+        <ref name="db.refentry"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.recursive.blocks.or.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.recursive.sections"/>
+        </optional>
+      </group>
+      <ref name="db.recursive.sections"/>
+    </choice>
+  </define>
+  <define name="db.divisions">
+    <choice>
+      <ref name="db.part"/>
+      <ref name="db.reference"/>
+    </choice>
+  </define>
+  <define name="db.components">
+    <choice>
+      <ref name="db.dedication"/>
+      <ref name="db.acknowledgements"/>
+      <ref name="db.preface"/>
+      <ref name="db.chapter"/>
+      <ref name="db.appendix"/>
+      <ref name="db.article"/>
+      <ref name="db.colophon"/>
+    </choice>
+  </define>
+  <define name="db.navigation.components">
+    <choice>
+      <notAllowed/>
+      <ref name="db.glossary"/>
+      <ref name="db.bibliography"/>
+      <ref name="db.index"/>
+      <ref name="db.toc"/>
+    </choice>
+  </define>
+  <define name="db.component.contentmodel">
+    <zeroOrMore>
+      <ref name="db.navigation.components"/>
+    </zeroOrMore>
+    <ref name="db.toplevel.blocks.or.sections"/>
+    <zeroOrMore>
+      <ref name="db.navigation.components"/>
+    </zeroOrMore>
+  </define>
+  <define name="db.setindex.components">
+    <choice>
+      <notAllowed/>
+      <ref name="db.setindex"/>
+    </choice>
+  </define>
+  <define name="db.toc.components">
+    <choice>
+      <notAllowed/>
+      <ref name="db.toc"/>
+    </choice>
+  </define>
+  <define name="db.set.components">
+    <choice>
+      <ref name="db.set"/>
+      <ref name="db.book"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.set.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.set.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.set.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.set.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.set.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.set.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.set">
+      <element name="set">
+        <a:documentation>A collection of books</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:set">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.set.attlist"/>
+        <ref name="db.set.info"/>
+        <optional>
+          <ref name="db.toc.components"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.set.components"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.setindex.components"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.book.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.book.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.book.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.book.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.book.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.book.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.book">
+      <element name="book">
+        <a:documentation>A book</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:book">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.book.attlist"/>
+        <ref name="db.book.info"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.navigation.components"/>
+            <ref name="db.components"/>
+            <ref name="db.divisions"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.dedication.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.dedication.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.dedication.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.dedication.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.dedication.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.dedication.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.dedication">
+      <element name="dedication">
+        <a:documentation>The dedication of a book or other component</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:dedication">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.dedication.attlist"/>
+        <ref name="db.dedication.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.acknowledgements.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.acknowledgements.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.acknowledgements.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.acknowledgements.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.acknowledgements.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.acknowledgements.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.acknowledgements">
+      <element name="acknowledgements">
+        <a:documentation>Acknowledgements of a book or other component</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:acknowledgements">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.acknowledgements.attlist"/>
+        <ref name="db.acknowledgements.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.colophon.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.colophon.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.colophon.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.colophon.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colophon.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.colophon.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.colophon">
+      <element name="colophon">
+        <a:documentation>Text at the back of a book describing facts about its production</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:colophon">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.colophon.attlist"/>
+        <ref name="db.colophon.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.appendix.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.appendix.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.appendix.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.appendix.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.appendix.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.appendix.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.appendix">
+      <element name="appendix">
+        <a:documentation>An appendix in a Book or Article</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:appendix">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.appendix.attlist"/>
+        <ref name="db.appendix.info"/>
+        <ref name="db.component.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.chapter.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.chapter.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.chapter.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.chapter.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.chapter.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.chapter.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.chapter">
+      <element name="chapter">
+        <a:documentation>A chapter, as of a book</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:chapter">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.chapter.attlist"/>
+        <ref name="db.chapter.info"/>
+        <ref name="db.component.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.part.components">
+    <choice>
+      <choice>
+        <ref name="db.navigation.components"/>
+        <ref name="db.components"/>
+      </choice>
+      <choice>
+        <ref name="db.refentry"/>
+        <ref name="db.reference"/>
+      </choice>
+    </choice>
+  </define>
+  <div>
+    <define name="db.part.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.part.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.part.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.part.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.part.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.part.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.part">
+      <element name="part">
+        <a:documentation>A division in a book</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:part">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.part.attlist"/>
+        <ref name="db.part.info"/>
+        <optional>
+          <ref name="db.partintro"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.part.components"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.preface.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.preface.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.preface.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.preface.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.preface.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.preface.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.preface">
+      <element name="preface">
+        <a:documentation>Introductory matter preceding the first chapter of a book</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:preface">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.preface.attlist"/>
+        <ref name="db.preface.info"/>
+        <ref name="db.component.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.partintro.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.partintro.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.partintro.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.partintro.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.partintro.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.partintro.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.partintro">
+      <element name="partintro">
+        <a:documentation>An introduction to the contents of a part</a:documentation>
+        <ref name="db.partintro.attlist"/>
+        <ref name="db.partintro.info"/>
+        <ref name="db.toplevel.blocks.or.sections"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.section.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.section.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.section.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.section.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.section.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.section.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.section">
+      <element name="section">
+        <a:documentation>A recursive section</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:section">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.section.attlist"/>
+        <ref name="db.section.info"/>
+        <ref name="db.recursive.blocks.or.sections"/>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.simplesect.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.simplesect.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.simplesect.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.simplesect.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.simplesect.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.simplesect.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.simplesect">
+      <element name="simplesect">
+        <a:documentation>A section of a document with no subdivisions</a:documentation>
+        <ref name="db.simplesect.attlist"/>
+        <ref name="db.simplesect.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.article.components">
+    <ref name="db.toplevel.sections"/>
+  </define>
+  <div>
+    <define name="db.article.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.article.class.enumeration">
+      <choice>
+        <value>faq</value>
+        <a:documentation>A collection of frequently asked questions.</a:documentation>
+        <value>journalarticle</value>
+        <a:documentation>An article in a journal or other periodical.</a:documentation>
+        <value>productsheet</value>
+        <a:documentation>A description of a product.</a:documentation>
+        <value>specification</value>
+        <a:documentation>A specification.</a:documentation>
+        <value>techreport</value>
+        <a:documentation>A technical report.</a:documentation>
+        <value>whitepaper</value>
+        <a:documentation>A white paper.</a:documentation>
+      </choice>
+    </define>
+    <define name="db.article.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the nature of the article</a:documentation>
+        <ref name="db.article.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.article.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.article.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.article.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.article.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.article.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.article.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.article">
+      <element name="article">
+        <a:documentation>An article</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:article">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.article.attlist"/>
+        <ref name="db.article.info"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.navigation.components"/>
+            <ref name="db.appendix"/>
+            <ref name="db.acknowledgements"/>
+            <ref name="db.colophon"/>
+          </choice>
+        </zeroOrMore>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.article.components"/>
+            </optional>
+          </group>
+          <ref name="db.article.components"/>
+        </choice>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.navigation.components"/>
+            <ref name="db.appendix"/>
+            <ref name="db.acknowledgements"/>
+            <ref name="db.colophon"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.annotations.attribute">
+    <attribute name="annotations">
+      <a:documentation>Identifies one or more annotations that apply to this element</a:documentation>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.annotation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.annotation.annotates.attribute">
+      <attribute name="annotates">
+        <a:documentation>Identifies one ore more elements to which this annotation applies</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.annotation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.annotation.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.annotation.annotates.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.annotation.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.annotation">
+      <element name="annotation">
+        <a:documentation>An annotation</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:annotation">
+            <s:assert test="not(.//db:annotation)">annotation must not occur in the descendants of annotation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.annotation.attlist"/>
+        <ref name="db.annotation.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.xlink.from.attribute">
+    <optional>
+      <attribute name="xlink:from">
+        <a:documentation>Specifies the XLink traversal-from</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.xlink.label.attribute">
+    <optional>
+      <attribute name="xlink:label">
+        <a:documentation>Specifies the XLink label</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.xlink.to.attribute">
+    <optional>
+      <attribute name="xlink:to">
+        <a:documentation>Specifies the XLink traversal-to</a:documentation>
+        <data type="NMTOKEN"/>
+      </attribute>
+    </optional>
+  </define>
+  <div>
+    <define name="db.extendedlink.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.extendedlink.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.extendedlink.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <attribute name="xlink:type" a:defaultValue="extended">
+            <a:documentation>Identifies the XLink link type </a:documentation>
+            <value>extended</value>
+            <a:documentation>An XLink extended link</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="db.xlink.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.title.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.extendedlink">
+      <element name="extendedlink">
+        <a:documentation>An XLink extended link</a:documentation>
+        <ref name="db.extendedlink.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.locator"/>
+            <ref name="db.arc"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.locator.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.locator.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.locator.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <attribute name="xlink:type" a:defaultValue="locator">
+            <a:documentation>Identifies the XLink link type </a:documentation>
+            <value>locator</value>
+            <a:documentation>An XLink locator link</a:documentation>
+          </attribute>
+        </optional>
+        <ref name="db.xlink.href.attribute"/>
+        <optional>
+          <ref name="db.xlink.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.title.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.locator">
+      <element name="locator">
+        <a:documentation>An XLink locator in an extendedlink</a:documentation>
+        <ref name="db.locator.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.arc.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.arc.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.arc.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <attribute name="xlink:type" a:defaultValue="arc">
+            <a:documentation>Identifies the XLink link type </a:documentation>
+            <value>arc</value>
+            <a:documentation>An XLink arc link</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="db.xlink.arcrole.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.title.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.show.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.actuate.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.from.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.xlink.to.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.arc">
+      <element name="arc">
+        <a:documentation>An XLink arc in an extendedlink</a:documentation>
+        <ref name="db.arc.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <define name="db.sect1.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.sect2"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.simplesect"/>
+        </zeroOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="db.simplesect"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.sect1.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.sect1.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sect1.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sect1.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.sect1.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.sect1.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.sect1">
+      <element name="sect1">
+        <a:documentation>A top-level section of document</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:sect1">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sect1.attlist"/>
+        <ref name="db.sect1.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.sect1.sections"/>
+            </optional>
+          </group>
+          <ref name="db.sect1.sections"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.sect2.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.sect3"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.simplesect"/>
+        </zeroOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="db.simplesect"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.sect2.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.sect2.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sect2.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sect2.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.sect2.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.sect2.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.sect2">
+      <element name="sect2">
+        <a:documentation>A subsection within a Sect1</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:sect2">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sect2.attlist"/>
+        <ref name="db.sect2.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.sect2.sections"/>
+            </optional>
+          </group>
+          <ref name="db.sect2.sections"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.sect3.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.sect4"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.simplesect"/>
+        </zeroOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="db.simplesect"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.sect3.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.sect3.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sect3.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sect3.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.sect3.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.sect3.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.sect3">
+      <element name="sect3">
+        <a:documentation>A subsection within a Sect2</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:sect3">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sect3.attlist"/>
+        <ref name="db.sect3.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.sect3.sections"/>
+            </optional>
+          </group>
+          <ref name="db.sect3.sections"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.sect4.sections">
+    <choice>
+      <group>
+        <oneOrMore>
+          <ref name="db.sect5"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.simplesect"/>
+        </zeroOrMore>
+      </group>
+      <oneOrMore>
+        <ref name="db.simplesect"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.sect4.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.sect4.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sect4.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sect4.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.sect4.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.sect4.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.sect4">
+      <element name="sect4">
+        <a:documentation>A subsection within a Sect3</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:sect4">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sect4.attlist"/>
+        <ref name="db.sect4.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.sect4.sections"/>
+            </optional>
+          </group>
+          <ref name="db.sect4.sections"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.sect5.sections">
+    <oneOrMore>
+      <ref name="db.simplesect"/>
+    </oneOrMore>
+  </define>
+  <div>
+    <define name="db.sect5.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.sect5.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sect5.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sect5.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.sect5.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.sect5.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.sect5">
+      <element name="sect5">
+        <a:documentation>A subsection within a Sect4</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:sect5">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.sect5.attlist"/>
+        <ref name="db.sect5.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.sect5.sections"/>
+            </optional>
+          </group>
+          <ref name="db.sect5.sections"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.navigation.components"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.toplevel.refsection">
+    <choice>
+      <oneOrMore>
+        <ref name="db.refsection"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="db.refsect1"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.secondlevel.refsection">
+    <choice>
+      <oneOrMore>
+        <ref name="db.refsection"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="db.refsect2"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.reference.components">
+    <ref name="db.refentry"/>
+  </define>
+  <div>
+    <define name="db.reference.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.reference.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.reference.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.reference.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.reference">
+      <element name="reference">
+        <a:documentation>A collection of reference entries</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:reference">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.reference.attlist"/>
+        <ref name="db.reference.info"/>
+        <optional>
+          <ref name="db.partintro"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.reference.components"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refentry.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.refentry">
+      <element name="refentry">
+        <a:documentation>A reference page (originally a UNIX man-style reference page)</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:refentry">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.refentry.attlist"/>
+        <zeroOrMore>
+          <ref name="db.indexterm"/>
+        </zeroOrMore>
+        <ref name="db.refentry.info"/>
+        <optional>
+          <ref name="db.refmeta"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.refnamediv"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.refsynopsisdiv"/>
+        </optional>
+        <ref name="db.toplevel.refsection"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refmeta.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refmeta.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refmeta.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refmeta">
+      <element name="refmeta">
+        <a:documentation>Meta-information for a reference entry</a:documentation>
+        <ref name="db.refmeta.attlist"/>
+        <zeroOrMore>
+          <ref name="db.indexterm"/>
+        </zeroOrMore>
+        <ref name="db.refentrytitle"/>
+        <optional>
+          <ref name="db.manvolnum"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.refmiscinfo"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.indexterm"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.refmiscinfo.class.enumeration">
+    <choice>
+      <value>source</value>
+      <a:documentation>The name of the software product or component to which this topic applies</a:documentation>
+      <value>version</value>
+      <a:documentation>The version of the software product or component to which this topic applies</a:documentation>
+      <value>manual</value>
+      <a:documentation>The section title of the reference page (e.g., User Commands)</a:documentation>
+      <value>sectdesc</value>
+      <a:documentation>The section title of the reference page (believed synonymous with "manual" but in wide use)</a:documentation>
+      <value>software</value>
+      <a:documentation>The name of the software product or component to which this topic applies (e.g., SunOS x.y; believed synonymous with "source" but in wide use)</a:documentation>
+    </choice>
+  </define>
+  <define name="db.refmiscinfo.class-enum.attribute">
+    <optional>
+      <attribute name="class">
+        <a:documentation>Identifies the kind of miscellaneous information</a:documentation>
+        <ref name="db.refmiscinfo.class.enumeration"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.refmiscinfo.class-other.attribute">
+    <attribute name="otherclass">
+      <a:documentation>Identifies the nature of non-standard miscellaneous information</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.refmiscinfo.class-other.attributes">
+    <interleave>
+      <attribute name="class">
+        <a:documentation>Identifies the kind of miscellaneious information</a:documentation>
+        <value>other</value>
+        <a:documentation>Indicates that the information is some 'other' kind.</a:documentation>
+      </attribute>
+      <ref name="db.refmiscinfo.class-other.attribute"/>
+    </interleave>
+  </define>
+  <define name="db.refmiscinfo.class.attribute">
+    <choice>
+      <ref name="db.refmiscinfo.class-enum.attribute"/>
+      <ref name="db.refmiscinfo.class-other.attributes"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.refmiscinfo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refmiscinfo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refmiscinfo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.refmiscinfo.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refmiscinfo">
+      <element name="refmiscinfo">
+        <a:documentation>Meta-information for a reference entry other than the title and volume number</a:documentation>
+        <ref name="db.refmiscinfo.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refnamediv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refnamediv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refnamediv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refnamediv">
+      <element name="refnamediv">
+        <a:documentation>The name, purpose, and classification of a reference page</a:documentation>
+        <ref name="db.refnamediv.attlist"/>
+        <optional>
+          <ref name="db.refdescriptor"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.refname"/>
+        </oneOrMore>
+        <ref name="db.refpurpose"/>
+        <zeroOrMore>
+          <ref name="db.refclass"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refdescriptor.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refdescriptor.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refdescriptor.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refdescriptor">
+      <element name="refdescriptor">
+        <a:documentation>A description of the topic of a reference page</a:documentation>
+        <ref name="db.refdescriptor.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refname">
+      <element name="refname">
+        <a:documentation>The name of (one of) the subject(s) of a reference page</a:documentation>
+        <ref name="db.refname.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refpurpose.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refpurpose.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refpurpose.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refpurpose">
+      <element name="refpurpose">
+        <a:documentation>A short (one sentence) synopsis of the topic of a reference page</a:documentation>
+        <ref name="db.refpurpose.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refclass.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refclass.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refclass.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refclass">
+      <element name="refclass">
+        <a:documentation>The scope or other indication of applicability of a reference entry</a:documentation>
+        <ref name="db.refclass.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="db.application"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refsynopsisdiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refsynopsisdiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refsynopsisdiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.refsynopsisdiv.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.refsynopsisdiv">
+      <element name="refsynopsisdiv">
+        <a:documentation>A syntactic synopsis of the subject of the reference page</a:documentation>
+        <ref name="db.refsynopsisdiv.attlist"/>
+        <ref name="db.refsynopsisdiv.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.secondlevel.refsection"/>
+            </optional>
+          </group>
+          <ref name="db.secondlevel.refsection"/>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refsection.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refsection.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refsection.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refsection.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.refsection">
+      <element name="refsection">
+        <a:documentation>A recursive section in a refentry</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:refsection">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.refsection.attlist"/>
+        <ref name="db.refsection.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <zeroOrMore>
+              <ref name="db.refsection"/>
+            </zeroOrMore>
+          </group>
+          <oneOrMore>
+            <ref name="db.refsection"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <define name="db.refsect1.sections">
+    <oneOrMore>
+      <ref name="db.refsect2"/>
+    </oneOrMore>
+  </define>
+  <div>
+    <define name="db.refsect1.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.refsect1.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refsect1.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refsect1.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.refsect1.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refsect1.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.refsect1">
+      <element name="refsect1">
+        <a:documentation>A major subsection of a reference entry</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:refsect1">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.refsect1.attlist"/>
+        <ref name="db.refsect1.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.refsect1.sections"/>
+            </optional>
+          </group>
+          <ref name="db.refsect1.sections"/>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <define name="db.refsect2.sections">
+    <oneOrMore>
+      <ref name="db.refsect3"/>
+    </oneOrMore>
+  </define>
+  <div>
+    <define name="db.refsect2.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.refsect2.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refsect2.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refsect2.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.refsect2.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refsect2.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.refsect2">
+      <element name="refsect2">
+        <a:documentation>A subsection of a refsect1</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:refsect2">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.refsect2.attlist"/>
+        <ref name="db.refsect2.info"/>
+        <choice>
+          <group>
+            <oneOrMore>
+              <ref name="db.all.blocks"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.refsect2.sections"/>
+            </optional>
+          </group>
+          <ref name="db.refsect2.sections"/>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.refsect3.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.refsect3.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.refsect3.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.refsect3.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.refsect3.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.refsect3.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.refsect3">
+      <element name="refsect3">
+        <a:documentation>A subsection of a refsect2</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:refsect3">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.refsect3.attlist"/>
+        <ref name="db.refsect3.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.glossary.inlines">
+    <choice>
+      <ref name="db.firstterm"/>
+      <ref name="db.glossterm"/>
+    </choice>
+  </define>
+  <define name="db.baseform.attribute">
+    <optional>
+      <attribute name="baseform">
+        <a:documentation>Specifies the base form of the term, the one that appears in the glossary. This allows adjectival, plural, and other variations of the term to appear in the element. The element content is the default base form.</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <div>
+    <define name="db.glosslist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glosslist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glosslist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.glosslist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.glosslist">
+      <element name="glosslist">
+        <a:documentation>A wrapper for a list of glossary entries</a:documentation>
+        <ref name="db.glosslist.attlist"/>
+        <optional>
+          <ref name="db.glosslist.info"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.glossentry"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossentry.sortas.attribute">
+      <attribute name="sortas">
+        <a:documentation>Specifies the string by which the element's content is to be sorted; if unspecified, the content is used</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.glossentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.glossentry.sortas.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glossentry">
+      <element name="glossentry">
+        <a:documentation>An entry in a Glossary or GlossList</a:documentation>
+        <ref name="db.glossentry.attlist"/>
+        <ref name="db.glossterm"/>
+        <optional>
+          <ref name="db.acronym"/>
+        </optional>
+        <optional>
+          <ref name="db.abbrev"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.indexterm"/>
+        </zeroOrMore>
+        <choice>
+          <ref name="db.glosssee"/>
+          <oneOrMore>
+            <ref name="db.glossdef"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossdef.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossdef.subject.attribute">
+      <attribute name="subject">
+        <a:documentation>Specifies a list of keywords for the definition</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.glossdef.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossdef.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.glossdef.subject.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glossdef">
+      <element name="glossdef">
+        <a:documentation>A definition in a GlossEntry</a:documentation>
+        <ref name="db.glossdef.attlist"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.glossseealso"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glosssee.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glosssee.otherterm.attribute">
+      <attribute name="otherterm">
+        <a:documentation>Identifies the other term</a:documentation>
+        <data type="IDREF"/>
+      </attribute>
+    </define>
+    <define name="db.glosssee.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glosssee.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.glosssee.otherterm.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glosssee">
+      <element name="glosssee">
+        <a:documentation>A cross-reference from one glossentry
+ to another</a:documentation>
+        <s:pattern name="Glosssary 'see' type constraint">
+          <s:rule context="db:glosssee[@otherterm]">
+            <s:assert test="local-name(//*[@xml:id=current()/@otherterm]) = 'glossentry' and namespace-uri(//*[@xml:id=current()/@otherterm]) = 'http://docbook.org/ns/docbook'">@otherterm on glosssee must point to a glossentry.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.glosssee.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossseealso.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossseealso.otherterm.attribute">
+      <attribute name="otherterm">
+        <a:documentation>Identifies the other term</a:documentation>
+        <data type="IDREF"/>
+      </attribute>
+    </define>
+    <define name="db.glossseealso.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossseealso.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.glossseealso.otherterm.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glossseealso">
+      <element name="glossseealso">
+        <a:documentation>A cross-reference from one GlossEntry to another</a:documentation>
+        <s:pattern name="Glossary 'seealso' type constraint">
+          <s:rule context="db:glossseealso[@otherterm]">
+            <s:assert test="local-name(//*[@xml:id=current()/@otherterm]) = 'glossentry' and namespace-uri(//*[@xml:id=current()/@otherterm]) = 'http://docbook.org/ns/docbook'">@otherterm on glossseealso must point to a glossentry.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.glossseealso.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.firstterm.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.firstterm.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.firstterm.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.baseform.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.firstterm">
+      <element name="firstterm">
+        <a:documentation>The first occurrence of a term</a:documentation>
+        <s:pattern name="Glossary 'firstterm' type constraint">
+          <s:rule context="db:firstterm[@linkend]">
+            <s:assert test="local-name(//*[@xml:id=current()/@linkend]) = 'glossentry' and namespace-uri(//*[@xml:id=current()/@linkend]) = 'http://docbook.org/ns/docbook'">@linkend on firstterm must point to a glossentry.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.firstterm.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossterm.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossterm.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossterm.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.baseform.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.glossterm">
+      <element name="glossterm">
+        <a:documentation>A glossary term</a:documentation>
+        <s:pattern name="Glossary 'glossterm' type constraint">
+          <s:rule context="db:glossterm[@linkend]">
+            <s:assert test="local-name(//*[@xml:id=current()/@linkend]) = 'glossentry' and namespace-uri(//*[@xml:id=current()/@linkend]) = 'http://docbook.org/ns/docbook'">@linkend on glossterm must point to a glossentry.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.glossterm.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossary.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.glossary.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossary.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossary.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.glossary.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glossary.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.glossary">
+      <element name="glossary">
+        <a:documentation>A glossary</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:glossary">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.glossary.attlist"/>
+        <ref name="db.glossary.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.glossdiv"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.glossentry"/>
+          </zeroOrMore>
+        </choice>
+        <optional>
+          <ref name="db.bibliography"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.glossdiv.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.glossdiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.glossdiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.glossdiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.glossdiv.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.glossdiv.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.glossdiv">
+      <element name="glossdiv">
+        <a:documentation>A division in a Glossary</a:documentation>
+        <ref name="db.glossdiv.attlist"/>
+        <ref name="db.glossdiv.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.glossentry"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.termdef.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.termdef.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.termdef.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.glossentry.sortas.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.baseform.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.termdef">
+      <element name="termdef">
+        <a:documentation>An inline definition of a term</a:documentation>
+        <s:pattern name="Glossary term definition constraint">
+          <s:rule context="db:termdef">
+            <s:assert test="count(db:firstterm) = 1">A termdef must contain exactly one firstterm</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.termdef.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.relation.attribute">
+    <attribute name="relation">
+      <a:documentation>Identifies the relationship between the bibliographic elemnts</a:documentation>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.biblioentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.biblioentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.biblioentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.biblioentry">
+      <element name="biblioentry">
+        <a:documentation>An entry in a Bibliography</a:documentation>
+        <ref name="db.biblioentry.attlist"/>
+        <oneOrMore>
+          <ref name="db.bibliographic.elements"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliomixed.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliomixed.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliomixed.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.bibliomixed">
+      <element name="bibliomixed">
+        <a:documentation>An entry in a Bibliography</a:documentation>
+        <ref name="db.bibliomixed.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="db.bibliographic.elements"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.biblioset.relation.attribute">
+      <ref name="db.relation.attribute"/>
+    </define>
+    <define name="db.biblioset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.biblioset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.biblioset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.biblioset.relation.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.biblioset">
+      <element name="biblioset">
+        <a:documentation>A raw container for related bibliographic information</a:documentation>
+        <ref name="db.biblioset.attlist"/>
+        <oneOrMore>
+          <ref name="db.bibliographic.elements"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliomset.relation.attribute">
+      <ref name="db.relation.attribute"/>
+    </define>
+    <define name="db.bibliomset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliomset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliomset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.bibliomset.relation.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.bibliomset">
+      <element name="bibliomset">
+        <a:documentation>A cooked container for related bibliographic information</a:documentation>
+        <ref name="db.bibliomset.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.bibliographic.elements"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliomisc.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliomisc.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliomisc.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.bibliomisc">
+      <element name="bibliomisc">
+        <a:documentation>Untyped bibliographic information</a:documentation>
+        <ref name="db.bibliomisc.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliography.status.attrib">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.bibliography.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliography.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliography.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.bibliography.status.attrib"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.bibliography.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.bibliography">
+      <element name="bibliography">
+        <a:documentation>A bibliography</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:bibliography">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.bibliography.attlist"/>
+        <ref name="db.bibliography.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <oneOrMore>
+            <ref name="db.bibliodiv"/>
+          </oneOrMore>
+          <oneOrMore>
+            <choice>
+              <ref name="db.biblioentry"/>
+              <ref name="db.bibliomixed"/>
+            </choice>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliodiv.status.attrib">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.bibliodiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliodiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliodiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.bibliodiv.status.attrib"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.bibliodiv.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.bibliodiv">
+      <element name="bibliodiv">
+        <a:documentation>A section of a Bibliography</a:documentation>
+        <ref name="db.bibliodiv.attlist"/>
+        <ref name="db.bibliodiv.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="db.biblioentry"/>
+            <ref name="db.bibliomixed"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.bibliolist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.bibliolist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.bibliolist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.bibliolist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.bibliolist">
+      <element name="bibliolist">
+        <a:documentation>A wrapper for a list of bibliography entries</a:documentation>
+        <ref name="db.bibliolist.attlist"/>
+        <optional>
+          <ref name="db.bibliolist.info"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="db.biblioentry"/>
+            <ref name="db.bibliomixed"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.biblioref.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.biblioref.xrefstyle.attribute">
+      <ref name="db.xrefstyle.attribute"/>
+    </define>
+    <define name="db.biblioref.endterm.attribute">
+      <ref name="db.endterm.attribute"/>
+    </define>
+    <define name="db.biblioref.units.attribute">
+      <attribute name="units">
+        <a:documentation>The units (for example, pages) used to identify the beginning and ending of a reference.</a:documentation>
+        <data type="token"/>
+      </attribute>
+    </define>
+    <define name="db.biblioref.begin.attribute">
+      <attribute name="begin">
+        <a:documentation>Identifies the beginning of a reference; the location within the work that is being referenced.</a:documentation>
+        <data type="token"/>
+      </attribute>
+    </define>
+    <define name="db.biblioref.end.attribute">
+      <attribute name="end">
+        <a:documentation>Identifies the end of a reference.</a:documentation>
+        <data type="token"/>
+      </attribute>
+    </define>
+    <define name="db.biblioref.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.biblioref.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.req.linking.attributes"/>
+        <optional>
+          <ref name="db.biblioref.xrefstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.biblioref.endterm.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.biblioref.units.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.biblioref.begin.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.biblioref.end.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.biblioref">
+      <element name="biblioref">
+        <a:documentation>A cross-reference to a bibliographic entry</a:documentation>
+        <ref name="db.biblioref.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <define name="db.significance.enumeration">
+    <choice>
+      <value>normal</value>
+      <a:documentation>Normal</a:documentation>
+      <value>preferred</value>
+      <a:documentation>Preferred</a:documentation>
+    </choice>
+  </define>
+  <define name="db.significance.attribute">
+    <attribute name="significance">
+      <a:documentation>Specifies the significance of the term</a:documentation>
+      <ref name="db.significance.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.zone.attribute">
+    <attribute name="zone">
+      <a:documentation>Specifies the IDs of the elements to which this term applies</a:documentation>
+      <data type="IDREFS"/>
+    </attribute>
+  </define>
+  <define name="db.indexterm.pagenum.attribute">
+    <attribute name="pagenum">
+      <a:documentation>Indicates the page on which this index term occurs in some version of the printed document</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.scope.enumeration">
+    <choice>
+      <value>all</value>
+      <a:documentation>All indexes</a:documentation>
+      <value>global</value>
+      <a:documentation>The global index (as for a combined index of a set of box)</a:documentation>
+      <value>local</value>
+      <a:documentation>The local index (the index for this document only)</a:documentation>
+    </choice>
+  </define>
+  <define name="db.scope.attribute">
+    <attribute name="scope">
+      <a:documentation>Specifies the scope of the index term</a:documentation>
+      <ref name="db.scope.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.sortas.attribute">
+    <attribute name="sortas">
+      <a:documentation>Specifies the string by which the term is to be sorted; if unspecified, the term content is used</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.index.type.attribute">
+    <attribute name="type">
+      <a:documentation>Specifies the target index for this term</a:documentation>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.itermset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.itermset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.itermset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.itermset">
+      <element name="itermset">
+        <a:documentation>A set of index terms in the meta-information of a document</a:documentation>
+        <ref name="db.itermset.attlist"/>
+        <oneOrMore>
+          <ref name="db.indexterm.singular"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.indexterm.contentmodel">
+    <optional>
+      <ref name="db.primary"/>
+    </optional>
+    <optional>
+      <choice>
+        <group>
+          <ref name="db.secondary"/>
+          <optional>
+            <choice>
+              <group>
+                <ref name="db.tertiary"/>
+                <optional>
+                  <choice>
+                    <ref name="db.see"/>
+                    <oneOrMore>
+                      <ref name="db.seealso"/>
+                    </oneOrMore>
+                  </choice>
+                </optional>
+              </group>
+              <ref name="db.see"/>
+              <oneOrMore>
+                <ref name="db.seealso"/>
+              </oneOrMore>
+            </choice>
+          </optional>
+        </group>
+        <ref name="db.see"/>
+        <oneOrMore>
+          <ref name="db.seealso"/>
+        </oneOrMore>
+      </choice>
+    </optional>
+  </define>
+  <div>
+    <define name="db.indexterm.singular.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.indexterm.singular.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of index term</a:documentation>
+        <value>singular</value>
+        <a:documentation>A singular index term</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.indexterm.singular.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.indexterm.singular.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.significance.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.zone.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.indexterm.pagenum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.scope.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.index.type.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.indexterm.singular.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.indexterm.singular">
+      <element name="indexterm">
+        <a:documentation>A wrapper for an indexed term</a:documentation>
+        <ref name="db.indexterm.singular.attlist"/>
+        <ref name="db.indexterm.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.indexterm.startofrange.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.indexterm.startofrange.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of index term</a:documentation>
+        <value>startofrange</value>
+        <a:documentation>The start of a range</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.indexterm.startofrange.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.indexterm.startofrange.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.significance.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.zone.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.indexterm.pagenum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.scope.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.index.type.attribute"/>
+        </optional>
+        <ref name="db.indexterm.startofrange.class.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.indexterm.startofrange">
+      <element name="indexterm">
+        <a:documentation>A wrapper for an indexed term that covers a range</a:documentation>
+        <ref name="db.indexterm.startofrange.attlist"/>
+        <ref name="db.indexterm.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.indexterm.endofrange.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.indexterm.endofrange.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of index term</a:documentation>
+        <value>endofrange</value>
+        <a:documentation>The end of a range</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.indexterm.endofrange.startref.attribute">
+      <attribute name="startref">
+        <a:documentation>Points to the start of the range</a:documentation>
+        <data type="IDREF"/>
+      </attribute>
+    </define>
+    <define name="db.indexterm.endofrange.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.indexterm.endofrange.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.indexterm.endofrange.class.attribute"/>
+        <ref name="db.indexterm.endofrange.startref.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.indexterm.endofrange">
+      <element name="indexterm">
+        <a:documentation>Identifies the end of a range associated with an indexed term</a:documentation>
+        <ref name="db.indexterm.endofrange.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.indexterm">
+      <choice>
+        <ref name="db.indexterm.singular"/>
+        <ref name="db.indexterm.startofrange"/>
+        <ref name="db.indexterm.endofrange"/>
+      </choice>
+    </define>
+  </div>
+  <div>
+    <define name="db.primary.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.primary.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.primary.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.sortas.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.primary">
+      <element name="primary">
+        <a:documentation>The primary word or phrase under which an index term should be sorted</a:documentation>
+        <ref name="db.primary.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.secondary.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.secondary.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.secondary.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.sortas.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.secondary">
+      <element name="secondary">
+        <a:documentation>A secondary word or phrase in an index term</a:documentation>
+        <ref name="db.secondary.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tertiary.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tertiary.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tertiary.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.sortas.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tertiary">
+      <element name="tertiary">
+        <a:documentation>A tertiary word or phrase in an index term</a:documentation>
+        <ref name="db.tertiary.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.see.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.see.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.see.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.see">
+      <element name="see">
+        <a:documentation>Part of an index term directing the reader instead to another entry in the index</a:documentation>
+        <ref name="db.see.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seealso.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seealso.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seealso.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.seealso">
+      <element name="seealso">
+        <a:documentation>Part of an index term directing the reader also to another entry in the index</a:documentation>
+        <ref name="db.seealso.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.index.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.index.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.index.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.index.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.index.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.index.type.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.index.info">
+      <ref name="db._info"/>
+    </define>
+<!--
+
+      Yes, db.indexdiv* and db.indexentry*; that way an <index/> is valid.
+      Authors can use an empty index to indicate where a generated index should
+      appear.
+    -->
+    <define name="db.index">
+      <element name="index">
+        <a:documentation>An index to a book or part of a book</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:index">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.index.attlist"/>
+        <ref name="db.index.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.indexdiv"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.indexentry"/>
+          </zeroOrMore>
+          <ref name="db.segmentedlist"/>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.setindex.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.setindex.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.setindex.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.setindex.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.setindex.status.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.index.type.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.setindex.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.setindex">
+      <element name="setindex">
+        <a:documentation>An index to a set of books</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:setindex">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.setindex.attlist"/>
+        <ref name="db.setindex.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.indexdiv"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.indexentry"/>
+          </zeroOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.indexdiv.status.attribute">
+      <ref name="db.status.attribute"/>
+    </define>
+    <define name="db.indexdiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.indexdiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.indexdiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.indexdiv.status.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.indexdiv.info">
+      <ref name="db._info.title.req"/>
+    </define>
+    <define name="db.indexdiv">
+      <element name="indexdiv">
+        <a:documentation>A division in an index</a:documentation>
+        <ref name="db.indexdiv.attlist"/>
+        <ref name="db.indexdiv.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <oneOrMore>
+            <ref name="db.indexentry"/>
+          </oneOrMore>
+          <ref name="db.segmentedlist"/>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.indexentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.indexentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.indexentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.indexentry">
+      <element name="indexentry">
+        <a:documentation>An entry in an index</a:documentation>
+        <ref name="db.indexentry.attlist"/>
+        <ref name="db.primaryie"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.seeie"/>
+            <ref name="db.seealsoie"/>
+          </choice>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.secondaryie"/>
+          <zeroOrMore>
+            <choice>
+              <ref name="db.seeie"/>
+              <ref name="db.seealsoie"/>
+              <ref name="db.tertiaryie"/>
+            </choice>
+          </zeroOrMore>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.primaryie.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.primaryie.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.primaryie.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.linkends.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.primaryie">
+      <element name="primaryie">
+        <a:documentation>A primary term in an index entry, not in the text</a:documentation>
+        <ref name="db.primaryie.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.secondaryie.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.secondaryie.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.secondaryie.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.linkends.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.secondaryie">
+      <element name="secondaryie">
+        <a:documentation>A secondary term in an index entry, rather than in the text</a:documentation>
+        <ref name="db.secondaryie.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tertiaryie.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tertiaryie.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tertiaryie.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.linkends.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tertiaryie">
+      <element name="tertiaryie">
+        <a:documentation>A tertiary term in an index entry, rather than in the text</a:documentation>
+        <ref name="db.tertiaryie.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seeie.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seeie.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seeie.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.linkend.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.seeie">
+      <element name="seeie">
+        <a:documentation>A See
+entry in an index, rather than in the text</a:documentation>
+        <ref name="db.seeie.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.seealsoie.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.seealsoie.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.seealsoie.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.linkends.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.seealsoie">
+      <element name="seealsoie">
+        <a:documentation>A See also
+ entry in an index, rather than in the text</a:documentation>
+        <ref name="db.seealsoie.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.toc.pagenum.attribute">
+    <attribute name="pagenum">
+      <a:documentation>Indicates the page on which this element occurs in some version of the printed document</a:documentation>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.toc.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.toc.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.toc.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.toc.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.toc">
+      <element name="toc">
+        <a:documentation>A table of contents</a:documentation>
+        <s:pattern name="Root must have version">
+          <s:rule context="/db:toc">
+            <s:assert test="@version">The root element must have a version attribute.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.toc.attlist"/>
+        <ref name="db.toc.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.tocdiv"/>
+            <ref name="db.tocentry"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tocdiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tocdiv.pagenum.attribute">
+      <ref name="db.toc.pagenum.attribute"/>
+    </define>
+    <define name="db.tocdiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tocdiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.tocdiv.pagenum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.linkend.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tocdiv.info">
+      <ref name="db._info"/>
+    </define>
+    <define name="db.tocdiv">
+      <element name="tocdiv">
+        <a:documentation>A division in a table of contents</a:documentation>
+        <ref name="db.tocdiv.attlist"/>
+        <ref name="db.tocdiv.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <choice>
+            <ref name="db.tocdiv"/>
+            <ref name="db.tocentry"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tocentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tocentry.pagenum.attribute">
+      <ref name="db.toc.pagenum.attribute"/>
+    </define>
+    <define name="db.tocentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tocentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <ref name="db.tocentry.pagenum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.linkend.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tocentry">
+      <element name="tocentry">
+        <a:documentation>A component title in a table of contents</a:documentation>
+        <ref name="db.tocentry.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.task.info">
+    <ref name="db._info.title.req"/>
+  </define>
+  <div>
+    <define name="db.task.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.task.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.task.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.task">
+      <element name="task">
+        <a:documentation>A task to be completed</a:documentation>
+        <ref name="db.task.attlist"/>
+        <ref name="db.task.info"/>
+        <optional>
+          <ref name="db.tasksummary"/>
+        </optional>
+        <optional>
+          <ref name="db.taskprerequisites"/>
+        </optional>
+        <ref name="db.procedure"/>
+        <zeroOrMore>
+          <ref name="db.example"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.taskrelated"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tasksummary.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tasksummary.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tasksummary.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.tasksummary.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.tasksummary">
+      <element name="tasksummary">
+        <a:documentation>A summary of a task</a:documentation>
+        <ref name="db.tasksummary.attlist"/>
+        <ref name="db.tasksummary.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.taskprerequisites.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.taskprerequisites.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.taskprerequisites.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.taskprerequisites.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.taskprerequisites">
+      <element name="taskprerequisites">
+        <a:documentation>The prerequisites for a task</a:documentation>
+        <ref name="db.taskprerequisites.attlist"/>
+        <ref name="db.taskprerequisites.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.taskrelated.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.taskrelated.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.taskrelated.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.taskrelated.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.taskrelated">
+      <element name="taskrelated">
+        <a:documentation>Information related to a task</a:documentation>
+        <ref name="db.taskrelated.attlist"/>
+        <ref name="db.taskrelated.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.area.units.enumeration">
+    <choice>
+      <value>calspair</value>
+      <a:documentation>Coordinates expressed as a pair of CALS graphic coordinates.</a:documentation>
+      <value>linecolumn</value>
+      <a:documentation>Coordinates expressed as a line and column.</a:documentation>
+      <value>linecolumnpair</value>
+      <a:documentation>Coordinates expressed as a pair of lines and columns.</a:documentation>
+      <value>linerange</value>
+      <a:documentation>Coordinates expressed as a line range.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.area.units-enum.attribute">
+    <optional>
+      <attribute name="units">
+        <a:documentation>Identifies the units used in the coords attribute The default units vary according to the type of callout specified: calspair
+ for graphics and linecolumn
+ for line-oriented elements.</a:documentation>
+        <ref name="db.area.units.enumeration"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.area.units-other.attributes">
+    <optional>
+      <attribute name="units">
+        <a:documentation>Indicates that non-standard units are used for this area
+. In this case otherunits
+ must be specified.</a:documentation>
+        <value>other</value>
+        <a:documentation>Coordinates expressed in some non-standard units.</a:documentation>
+      </attribute>
+    </optional>
+    <attribute name="otherunits">
+      <a:documentation>Identifies the units used in the coords
+ attribute when the units
+ attribute is other
+. This attribute is forbidden otherwise.</a:documentation>
+      <data type="NMTOKEN"/>
+    </attribute>
+  </define>
+  <define name="db.area.units.attribute">
+    <choice>
+      <ref name="db.area.units-enum.attribute"/>
+      <ref name="db.area.units-other.attributes"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.calloutlist.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.calloutlist.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.calloutlist.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.calloutlist.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.calloutlist">
+      <element name="calloutlist">
+        <a:documentation>A list of callout
+s</a:documentation>
+        <ref name="db.calloutlist.attlist"/>
+        <ref name="db.calloutlist.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.callout"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.callout.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.callout.arearefs.attribute">
+      <attribute name="arearefs">
+        <a:documentation>Identifies the areas described by this callout.</a:documentation>
+        <data type="IDREFS"/>
+      </attribute>
+    </define>
+    <define name="db.callout.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.callout.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.callout.arearefs.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.callout">
+      <element name="callout">
+        <a:documentation>A called out
+ description of a marked Area</a:documentation>
+        <ref name="db.callout.attlist"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.programlistingco.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.programlistingco.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.programlistingco.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.programlistingco.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.programlistingco">
+      <element name="programlistingco">
+        <a:documentation>A program listing with associated areas used in callouts</a:documentation>
+        <ref name="db.programlistingco.attlist"/>
+        <ref name="db.programlistingco.info"/>
+        <ref name="db.areaspec"/>
+        <ref name="db.programlisting"/>
+        <zeroOrMore>
+          <ref name="db.calloutlist"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.areaspec.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.areaspec.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.areaspec.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.area.units.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.areaspec">
+      <element name="areaspec">
+        <a:documentation>A collection of regions in a graphic or code example</a:documentation>
+        <ref name="db.areaspec.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.area"/>
+            <ref name="db.areaset"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.area.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.area.linkends.attribute">
+      <attribute name="linkends">
+        <a:documentation>Point to the callout
+s which refer to this area. (This provides bidirectional linking which may be useful in online presentation.)</a:documentation>
+        <data type="IDREFS"/>
+      </attribute>
+    </define>
+    <define name="db.area.label.attribute">
+      <attribute name="label">
+        <a:documentation>Specifies an identifying number or string that may be used in presentation. The area label might be drawn on top of the figure, for example, at the position indicated by the coords attribute.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.area.coords.attribute">
+      <attribute name="coords">
+        <a:documentation>Provides the coordinates of the area. The coordinates must be interpreted using the units
+ specified.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.area.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.area.role.attribute"/>
+        </optional>
+        <ref name="db.common.idreq.attributes"/>
+        <ref name="db.area.units.attribute"/>
+        <optional>
+          <choice>
+            <ref name="db.area.linkends.attribute"/>
+            <ref name="db.href.attributes"/>
+          </choice>
+        </optional>
+        <optional>
+          <ref name="db.area.label.attribute"/>
+        </optional>
+        <ref name="db.area.coords.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.area">
+      <element name="area">
+        <a:documentation>A region defined for a Callout in a graphic or code example</a:documentation>
+        <ref name="db.area.attlist"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+<!-- The only difference is that xml:id is optional -->
+    <define name="db.area.inareaset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.area.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.area.units.attribute"/>
+        <optional>
+          <choice>
+            <ref name="db.area.linkends.attribute"/>
+            <ref name="db.href.attributes"/>
+          </choice>
+        </optional>
+        <optional>
+          <ref name="db.area.label.attribute"/>
+        </optional>
+        <ref name="db.area.coords.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.area.inareaset">
+      <element name="area">
+        <a:documentation>A region defined for a Callout in a graphic or code example</a:documentation>
+        <ref name="db.area.inareaset.attlist"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.areaset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.areaset.linkends.attribute">
+      <ref name="db.linkends.attribute"/>
+    </define>
+    <define name="db.areaset.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.areaset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.areaset.role.attribute"/>
+        </optional>
+        <ref name="db.common.idreq.attributes"/>
+        <ref name="db.area.units.attribute"/>
+        <optional>
+          <choice>
+            <ref name="db.areaset.linkends.attribute"/>
+            <ref name="db.href.attributes"/>
+          </choice>
+        </optional>
+        <optional>
+          <ref name="db.areaset.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.areaset">
+      <element name="areaset">
+        <a:documentation>A set of related areas in a graphic or code example</a:documentation>
+        <ref name="db.areaset.attlist"/>
+        <oneOrMore>
+          <ref name="db.area.inareaset"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.screenco.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.screenco.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.screenco.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.screenco.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.screenco">
+      <element name="screenco">
+        <a:documentation>A screen with associated areas used in callouts</a:documentation>
+        <ref name="db.screenco.attlist"/>
+        <ref name="db.screenco.info"/>
+        <ref name="db.areaspec"/>
+        <ref name="db.screen"/>
+        <zeroOrMore>
+          <ref name="db.calloutlist"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.imageobjectco.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.imageobjectco.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.imageobjectco.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.imageobjectco.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.imageobjectco">
+      <element name="imageobjectco">
+        <a:documentation>A wrapper for an image object with callouts</a:documentation>
+        <ref name="db.imageobjectco.attlist"/>
+        <ref name="db.imageobjectco.info"/>
+        <ref name="db.areaspec"/>
+        <oneOrMore>
+          <ref name="db.imageobject"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.calloutlist"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.co.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.co.linkends.attribute">
+      <ref name="db.linkends.attribute"/>
+    </define>
+    <define name="db.co.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.co.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.co.role.attribute"/>
+        </optional>
+        <ref name="db.common.idreq.attributes"/>
+        <optional>
+          <ref name="db.co.linkends.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.co.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.co">
+      <element name="co">
+        <a:documentation>The location of a callout embedded in text</a:documentation>
+        <ref name="db.co.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.coref.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.coref.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.coref.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.coref.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.linkend.attribute"/>
+        <optional>
+          <ref name="db.coref.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.coref">
+      <element name="coref">
+        <a:documentation>A cross reference to a co</a:documentation>
+        <ref name="db.coref.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.productionset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.productionset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.productionset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.productionset.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.productionset">
+      <element name="productionset">
+        <a:documentation>A set of EBNF productions</a:documentation>
+        <ref name="db.productionset.attlist"/>
+        <ref name="db.productionset.info"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.production"/>
+            <ref name="db.productionrecap"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.production.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.production.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.production.role.attribute"/>
+        </optional>
+        <ref name="db.common.idreq.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.production">
+      <element name="production">
+        <a:documentation>A production in a set of EBNF productions</a:documentation>
+        <ref name="db.production.attlist"/>
+        <ref name="db.lhs"/>
+        <ref name="db.rhs"/>
+        <zeroOrMore>
+          <ref name="db.constraint"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.lhs.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.lhs.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.lhs.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.lhs">
+      <element name="lhs">
+        <a:documentation>The left-hand side of an EBNF production</a:documentation>
+        <ref name="db.lhs.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.rhs.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.rhs.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.rhs.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.rhs">
+      <element name="rhs">
+        <a:documentation>The right-hand side of an EBNF production</a:documentation>
+        <ref name="db.rhs.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="db.nonterminal"/>
+            <ref name="db.lineannotation"/>
+            <ref name="db.sbr"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.nonterminal.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.nonterminal.def.attribute">
+      <attribute name="def">
+        <a:documentation>Specifies a URI that points to a production
+where the nonterminal
+ is defined</a:documentation>
+        <data type="anyURI"/>
+      </attribute>
+    </define>
+    <define name="db.nonterminal.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.nonterminal.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.nonterminal.def.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.nonterminal">
+      <element name="nonterminal">
+        <a:documentation>A non-terminal in an EBNF production</a:documentation>
+        <ref name="db.nonterminal.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.constraint.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.constraint.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.constraint.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.req.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.constraint">
+      <element name="constraint">
+        <a:documentation>A constraint in an EBNF production</a:documentation>
+        <ref name="db.constraint.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.productionrecap.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.productionrecap.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.productionrecap.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.req.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.productionrecap">
+      <element name="productionrecap">
+        <a:documentation>A cross-reference to an EBNF production</a:documentation>
+        <ref name="db.productionrecap.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.constraintdef.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.constraintdef.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.constraintdef.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.constraintdef.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.constraintdef">
+      <element name="constraintdef">
+        <a:documentation>The definition of a constraint in an EBNF production</a:documentation>
+        <ref name="db.constraintdef.attlist"/>
+        <ref name="db.constraintdef.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.char.attribute">
+    <attribute name="char">
+      <a:documentation>Specifies the alignment character when align
+ is set to char
+.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.charoff.attribute">
+    <attribute name="charoff">
+      <a:documentation>Specifies the percentage of the column's total width that should appear to the left of the first occurance of the character identified in char
+ when align
+ is set to char
+.</a:documentation>
+      <data type="decimal">
+        <param name="minExclusive">0</param>
+        <param name="maxExclusive">100</param>
+      </data>
+    </attribute>
+  </define>
+  <define name="db.frame.attribute">
+    <attribute name="frame">
+      <a:documentation>Specifies how the table is to be framed. Note that there is no way to obtain a border on only the starting edge (left, in left-to-right writing systems) of the table.</a:documentation>
+      <choice>
+        <value>all</value>
+        <a:documentation>Frame all four sides of the table. In some environments with limited control over table border formatting, such as HTML, this may imply additional borders.</a:documentation>
+        <value>bottom</value>
+        <a:documentation>Frame only the bottom of the table.</a:documentation>
+        <value>none</value>
+        <a:documentation>Place no border on the table. In some environments with limited control over table border formatting, such as HTML, this may disable other borders as well.</a:documentation>
+        <value>sides</value>
+        <a:documentation>Frame the left and right sides of the table.</a:documentation>
+        <value>top</value>
+        <a:documentation>Frame the top of the table.</a:documentation>
+        <value>topbot</value>
+        <a:documentation>Frame the top and bottom of the table.</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.colsep.attribute">
+    <attribute name="colsep">
+      <a:documentation>Specifies the presence or absence of the column separator</a:documentation>
+      <choice>
+        <value>0</value>
+        <a:documentation>No column separator rule.</a:documentation>
+        <value>1</value>
+        <a:documentation>Provide a column separator rule on the right</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.rowsep.attribute">
+    <attribute name="rowsep">
+      <a:documentation>Specifies the presence or absence of the row separator</a:documentation>
+      <choice>
+        <value>0</value>
+        <a:documentation>No row separator rule.</a:documentation>
+        <value>1</value>
+        <a:documentation>Provide a row separator rule below</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.orient.attribute">
+    <attribute name="orient">
+      <a:documentation>Specifies the orientation of the table</a:documentation>
+      <choice>
+        <value>land</value>
+        <a:documentation>90 degrees counter-clockwise from the rest of the text flow.</a:documentation>
+        <value>port</value>
+        <a:documentation>The same orientation as the rest of the text flow.</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.tabstyle.attribute">
+    <attribute name="tabstyle">
+      <a:documentation>Specifies the table style</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.rowheader.attribute">
+    <attribute name="rowheader">
+      <a:documentation>Indicates whether or not the entries in the first column should be considered row headers</a:documentation>
+      <choice>
+        <value>firstcol</value>
+        <a:documentation>Indicates that entries in the first column of the table are functionally row headers (analogous to the way that a thead provides column headers).</a:documentation>
+        <value>norowheader</value>
+        <a:documentation>Indicates that entries in the first column have no special significance with respect to column headers.</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.align.attribute">
+    <attribute name="align">
+      <a:documentation>Specifies the horizontal alignment of text in an entry.</a:documentation>
+      <choice>
+        <value>center</value>
+        <a:documentation>Centered.</a:documentation>
+        <value>char</value>
+        <a:documentation>Aligned on a particular character.</a:documentation>
+        <value>justify</value>
+        <a:documentation>Left and right justified.</a:documentation>
+        <value>left</value>
+        <a:documentation>Left justified.</a:documentation>
+        <value>right</value>
+        <a:documentation>Right justified.</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.valign.attribute">
+    <attribute name="valign">
+      <a:documentation>Specifies the vertical alignment of text in an entry.</a:documentation>
+      <choice>
+        <value>bottom</value>
+        <a:documentation>Aligned on the bottom of the entry.</a:documentation>
+        <value>middle</value>
+        <a:documentation>Aligned in the middle.</a:documentation>
+        <value>top</value>
+        <a:documentation>Aligned at the top of the entry.</a:documentation>
+      </choice>
+    </attribute>
+  </define>
+  <define name="db.specify-col-by-colname.attributes">
+    <attribute name="colname">
+      <a:documentation>Specifies a column specification by name.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.specify-col-by-namest.attributes">
+    <attribute name="namest">
+      <a:documentation>Specifies a starting column by name.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.specify-span-by-spanspec.attributes">
+    <attribute name="spanname">
+      <a:documentation>Specifies a span by name.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.specify-span-directly.attributes">
+    <interleave>
+      <attribute name="namest">
+        <a:documentation>Specifies a starting column by name.</a:documentation>
+      </attribute>
+      <attribute name="nameend">
+        <a:documentation>Specifies an ending column by name.</a:documentation>
+      </attribute>
+    </interleave>
+  </define>
+  <define name="db.column-spec.attributes">
+    <choice>
+      <ref name="db.specify-col-by-colname.attributes"/>
+      <ref name="db.specify-col-by-namest.attributes"/>
+      <ref name="db.specify-span-by-spanspec.attributes"/>
+      <ref name="db.specify-span-directly.attributes"/>
+    </choice>
+  </define>
+  <define name="db.colname.attribute">
+    <attribute name="colname">
+      <a:documentation>Provides a name for a column specification.</a:documentation>
+    </attribute>
+  </define>
+  <define name="db.spanname.attribute">
+    <attribute name="spanname">
+      <a:documentation>Provides a name for a span specification.</a:documentation>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.tgroup.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tgroup.tgroupstyle.attribute">
+      <attribute name="tgroupstyle">
+        <a:documentation>Additional style information for downstream processing; typically the name of a style.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.tgroup.cols.attribute">
+      <attribute name="cols">
+        <a:documentation>The number of columns in the table. Must be an integer greater than zero.</a:documentation>
+        <data type="positiveInteger"/>
+      </attribute>
+    </define>
+    <define name="db.tgroup.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tgroup.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.char.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.charoff.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.tgroup.tgroupstyle.attribute"/>
+        </optional>
+        <ref name="db.tgroup.cols.attribute"/>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.align.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tgroup">
+      <element name="tgroup">
+        <a:documentation>A wrapper for the main content of a table, or part of a table</a:documentation>
+        <ref name="db.tgroup.attlist"/>
+        <zeroOrMore>
+          <ref name="db.colspec"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.spanspec"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.cals.thead"/>
+        </optional>
+        <optional>
+          <ref name="db.cals.tfoot"/>
+        </optional>
+        <ref name="db.cals.tbody"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.colspec.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.colspec.colnum.attribute">
+      <attribute name="colnum">
+        <a:documentation>The number of the column to which this specification applies. Must be greater than any preceding column number. Defaults to one more than the number of the preceding column, if there is one, or one.</a:documentation>
+        <data type="positiveInteger"/>
+      </attribute>
+    </define>
+    <define name="db.colspec.colwidth.attribute">
+      <attribute name="colwidth">
+        <a:documentation>Specifies the width of the column.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.colspec.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.colspec.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.colspec.colnum.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.char.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colspec.colwidth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.charoff.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colname.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.align.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.colspec">
+      <element name="colspec">
+        <a:documentation>Specifications for a column in a table</a:documentation>
+        <ref name="db.colspec.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.spanspec.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.spanspec.namest.attribute">
+      <attribute name="namest">
+        <a:documentation>Specifies a starting column by name.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.spanspec.nameend.attribute">
+      <attribute name="nameend">
+        <a:documentation>Specifies an ending column by name.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.spanspec.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.spanspec.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.spanname.attribute"/>
+        <ref name="db.spanspec.namest.attribute"/>
+        <ref name="db.spanspec.nameend.attribute"/>
+        <optional>
+          <ref name="db.char.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.charoff.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.align.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.spanspec">
+      <element name="spanspec">
+        <a:documentation>Formatting information for a spanned column in a table</a:documentation>
+        <ref name="db.spanspec.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.thead.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.thead.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.thead.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.thead">
+      <element name="thead">
+        <a:documentation>A table header consisting of one or more rows</a:documentation>
+        <ref name="db.cals.thead.attlist"/>
+        <zeroOrMore>
+          <ref name="db.colspec"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.row"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.tfoot.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.tfoot.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.tfoot.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.tfoot">
+      <element name="tfoot">
+        <a:documentation>A table footer consisting of one or more rows</a:documentation>
+        <ref name="db.cals.tfoot.attlist"/>
+        <zeroOrMore>
+          <ref name="db.colspec"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.row"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.tbody.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.tbody.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.tbody.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.tbody">
+      <element name="tbody">
+        <a:documentation>A wrapper for the rows of a table or informal table</a:documentation>
+        <ref name="db.cals.tbody.attlist"/>
+        <oneOrMore>
+          <ref name="db.row"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.row.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.row.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.row.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.row">
+      <element name="row">
+        <a:documentation>A row in a table</a:documentation>
+        <ref name="db.row.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.entry"/>
+            <ref name="db.entrytbl"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.entry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.entry.morerows.attribute">
+      <attribute name="morerows">
+        <a:documentation>Specifies the number of additional rows which this entry occupies. Defaults to zero.</a:documentation>
+        <data type="integer"/>
+      </attribute>
+    </define>
+    <define name="db.entry.rotate.attribute">
+      <attribute name="rotate">
+        <a:documentation>Specifies the rotation of this entry. A value of 1 (true) rotates the cell 90 degrees counter-clockwise. A value of 0 (false) leaves the cell unrotated.</a:documentation>
+        <choice>
+          <value>0</value>
+          <a:documentation>Do not rotate the cell.</a:documentation>
+          <value>1</value>
+          <a:documentation>Rotate the cell 90 degrees counter-clockwise.</a:documentation>
+        </choice>
+      </attribute>
+    </define>
+    <define name="db.entry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.entry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.char.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.charoff.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.entry.morerows.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.column-spec.attributes"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.entry.rotate.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.align.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.entry">
+      <element name="entry">
+        <a:documentation>A cell in a table</a:documentation>
+        <ref name="db.entry.attlist"/>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.all.inlines"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.all.blocks"/>
+          </zeroOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.entrytbl.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.entrytbl.tgroupstyle.attribute">
+      <attribute name="tgroupstyle">
+        <a:documentation>Additional style information for downstream processing; typically the name of a style.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.entrytbl.cols.attribute">
+      <attribute name="cols">
+        <a:documentation>The number of columns in the entry table. Must be an integer greater than zero.</a:documentation>
+        <data type="positiveInteger"/>
+      </attribute>
+    </define>
+    <define name="db.entrytbl.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.entrytbl.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.char.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.charoff.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.column-spec.attributes"/>
+        </optional>
+        <optional>
+          <ref name="db.entrytbl.tgroupstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.entrytbl.cols.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.align.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.entrytbl">
+      <element name="entrytbl">
+        <a:documentation>A subtable appearing in place of an Entry in a table</a:documentation>
+        <ref name="db.entrytbl.attlist"/>
+        <zeroOrMore>
+          <ref name="db.colspec"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.spanspec"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.cals.entrytbl.thead"/>
+        </optional>
+        <ref name="db.cals.entrytbl.tbody"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.entrytbl.thead.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.entrytbl.thead.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.entrytbl.thead.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.entrytbl.thead">
+      <element name="thead">
+        <a:documentation>A table header consisting of one or more rows</a:documentation>
+        <ref name="db.cals.entrytbl.thead.attlist"/>
+        <zeroOrMore>
+          <ref name="db.colspec"/>
+        </zeroOrMore>
+        <oneOrMore>
+          <ref name="db.entrytbl.row"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.entrytbl.tbody.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.entrytbl.tbody.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.entrytbl.tbody.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.entrytbl.tbody">
+      <element name="tbody">
+        <a:documentation>A wrapper for the rows of a table or informal table</a:documentation>
+        <ref name="db.cals.entrytbl.tbody.attlist"/>
+        <oneOrMore>
+          <ref name="db.entrytbl.row"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.entrytbl.row.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.entrytbl.row.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.entrytbl.row.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.valign.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.entrytbl.row">
+      <element name="row">
+        <a:documentation>A row in a table</a:documentation>
+        <ref name="db.entrytbl.row.attlist"/>
+        <oneOrMore>
+          <ref name="db.entry"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.table.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.table.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.cals.table.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.table.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.cals.table.label.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.tabstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.floatstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.orient.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.frame.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <attribute name="shortentry">
+            <a:documentation>Indicates if the short or long title should be used in a List of Tables</a:documentation>
+            <choice>
+              <value>0</value>
+              <a:documentation>Indicates that the full title should be used.</a:documentation>
+              <value>1</value>
+              <a:documentation>Indicates that the short short title (titleabbrev) should be used.</a:documentation>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="tocentry">
+            <a:documentation>Indicates if the table should appear in a List of Tables</a:documentation>
+            <choice>
+              <value>0</value>
+              <a:documentation>Indicates that the table should not occur in the List of Tables.</a:documentation>
+              <value>1</value>
+              <a:documentation>Indicates that the table should appear in the List of Tables.</a:documentation>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="db.rowheader.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.table.info">
+      <ref name="db._info.title.onlyreq"/>
+    </define>
+    <define name="db.cals.table">
+      <element name="table">
+        <a:documentation>A formal table in a document</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:informaltable)">informaltable must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.cals.table.attlist"/>
+        <ref name="db.cals.table.info"/>
+        <interleave>
+          <optional>
+            <ref name="db.alt"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="db.indexing.inlines"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.textobject"/>
+          </zeroOrMore>
+        </interleave>
+        <choice>
+          <oneOrMore>
+            <ref name="db.mediaobject"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.tgroup"/>
+          </oneOrMore>
+        </choice>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cals.informaltable.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cals.informaltable.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cals.informaltable.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.tabstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.floatstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.orient.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.colsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowsep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.frame.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.rowheader.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cals.informaltable.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.cals.informaltable">
+      <element name="informaltable">
+        <a:documentation>A table without a title</a:documentation>
+        <ref name="db.cals.informaltable.attlist"/>
+        <ref name="db.cals.informaltable.info"/>
+        <interleave>
+          <optional>
+            <ref name="db.alt"/>
+          </optional>
+          <zeroOrMore>
+            <ref name="db.indexing.inlines"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.textobject"/>
+          </zeroOrMore>
+        </interleave>
+        <choice>
+          <oneOrMore>
+            <ref name="db.mediaobject"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.tgroup"/>
+          </oneOrMore>
+        </choice>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <define name="db.html.coreattrs">
+    <interleave>
+      <optional>
+        <attribute name="class">
+          <a:documentation>This attribute assigns a class name or set of class names to an element. Any number of elements may be assigned the same class name or names. Multiple class names must be separated by white space characters.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="style">
+          <a:documentation>This attribute specifies style information for the current element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="title">
+          <a:documentation>This attribute offers advisory information about the element for which it is set.</a:documentation>
+        </attribute>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.html.i18n">
+    <optional>
+      <attribute name="lang">
+        <a:documentation>This attribute specifies the base language of an element's attribute values and text content. The default value of this attribute is unknown.</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.html.events">
+    <interleave>
+      <optional>
+        <attribute name="onclick">
+          <a:documentation>Occurs when the pointing device button is clicked over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="ondblclick">
+          <a:documentation>Occurs when the pointing device button is double clicked over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onmousedown">
+          <a:documentation>Occurs when the pointing device button is pressed over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onmouseup">
+          <a:documentation>Occurs when the pointing device button is released over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onmouseover">
+          <a:documentation>Occurs when the pointing device is moved onto an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onmousemove">
+          <a:documentation>Occurs when the pointing device is moved while it is over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onmouseout">
+          <a:documentation>Occurs when the pointing device is moved away from an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onkeypress">
+          <a:documentation>Occurs when a key is pressed and released over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onkeydown">
+          <a:documentation>Occurs when a key is pressed down over an element.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="onkeyup">
+          <a:documentation>Occurs when a key is released over an element.</a:documentation>
+        </attribute>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.html.attrs">
+    <interleave>
+      <ref name="db.common.attributes"/>
+      <ref name="db.html.coreattrs"/>
+      <ref name="db.html.i18n"/>
+      <ref name="db.html.events"/>
+    </interleave>
+  </define>
+  <define name="db.html.cellhalign">
+    <interleave>
+      <optional>
+        <attribute name="align">
+          <a:documentation>Specifies the alignment of data and the justification of text in a cell.</a:documentation>
+          <choice>
+            <value>left</value>
+            <a:documentation>Left-flush data/Left-justify text. This is the default value for table data.</a:documentation>
+            <value>center</value>
+            <a:documentation>Center data/Center-justify text. This is the default value for table headers.</a:documentation>
+            <value>right</value>
+            <a:documentation>Right-flush data/Right-justify text.</a:documentation>
+            <value>justify</value>
+            <a:documentation>Double-justify text.</a:documentation>
+            <value>char</value>
+            <a:documentation>Align text around a specific character. If a user agent doesn't support character alignment, behavior in the presence of this value is unspecified.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="char">
+          <a:documentation>This attribute specifies a single character within a text fragment to act as an axis for alignment. The default value for this attribute is the decimal point character for the current language as set by the lang attribute (e.g., the period in English and the comma in French). User agents are not required to support this attribute.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="charoff">
+          <a:documentation>When present, this attribute specifies the offset to the first occurrence of the alignment character on each line. If a line doesn't include the alignment character, it should be horizontally shifted to end at the alignment position. When charoff is used to set the offset of an alignment character, the direction of offset is determined by the current text direction (set by the dir attribute). In left-to-right texts (the default), offset is from the left margin. In right-to-left texts, offset is from the right margin. User agents are not required to support this attribute.</a:documentation>
+          <choice>
+            <data type="integer"/>
+            <data type="string">
+              <param name="pattern">[0-9]+%</param>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.html.cellvalign">
+    <optional>
+      <attribute name="valign">
+        <a:documentation>Specifies the vertical position of data within a cell.</a:documentation>
+        <choice>
+          <value>top</value>
+          <a:documentation>Cell data is flush with the top of the cell.</a:documentation>
+          <value>middle</value>
+          <a:documentation>Cell data is centered vertically within the cell. This is the default value.</a:documentation>
+          <value>bottom</value>
+          <a:documentation>Cell data is flush with the bottom of the cell.</a:documentation>
+          <value>baseline</value>
+          <a:documentation>All cells in the same row as a cell whose valign attribute has this value should have their textual data positioned so that the first text line occurs on a baseline common to all cells in the row. This constraint does not apply to subsequent text lines in these cells.</a:documentation>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="db.html.table.attributes">
+    <interleave>
+      <optional>
+        <attribute name="summary">
+          <a:documentation>Provides a summary of the table's purpose and structure for user agents rendering to non-visual media such as speech and Braille.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="width">
+          <a:documentation>Specifies the desired width of the entire table and is intended for visual user agents. When the value is a percentage value, the value is relative to the user agent's available horizontal space. In the absence of any width specification, table width is determined by the user agent.</a:documentation>
+          <choice>
+            <data type="integer"/>
+            <data type="string">
+              <param name="pattern">[0-9]+%</param>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="border">
+          <a:documentation>Specifies the width (in pixels only) of the frame around a table.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="frame">
+          <a:documentation>Specifies which sides of the frame surrounding a table will be visible.</a:documentation>
+          <choice>
+            <value>void</value>
+            <a:documentation>No sides. This is the default value.</a:documentation>
+            <value>above</value>
+            <a:documentation>The top side only.</a:documentation>
+            <value>below</value>
+            <a:documentation>The bottom side only.</a:documentation>
+            <value>hsides</value>
+            <a:documentation>The top and bottom sides only.</a:documentation>
+            <value>lhs</value>
+            <a:documentation>The left-hand side only.</a:documentation>
+            <value>rhs</value>
+            <a:documentation>The right-hand side only.</a:documentation>
+            <value>vsides</value>
+            <a:documentation>The right and left sides only.</a:documentation>
+            <value>box</value>
+            <a:documentation>All four sides.</a:documentation>
+            <value>border</value>
+            <a:documentation>All four sides.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rules">
+          <a:documentation>Specifies which rules will appear between cells within a table. The rendering of rules is user agent dependent.</a:documentation>
+          <choice>
+            <value>none</value>
+            <a:documentation>No rules. This is the default value.</a:documentation>
+            <value>groups</value>
+            <a:documentation>Rules will appear between row groups (see thead, tfoot, and tbody) and column groups (see colgroup and col) only.</a:documentation>
+            <value>rows</value>
+            <a:documentation>Rules will appear between rows only.</a:documentation>
+            <value>cols</value>
+            <a:documentation>Rules will appear between columns only.</a:documentation>
+            <value>all</value>
+            <a:documentation>Rules will appear between all rows and columns.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="cellspacing">
+          <a:documentation>Specifies how much space the user agent should leave between the left side of the table and the left-hand side of the leftmost column, the top of the table and the top side of the topmost row, and so on for the right and bottom of the table. The attribute also specifies the amount of space to leave between cells.</a:documentation>
+          <choice>
+            <data type="integer"/>
+            <data type="string">
+              <param name="pattern">[0-9]+%</param>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="cellpadding">
+          <a:documentation>Specifies the amount of space between the border of the cell and its contents. If the value of this attribute is a pixel length, all four margins should be this distance from the contents. If the value of the attribute is a percentage length, the top and bottom margins should be equally separated from the content based on a percentage of the available vertical space, and the left and right margins should be equally separated from the content based on a percentage of the available horizontal space.</a:documentation>
+          <choice>
+            <data type="integer"/>
+            <data type="string">
+              <param name="pattern">[0-9]+%</param>
+            </data>
+          </choice>
+        </attribute>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.html.tablecell.attributes">
+    <interleave>
+      <optional>
+        <attribute name="abbr">
+          <a:documentation>Provides an abbreviated form of the cell's content and may be rendered by user agents when appropriate in place of the cell's content. Abbreviated names should be short since user agents may render them repeatedly. For instance, speech synthesizers may render the abbreviated headers relating to a particular cell before rendering that cell's content.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="axis">
+          <a:documentation>This attribute may be used to place a cell into conceptual categories that can be considered to form axes in an n-dimensional space. User agents may give users access to these categories (e.g., the user may query the user agent for all cells that belong to certain categories, the user agent may present a table in the form of a table of contents, etc.). Please consult an HTML reference for more details.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="headers">
+          <a:documentation>Specifies the list of header cells that provide header information for the current data cell. The value of this attribute is a space-separated list of cell names; those cells must be named by setting their id attribute. Authors generally use the headers attribute to help non-visual user agents render header information about data cells (e.g., header information is spoken prior to the cell data), but the attribute may also be used in conjunction with style sheets.</a:documentation>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="scope">
+          <a:documentation>Specifies the set of data cells for which the current header cell provides header information. This attribute may be used in place of the headers attribute, particularly for simple tables.</a:documentation>
+          <choice>
+            <value>row</value>
+            <a:documentation>The current cell provides header information for the rest of the row that contains it</a:documentation>
+            <value>col</value>
+            <a:documentation>The current cell provides header information for the rest of the column that contains it.</a:documentation>
+            <value>rowgroup</value>
+            <a:documentation>The header cell provides header information for the rest of the row group that contains it.</a:documentation>
+            <value>colgroup</value>
+            <a:documentation>The header cell provides header information for the rest of the column group that contains it.</a:documentation>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="rowspan">
+          <a:documentation>Specifies the number of rows spanned by the current cell. The default value of this attribute is one (1
+). The value zero (0
+) means that the cell spans all rows from the current row to the last row of the table section (thead
+, tbody
+, or tfoot
+) in which the cell is defined.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="colspan">
+          <a:documentation>Specifies the number of columns spanned by the current cell. The default value of this attribute is one (1
+). The value zero (0
+) means that the cell spans all columns from the current column to the last column of the column group (colgroup
+) in which the cell is defined.</a:documentation>
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+    </interleave>
+  </define>
+  <define name="db.html.table.info">
+    <ref name="db._info.title.forbidden"/>
+  </define>
+  <define name="db.html.table.model">
+    <optional>
+      <ref name="db.html.table.info"/>
+    </optional>
+    <ref name="db.html.caption"/>
+    <choice>
+      <zeroOrMore>
+        <ref name="db.html.col"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="db.html.colgroup"/>
+      </zeroOrMore>
+    </choice>
+    <optional>
+      <ref name="db.html.thead"/>
+    </optional>
+    <optional>
+      <ref name="db.html.tfoot"/>
+    </optional>
+    <choice>
+      <oneOrMore>
+        <ref name="db.html.tbody"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="db.html.tr"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.html.informaltable.info">
+    <ref name="db._info.title.forbidden"/>
+  </define>
+  <define name="db.html.informaltable.model">
+    <optional>
+      <ref name="db.html.informaltable.info"/>
+    </optional>
+    <choice>
+      <zeroOrMore>
+        <ref name="db.html.col"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="db.html.colgroup"/>
+      </zeroOrMore>
+    </choice>
+    <optional>
+      <ref name="db.html.thead"/>
+    </optional>
+    <optional>
+      <ref name="db.html.tfoot"/>
+    </optional>
+    <choice>
+      <oneOrMore>
+        <ref name="db.html.tbody"/>
+      </oneOrMore>
+      <oneOrMore>
+        <ref name="db.html.tr"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.html.table.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.html.table.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.html.table.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.table.attributes"/>
+        <optional>
+          <ref name="db.html.table.role.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.html.table.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.orient.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.tabstyle.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.floatstyle.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.html.table">
+      <element name="table">
+        <a:documentation>A formal (captioned) HTML table in a document</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:informaltable)">informaltable must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:table">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of table</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.html.table.attlist"/>
+        <ref name="db.html.table.model"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.informaltable.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.table.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.html.informaltable">
+      <element name="informaltable">
+        <a:documentation>An HTML table without a title</a:documentation>
+        <ref name="db.html.informaltable.attlist"/>
+        <ref name="db.html.informaltable.model"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.caption.attlist">
+      <ref name="db.html.attrs"/>
+    </define>
+    <define name="db.html.caption">
+      <element name="caption">
+        <a:documentation>An HTML table caption</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:sidebar)">sidebar must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:task)">task must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caption">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of caption</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.html.caption.attlist"/>
+        <zeroOrMore>
+          <ref name="db.all.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.col.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <optional>
+          <attribute name="span">
+            <a:documentation>This attribute, whose value must be an integer &gt; 0, specifies the number of columns spanned
+ by the col
+ element; the col
+ element shares its attributes with all the columns it spans. The default value for this attribute is 1 (i.e., a single column). If the span attribute is set to N &gt; 1, the current col
+ element shares its attributes with the next N-1 columns.</a:documentation>
+            <data type="nonNegativeInteger"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <a:documentation>Specifies a default width for each column spanned by the current col
+ element. It has the same meaning as the width
+ attribute for the colgroup
+ element and overrides it.</a:documentation>
+          </attribute>
+        </optional>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.col">
+      <element name="col">
+        <a:documentation>Specifications for a column in an HTML table</a:documentation>
+        <ref name="db.html.col.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.colgroup.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <optional>
+          <attribute name="span">
+            <a:documentation>This attribute, which must be an integer &gt; 0, specifies the number of columns in a column group. In the absence of a span attribute, each colgroup
+ defines a column group containing one column. If the span attribute is set to N &gt; 0, the current colgroup
+ element defines a column group containing N columns. User agents must ignore this attribute if the colgroup
+ element contains one or more col
+ elements.</a:documentation>
+            <data type="nonNegativeInteger"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="width">
+            <a:documentation>This attribute specifies a default width for each column in the current column group. In addition to the standard pixel, percentage, and relative values, this attribute allows the special form 0*
+ (zero asterisk) which means that the width of the each column in the group should be the minimum width necessary to hold the column's contents. This implies that a column's entire contents must be known before its width may be correctly computed. Authors should be aware that specifying 0*
+ will prevent visual user agents from rendering a table incrementally. This attribute is overridden for any column in the column group whose width is specified via a col
+ element.</a:documentation>
+          </attribute>
+        </optional>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.colgroup">
+      <element name="colgroup">
+        <a:documentation>A group of columns in an HTML table</a:documentation>
+        <ref name="db.html.colgroup.attlist"/>
+        <zeroOrMore>
+          <ref name="db.html.col"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.thead.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.thead">
+      <element name="thead">
+        <a:documentation>A table header consisting of one or more rows in an HTML table</a:documentation>
+        <ref name="db.html.thead.attlist"/>
+        <oneOrMore>
+          <ref name="db.html.tr"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.tfoot.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.tfoot">
+      <element name="tfoot">
+        <a:documentation>A table footer consisting of one or more rows in an HTML table</a:documentation>
+        <ref name="db.html.tfoot.attlist"/>
+        <oneOrMore>
+          <ref name="db.html.tr"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.tbody.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.tbody">
+      <element name="tbody">
+        <a:documentation>A wrapper for the rows of an HTML table or informal HTML table</a:documentation>
+        <ref name="db.html.tbody.attlist"/>
+        <oneOrMore>
+          <ref name="db.html.tr"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.tr.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.tr">
+      <element name="tr">
+        <a:documentation>A row in an HTML table</a:documentation>
+        <ref name="db.html.tr.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.html.th"/>
+            <ref name="db.html.td"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.th.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.tablecell.attributes"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.th">
+      <element name="th">
+        <a:documentation>A table header entry in an HTML table</a:documentation>
+        <ref name="db.html.th.attlist"/>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.all.inlines"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.all.blocks"/>
+          </zeroOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.html.td.attlist">
+      <interleave>
+        <ref name="db.html.attrs"/>
+        <ref name="db.html.tablecell.attributes"/>
+        <ref name="db.html.cellhalign"/>
+        <ref name="db.html.cellvalign"/>
+      </interleave>
+    </define>
+    <define name="db.html.td">
+      <element name="td">
+        <a:documentation>A table entry in an HTML table</a:documentation>
+        <ref name="db.html.td.attlist"/>
+        <choice>
+          <zeroOrMore>
+            <ref name="db.all.inlines"/>
+          </zeroOrMore>
+          <zeroOrMore>
+            <ref name="db.all.blocks"/>
+          </zeroOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgset.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msgset">
+      <element name="msgset">
+        <a:documentation>A detailed set of messages, usually error messages</a:documentation>
+        <ref name="db.msgset.attlist"/>
+        <ref name="db.msgset.info"/>
+        <choice>
+          <oneOrMore>
+            <ref name="db.msgentry"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.simplemsgentry"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgentry">
+      <element name="msgentry">
+        <a:documentation>A wrapper for an entry in a message set</a:documentation>
+        <ref name="db.msgentry.attlist"/>
+        <oneOrMore>
+          <ref name="db.msg"/>
+        </oneOrMore>
+        <optional>
+          <ref name="db.msginfo"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="db.msgexplan"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.simplemsgentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.simplemsgentry.msgaud.attribute">
+      <attribute name="msgaud">
+        <a:documentation>The audience to which the message relevant</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.simplemsgentry.msgorig.attribute">
+      <attribute name="msgorig">
+        <a:documentation>The origin of the message</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.simplemsgentry.msglevel.attribute">
+      <attribute name="msglevel">
+        <a:documentation>The level of importance or severity of a message</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.simplemsgentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.simplemsgentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.simplemsgentry.msgaud.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.simplemsgentry.msgorig.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.simplemsgentry.msglevel.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.simplemsgentry">
+      <element name="simplemsgentry">
+        <a:documentation>A wrapper for a simpler entry in a message set</a:documentation>
+        <ref name="db.simplemsgentry.attlist"/>
+        <ref name="db.msgtext"/>
+        <oneOrMore>
+          <ref name="db.msgexplan"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msg.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msg.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msg.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msg.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msg">
+      <element name="msg">
+        <a:documentation>A message in a message set</a:documentation>
+        <ref name="db.msg.attlist"/>
+        <ref name="db.msg.info"/>
+        <ref name="db.msgmain"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.msgsub"/>
+            <ref name="db.msgrel"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgmain.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgmain.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgmain.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgmain.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msgmain">
+      <element name="msgmain">
+        <a:documentation>The primary component of a message in a message set </a:documentation>
+        <ref name="db.msgmain.attlist"/>
+        <ref name="db.msgmain.info"/>
+        <ref name="db.msgtext"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgsub.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgsub.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgsub.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgsub.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msgsub">
+      <element name="msgsub">
+        <a:documentation>A subcomponent of a message in a message set</a:documentation>
+        <ref name="db.msgsub.attlist"/>
+        <ref name="db.msgsub.info"/>
+        <ref name="db.msgtext"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgrel.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgrel.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgrel.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgrel.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msgrel">
+      <element name="msgrel">
+        <a:documentation>A related component of a message in a message set</a:documentation>
+        <ref name="db.msgrel.attlist"/>
+        <ref name="db.msgrel.info"/>
+        <ref name="db.msgtext"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgtext.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgtext.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgtext.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgtext">
+      <element name="msgtext">
+        <a:documentation>The actual text of a message component in a message set</a:documentation>
+        <ref name="db.msgtext.attlist"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msginfo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msginfo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msginfo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msginfo">
+      <element name="msginfo">
+        <a:documentation>Information about a message in a message set</a:documentation>
+        <ref name="db.msginfo.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.msglevel"/>
+            <ref name="db.msgorig"/>
+            <ref name="db.msgaud"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msglevel.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msglevel.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msglevel.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msglevel">
+      <element name="msglevel">
+        <a:documentation>The level of importance or severity of a message in a message set</a:documentation>
+        <ref name="db.msglevel.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgorig.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgorig.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgorig.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgorig">
+      <element name="msgorig">
+        <a:documentation>The origin of a message in a message set</a:documentation>
+        <ref name="db.msgorig.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgaud.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgaud.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgaud.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgaud">
+      <element name="msgaud">
+        <a:documentation>The audience to which a message in a message set is relevant</a:documentation>
+        <ref name="db.msgaud.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.msgexplan.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.msgexplan.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.msgexplan.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.msgexplan.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.msgexplan">
+      <element name="msgexplan">
+        <a:documentation>Explanatory material relating to a message in a message set</a:documentation>
+        <ref name="db.msgexplan.attlist"/>
+        <ref name="db.msgexplan.info"/>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.qandaset.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.qandaset.defaultlabel.enumeration">
+      <choice>
+        <value>none</value>
+        <a:documentation>No labels</a:documentation>
+        <value>number</value>
+        <a:documentation>Numeric labels</a:documentation>
+        <value>qanda</value>
+        <a:documentation>"Q:" and "A:" labels</a:documentation>
+      </choice>
+    </define>
+    <define name="db.qandaset.defaultlabel.attribute">
+      <attribute name="defaultlabel">
+        <a:documentation>Specifies the default labelling</a:documentation>
+        <ref name="db.qandaset.defaultlabel.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.qandaset.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.qandaset.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.qandaset.defaultlabel.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.qandaset.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.qandaset">
+      <element name="qandaset">
+        <a:documentation>A question-and-answer set</a:documentation>
+        <ref name="db.qandaset.attlist"/>
+        <ref name="db.qandaset.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <oneOrMore>
+            <ref name="db.qandadiv"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.qandaentry"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.qandadiv.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.qandadiv.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.qandadiv.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.qandadiv.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.qandadiv">
+      <element name="qandadiv">
+        <a:documentation>A titled division in a QandASet</a:documentation>
+        <ref name="db.qandadiv.attlist"/>
+        <ref name="db.qandadiv.info"/>
+        <zeroOrMore>
+          <ref name="db.all.blocks"/>
+        </zeroOrMore>
+        <choice>
+          <oneOrMore>
+            <ref name="db.qandadiv"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.qandaentry"/>
+          </oneOrMore>
+        </choice>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.qandaentry.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.qandaentry.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.qandaentry.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.qandaentry.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.qandaentry">
+      <element name="qandaentry">
+        <a:documentation>A question/answer set within a QandASet</a:documentation>
+        <ref name="db.qandaentry.attlist"/>
+        <ref name="db.qandaentry.info"/>
+        <ref name="db.question"/>
+        <zeroOrMore>
+          <ref name="db.answer"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.question.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.question.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.question.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.question">
+      <element name="question">
+        <a:documentation>A question in a QandASet</a:documentation>
+        <ref name="db.question.attlist"/>
+        <optional>
+          <ref name="db.label"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.answer.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.answer.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.answer.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.answer">
+      <element name="answer">
+        <a:documentation>An answer to a question posed in a QandASet</a:documentation>
+        <ref name="db.answer.attlist"/>
+        <optional>
+          <ref name="db.label"/>
+        </optional>
+        <oneOrMore>
+          <ref name="db.all.blocks"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.label.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.label.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.label.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.label">
+      <element name="label">
+        <a:documentation>A label on a Question or Answer</a:documentation>
+        <ref name="db.label.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.math.inlines">
+    <ref name="db.inlineequation"/>
+  </define>
+  <define name="db.equation.content">
+    <choice>
+      <choice>
+        <oneOrMore>
+          <ref name="db.mediaobject"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="db.mathphrase"/>
+        </oneOrMore>
+      </choice>
+      <oneOrMore>
+        <ref name="db._any.mml"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <define name="db.inlineequation.content">
+    <choice>
+      <choice>
+        <oneOrMore>
+          <ref name="db.inlinemediaobject"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="db.mathphrase"/>
+        </oneOrMore>
+      </choice>
+      <oneOrMore>
+        <ref name="db._any.mml"/>
+      </oneOrMore>
+    </choice>
+  </define>
+  <div>
+    <define name="db.equation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.equation.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.equation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.equation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.equation.label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.pgwide.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.floatstyle.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.equation.info">
+      <ref name="db._info.title.only"/>
+    </define>
+    <define name="db.equation">
+      <element name="equation">
+        <a:documentation>A displayed mathematical equation</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:example)">example must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:figure)">figure must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:table)">table must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:equation)">equation must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:equation">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of equation</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.equation.attlist"/>
+        <ref name="db.equation.info"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+        <ref name="db.equation.content"/>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.informalequation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.informalequation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.informalequation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.informalequation.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.informalequation">
+      <element name="informalequation">
+        <a:documentation>A displayed mathematical equation without a title</a:documentation>
+        <ref name="db.informalequation.attlist"/>
+        <ref name="db.informalequation.info"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+        <ref name="db.equation.content"/>
+        <optional>
+          <ref name="db.caption"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.inlineequation.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.inlineequation.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.inlineequation.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.inlineequation">
+      <element name="inlineequation">
+        <a:documentation>A mathematical equation or expression occurring inline</a:documentation>
+        <ref name="db.inlineequation.attlist"/>
+        <optional>
+          <ref name="db.alt"/>
+        </optional>
+        <ref name="db.inlineequation.content"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.mathphrase.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.mathphrase.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.mathphrase.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.mathphrase">
+      <element name="mathphrase">
+        <a:documentation>A mathematical phrase, an expression that can be represented with ordinary text and a small amount of markup</a:documentation>
+        <ref name="db.mathphrase.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.ubiq.inlines"/>
+            <ref name="db._emphasis"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.imagedata.mathml.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.imagedata.mathml.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.imagedata.mathml.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <attribute name="format">
+            <a:documentation>Specifies that the format of the data is MathML</a:documentation>
+            <value>mathml</value>
+            <a:documentation>Specifies MathML.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.align.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.valign.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.width.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentwidth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scalefit.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scale.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.depth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentdepth.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.imagedata.mathml.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.imagedata.mathml">
+      <element name="imagedata">
+        <a:documentation>A MathML expression in a media object</a:documentation>
+        <ref name="db.imagedata.mathml.attlist"/>
+        <ref name="db.imagedata.mathml.info"/>
+        <oneOrMore>
+          <ref name="db._any.mml"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db._any.mml">
+      <element>
+        <a:documentation>Any element from the MathML namespace</a:documentation>
+        <nsName ns="http://www.w3.org/1998/Math/MathML"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._any.attribute"/>
+            <text/>
+            <ref name="db._any"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.imagedata.svg.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.imagedata.svg.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.imagedata.svg.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <optional>
+          <attribute name="format">
+            <a:documentation>Specifies that the format of the data is SVG</a:documentation>
+            <value>svg</value>
+            <a:documentation>Specifies SVG.</a:documentation>
+          </attribute>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.align.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.valign.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.width.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentwidth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scalefit.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.scale.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.depth.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.imagedata.contentdepth.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.imagedata.svg.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.imagedata.svg">
+      <element name="imagedata">
+        <a:documentation>An SVG drawing in a media object</a:documentation>
+        <ref name="db.imagedata.svg.attlist"/>
+        <ref name="db.imagedata.svg.info"/>
+        <oneOrMore>
+          <ref name="db._any.svg"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db._any.svg">
+      <element>
+        <a:documentation>Any element from the SVG namespace</a:documentation>
+        <nsName ns="http://www.w3.org/2000/svg"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._any.attribute"/>
+            <text/>
+            <ref name="db._any"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.markup.inlines">
+    <choice>
+      <ref name="db.tag"/>
+      <ref name="db.markup"/>
+      <ref name="db.token"/>
+      <ref name="db.symbol"/>
+      <ref name="db.literal"/>
+      <ref name="db.code"/>
+      <ref name="db.constant"/>
+      <ref name="db.email"/>
+      <ref name="db.uri"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.markup.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.markup.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.markup.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.markup">
+      <element name="markup">
+        <a:documentation>A string of formatting markup in text that is to be represented literally</a:documentation>
+        <ref name="db.markup.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tag.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tag.class.enumeration">
+      <choice>
+        <value>attribute</value>
+        <a:documentation>An attribute</a:documentation>
+        <value>attvalue</value>
+        <a:documentation>An attribute value</a:documentation>
+        <value>element</value>
+        <a:documentation>An element</a:documentation>
+        <value>emptytag</value>
+        <a:documentation>An empty element tag</a:documentation>
+        <value>endtag</value>
+        <a:documentation>An end tag</a:documentation>
+        <value>genentity</value>
+        <a:documentation>A general entity</a:documentation>
+        <value>localname</value>
+        <a:documentation>The local name part of a qualified name</a:documentation>
+        <value>namespace</value>
+        <a:documentation>A namespace</a:documentation>
+        <value>numcharref</value>
+        <a:documentation>A numeric character reference</a:documentation>
+        <value>paramentity</value>
+        <a:documentation>A parameter entity</a:documentation>
+        <value>pi</value>
+        <a:documentation>A processing instruction</a:documentation>
+        <value>prefix</value>
+        <a:documentation>The prefix part of a qualified name</a:documentation>
+        <value>comment</value>
+        <a:documentation>An SGML comment</a:documentation>
+        <value>starttag</value>
+        <a:documentation>A start tag</a:documentation>
+        <value>xmlpi</value>
+        <a:documentation>An XML processing instruction</a:documentation>
+      </choice>
+    </define>
+    <define name="db.tag.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the nature of the tag content</a:documentation>
+        <ref name="db.tag.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.tag.namespace.attribute">
+      <attribute name="namespace">
+        <a:documentation>Identifies the namespace of the tag content</a:documentation>
+        <data type="anyURI"/>
+      </attribute>
+    </define>
+    <define name="db.tag.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tag.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.tag.class.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.tag.namespace.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.tag">
+      <element name="tag">
+        <a:documentation>A component of XML (or SGML) markup</a:documentation>
+        <ref name="db.tag.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.symbol.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of symbol</a:documentation>
+        <value>limit</value>
+        <a:documentation>The value is a limit of some kind</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.symbol.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.symbol.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.symbol.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.symbol.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.symbol">
+      <element name="symbol">
+        <a:documentation>A name that is replaced by a value before processing</a:documentation>
+        <ref name="db.symbol.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.token.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.token.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.token.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.token">
+      <element name="token">
+        <a:documentation>A unit of information</a:documentation>
+        <ref name="db.token.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.literal.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.literal.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.literal.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.literal">
+      <element name="literal">
+        <a:documentation>Inline text that is some literal value</a:documentation>
+        <ref name="db.literal.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="code.language.attribute">
+      <attribute name="language">
+        <a:documentation>Identifies the (computer) language of the code fragment</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.code.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.code.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.code.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="code.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.code">
+      <element name="code">
+        <a:documentation>An inline code fragment</a:documentation>
+        <ref name="db.code.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.programming.inlines"/>
+            <ref name="db._text"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.constant.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of constant</a:documentation>
+        <value>limit</value>
+        <a:documentation>The value is a limit of some kind</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.constant.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.constant.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.constant.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.constant.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.constant">
+      <element name="constant">
+        <a:documentation>A programming or system constant</a:documentation>
+        <ref name="db.constant.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.productname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.productname.class.enumeration">
+      <choice>
+        <value>copyright</value>
+        <a:documentation>A name with a copyright</a:documentation>
+        <value>registered</value>
+        <a:documentation>A name with a registered copyright</a:documentation>
+        <value>service</value>
+        <a:documentation>A name of a service</a:documentation>
+        <value>trade</value>
+        <a:documentation>A name which is trademarked</a:documentation>
+      </choice>
+    </define>
+    <define name="db.productname.class.attribute">
+      <attribute name="class">
+        <a:documentation>Specifies the class of product name</a:documentation>
+        <ref name="db.productname.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.productname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.productname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.productname.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.productname">
+      <element name="productname">
+        <a:documentation>The formal name of a product</a:documentation>
+        <ref name="db.productname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.productnumber.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.productnumber.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.productnumber.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.productnumber">
+      <element name="productnumber">
+        <a:documentation>A number assigned to a product</a:documentation>
+        <ref name="db.productnumber.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.database.class.enumeration">
+      <choice>
+        <value>altkey</value>
+        <a:documentation>An alternate or secondary key</a:documentation>
+        <value>constraint</value>
+        <a:documentation>A constraint</a:documentation>
+        <value>datatype</value>
+        <a:documentation>A data type</a:documentation>
+        <value>field</value>
+        <a:documentation>A field</a:documentation>
+        <value>foreignkey</value>
+        <a:documentation>A foreign key</a:documentation>
+        <value>group</value>
+        <a:documentation>A group</a:documentation>
+        <value>index</value>
+        <a:documentation>An index</a:documentation>
+        <value>key1</value>
+        <a:documentation>The first or primary key</a:documentation>
+        <value>key2</value>
+        <a:documentation>An alternate or secondary key</a:documentation>
+        <value>name</value>
+        <a:documentation>A name</a:documentation>
+        <value>primarykey</value>
+        <a:documentation>The primary key</a:documentation>
+        <value>procedure</value>
+        <a:documentation>A (stored) procedure</a:documentation>
+        <value>record</value>
+        <a:documentation>A record</a:documentation>
+        <value>rule</value>
+        <a:documentation>A rule</a:documentation>
+        <value>secondarykey</value>
+        <a:documentation>The secondary key</a:documentation>
+        <value>table</value>
+        <a:documentation>A table</a:documentation>
+        <value>user</value>
+        <a:documentation>A user</a:documentation>
+        <value>view</value>
+        <a:documentation>A view</a:documentation>
+      </choice>
+    </define>
+    <define name="db.database.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of database artifact</a:documentation>
+        <ref name="db.database.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.database.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.database.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.database.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.database.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.database">
+      <element name="database">
+        <a:documentation>The name of a database, or part of a database</a:documentation>
+        <ref name="db.database.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.application.class.enumeration">
+      <choice>
+        <value>hardware</value>
+        <a:documentation>A hardware application</a:documentation>
+        <value>software</value>
+        <a:documentation>A software application</a:documentation>
+      </choice>
+    </define>
+    <define name="db.application.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of application</a:documentation>
+        <ref name="db.application.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.application.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.application.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.application.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.application.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.application">
+      <element name="application">
+        <a:documentation>The name of a software program</a:documentation>
+        <ref name="db.application.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.hardware.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.hardware.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.hardware.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.hardware">
+      <element name="hardware">
+        <a:documentation>A physical part of a computer system</a:documentation>
+        <ref name="db.hardware.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.gui.inlines">
+    <choice>
+      <ref name="db.guiicon"/>
+      <ref name="db.guibutton"/>
+      <ref name="db.guimenuitem"/>
+      <ref name="db.guimenu"/>
+      <ref name="db.guisubmenu"/>
+      <ref name="db.guilabel"/>
+      <ref name="db.menuchoice"/>
+      <ref name="db.mousebutton"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.guibutton.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guibutton.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guibutton.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guibutton">
+      <element name="guibutton">
+        <a:documentation>The text on a button in a GUI</a:documentation>
+        <ref name="db.guibutton.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.guiicon.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guiicon.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guiicon.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guiicon">
+      <element name="guiicon">
+        <a:documentation>Graphic and/or text appearing as a icon in a GUI</a:documentation>
+        <ref name="db.guiicon.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.guilabel.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guilabel.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guilabel.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guilabel">
+      <element name="guilabel">
+        <a:documentation>The text of a label in a GUI</a:documentation>
+        <ref name="db.guilabel.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.guimenu.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guimenu.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guimenu.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guimenu">
+      <element name="guimenu">
+        <a:documentation>The name of a menu in a GUI</a:documentation>
+        <ref name="db.guimenu.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.guimenuitem.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guimenuitem.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guimenuitem.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guimenuitem">
+      <element name="guimenuitem">
+        <a:documentation>The name of a terminal menu item in a GUI</a:documentation>
+        <ref name="db.guimenuitem.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.guisubmenu.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.guisubmenu.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.guisubmenu.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.guisubmenu">
+      <element name="guisubmenu">
+        <a:documentation>The name of a submenu in a GUI</a:documentation>
+        <ref name="db.guisubmenu.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.accel"/>
+            <ref name="db.superscript"/>
+            <ref name="db.subscript"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.menuchoice.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.menuchoice.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.menuchoice.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.menuchoice">
+      <element name="menuchoice">
+        <a:documentation>A selection or series of selections from a menu</a:documentation>
+        <ref name="db.menuchoice.attlist"/>
+        <optional>
+          <ref name="db.shortcut"/>
+        </optional>
+        <oneOrMore>
+          <choice>
+            <ref name="db.guibutton"/>
+            <ref name="db.guiicon"/>
+            <ref name="db.guilabel"/>
+            <ref name="db.guimenu"/>
+            <ref name="db.guimenuitem"/>
+            <ref name="db.guisubmenu"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.mousebutton.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.mousebutton.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.mousebutton.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.mousebutton">
+      <element name="mousebutton">
+        <a:documentation>The conventional name of a mouse button</a:documentation>
+        <ref name="db.mousebutton.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.keyboard.inlines">
+    <choice>
+      <ref name="db.keycombo"/>
+      <ref name="db.keycap"/>
+      <ref name="db.keycode"/>
+      <ref name="db.keysym"/>
+      <ref name="db.shortcut"/>
+      <ref name="db.accel"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.keycap.function.enumeration">
+      <choice>
+        <value>alt</value>
+        <a:documentation>The "Alt" key</a:documentation>
+        <value>backspace</value>
+        <a:documentation>The "Backspace" key</a:documentation>
+        <value>command</value>
+        <a:documentation>The "Command" key</a:documentation>
+        <value>control</value>
+        <a:documentation>The "Control" key</a:documentation>
+        <value>delete</value>
+        <a:documentation>The "Delete" key</a:documentation>
+        <value>down</value>
+        <a:documentation>The down arrow</a:documentation>
+        <value>end</value>
+        <a:documentation>The "End" key</a:documentation>
+        <value>enter</value>
+        <a:documentation>The "Enter" or "Return" key</a:documentation>
+        <value>escape</value>
+        <a:documentation>The "Escape" key</a:documentation>
+        <value>home</value>
+        <a:documentation>The "Home" key</a:documentation>
+        <value>insert</value>
+        <a:documentation>The "Insert" key</a:documentation>
+        <value>left</value>
+        <a:documentation>The left arrow</a:documentation>
+        <value>meta</value>
+        <a:documentation>The "Meta" key</a:documentation>
+        <value>option</value>
+        <a:documentation>The "Option" key</a:documentation>
+        <value>pagedown</value>
+        <a:documentation>The page down key</a:documentation>
+        <value>pageup</value>
+        <a:documentation>The page up key</a:documentation>
+        <value>right</value>
+        <a:documentation>The right arrow</a:documentation>
+        <value>shift</value>
+        <a:documentation>The "Shift" key</a:documentation>
+        <value>space</value>
+        <a:documentation>The spacebar</a:documentation>
+        <value>tab</value>
+        <a:documentation>The "Tab" key</a:documentation>
+        <value>up</value>
+        <a:documentation>The up arrow</a:documentation>
+      </choice>
+    </define>
+    <define name="db.keycap.function-enum.attribute">
+      <optional>
+        <attribute name="function">
+          <a:documentation>Identifies the function key</a:documentation>
+          <ref name="db.keycap.function.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.keycap.function-other.attributes">
+      <optional>
+        <attribute name="function">
+          <a:documentation>Identifies the function key</a:documentation>
+          <value>other</value>
+          <a:documentation>Indicates a non-standard function key</a:documentation>
+        </attribute>
+      </optional>
+      <attribute name="otherfunction">
+        <a:documentation>Specifies a keyword that identifies the non-standard key</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.keycap.function.attrib">
+      <choice>
+        <ref name="db.keycap.function-enum.attribute"/>
+        <ref name="db.keycap.function-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.keycap.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keycap.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keycap.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.keycap.function.attrib"/>
+      </interleave>
+    </define>
+    <define name="db.keycap">
+      <element name="keycap">
+        <a:documentation>The text printed on a key on a keyboard</a:documentation>
+        <ref name="db.keycap.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.keycode.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keycode.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keycode.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.keycode">
+      <element name="keycode">
+        <a:documentation>The internal, frequently numeric, identifier for a key on a keyboard</a:documentation>
+        <ref name="db.keycode.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.keycombination.contentmodel">
+    <choice>
+      <choice>
+        <ref name="db.keycap"/>
+        <ref name="db.keycombo"/>
+        <ref name="db.keysym"/>
+      </choice>
+      <ref name="db.mousebutton"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.keycombo.action.enumeration">
+      <choice>
+        <value>click</value>
+        <a:documentation>A (single) mouse click.</a:documentation>
+        <value>double-click</value>
+        <a:documentation>A double mouse click.</a:documentation>
+        <value>press</value>
+        <a:documentation>A mouse or key press.</a:documentation>
+        <value>seq</value>
+        <a:documentation>Sequential clicks or presses.</a:documentation>
+        <value>simul</value>
+        <a:documentation>Simultaneous clicks or presses.</a:documentation>
+      </choice>
+    </define>
+    <define name="db.keycombo.action-enum.attribute">
+      <optional>
+        <attribute name="action">
+          <a:documentation>Identifies the nature of the action taken. If keycombo
+ contains more than one element, simul
+ is the default, otherwise there is no default.</a:documentation>
+          <ref name="db.keycombo.action.enumeration"/>
+        </attribute>
+      </optional>
+    </define>
+    <define name="db.keycombo.action-other.attributes">
+      <optional>
+        <attribute name="action">
+          <a:documentation>Identifies the nature of the action taken</a:documentation>
+          <value>other</value>
+          <a:documentation>Indicates a non-standard action</a:documentation>
+        </attribute>
+      </optional>
+      <attribute name="otheraction">
+        <a:documentation>Identifies the non-standard action in some unspecified way.</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.keycombo.action.attrib">
+      <choice>
+        <ref name="db.keycombo.action-enum.attribute"/>
+        <ref name="db.keycombo.action-other.attributes"/>
+      </choice>
+    </define>
+    <define name="db.keycombo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keycombo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keycombo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.keycombo.action.attrib"/>
+      </interleave>
+    </define>
+    <define name="db.keycombo">
+      <element name="keycombo">
+        <a:documentation>A combination of input actions</a:documentation>
+        <ref name="db.keycombo.attlist"/>
+        <oneOrMore>
+          <ref name="db.keycombination.contentmodel"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.keysym.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.keysym.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.keysym.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.keysym">
+      <element name="keysym">
+        <a:documentation>The symbolic name of a key on a keyboard</a:documentation>
+        <ref name="db.keysym.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.accel.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.accel.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.accel.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.accel">
+      <element name="accel">
+        <a:documentation>A graphical user interface (GUI) keyboard shortcut</a:documentation>
+        <ref name="db.accel.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.shortcut.action.attrib">
+      <ref name="db.keycombo.action.attrib"/>
+    </define>
+    <define name="db.shortcut.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.shortcut.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.shortcut.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.shortcut.action.attrib"/>
+      </interleave>
+    </define>
+    <define name="db.shortcut">
+      <element name="shortcut">
+        <a:documentation>A key combination for an action that is also accessible through a menu</a:documentation>
+        <ref name="db.shortcut.attlist"/>
+        <oneOrMore>
+          <ref name="db.keycombination.contentmodel"/>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.os.inlines">
+    <choice>
+      <ref name="db.prompt"/>
+      <ref name="db.envar"/>
+      <ref name="db.filename"/>
+      <ref name="db.command"/>
+      <ref name="db.computeroutput"/>
+      <ref name="db.userinput"/>
+    </choice>
+  </define>
+  <define name="db.computeroutput.inlines">
+    <choice>
+      <choice>
+        <text/>
+        <ref name="db.ubiq.inlines"/>
+        <ref name="db.os.inlines"/>
+        <ref name="db.technical.inlines"/>
+      </choice>
+      <ref name="db.co"/>
+      <ref name="db.markup.inlines"/>
+    </choice>
+  </define>
+  <define name="db.userinput.inlines">
+    <choice>
+      <choice>
+        <text/>
+        <ref name="db.ubiq.inlines"/>
+        <ref name="db.os.inlines"/>
+        <ref name="db.technical.inlines"/>
+      </choice>
+      <ref name="db.co"/>
+      <ref name="db.markup.inlines"/>
+      <ref name="db.gui.inlines"/>
+      <ref name="db.keyboard.inlines"/>
+    </choice>
+  </define>
+  <define name="db.prompt.inlines">
+    <choice>
+      <ref name="db._text"/>
+      <ref name="db.co"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.prompt.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.prompt.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.prompt.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.prompt">
+      <element name="prompt">
+        <a:documentation>A character or string indicating the start of an input field in a  computer display</a:documentation>
+        <ref name="db.prompt.attlist"/>
+        <zeroOrMore>
+          <ref name="db.prompt.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.envar.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.envar.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.envar.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.envar">
+      <element name="envar">
+        <a:documentation>A software environment variable</a:documentation>
+        <ref name="db.envar.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.filename.class.enumeration">
+      <choice>
+        <value>devicefile</value>
+        <a:documentation>A device</a:documentation>
+        <value>directory</value>
+        <a:documentation>A directory</a:documentation>
+        <value>extension</value>
+        <a:documentation>A filename extension</a:documentation>
+        <value>headerfile</value>
+        <a:documentation>A header file (as for a programming language)</a:documentation>
+        <value>libraryfile</value>
+        <a:documentation>A library file</a:documentation>
+        <value>partition</value>
+        <a:documentation>A partition (as of a hard disk)</a:documentation>
+        <value>symlink</value>
+        <a:documentation>A symbolic link</a:documentation>
+      </choice>
+    </define>
+    <define name="db.filename.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the class of filename</a:documentation>
+        <ref name="db.filename.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.filename.path.attribute">
+      <attribute name="path">
+        <a:documentation>Specifies the path of the filename</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.filename.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.filename.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.filename.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.filename.path.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.filename.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.filename">
+      <element name="filename">
+        <a:documentation>The name of a file</a:documentation>
+        <ref name="db.filename.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.command.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.command.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.command.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.command">
+      <element name="command">
+        <a:documentation>The name of an executable program or other software command</a:documentation>
+        <ref name="db.command.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.computeroutput.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.computeroutput.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.computeroutput.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.computeroutput">
+      <element name="computeroutput">
+        <a:documentation>Data, generally text, displayed or presented by a computer</a:documentation>
+        <ref name="db.computeroutput.attlist"/>
+        <zeroOrMore>
+          <ref name="db.computeroutput.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.userinput.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.userinput.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.userinput.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.userinput">
+      <element name="userinput">
+        <a:documentation>Data entered by the user</a:documentation>
+        <ref name="db.userinput.attlist"/>
+        <zeroOrMore>
+          <ref name="db.userinput.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.cmdsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.cmdsynopsis.sepchar.attribute">
+      <attribute name="sepchar">
+        <a:documentation>Specifies the character that should separate the command and its top-level arguments</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.cmdsynopsis.cmdlength.attribute">
+      <attribute name="cmdlength">
+        <a:documentation>Indicates the displayed length of the command; this information may be used to intelligently indent command synopses which extend beyond one line</a:documentation>
+      </attribute>
+    </define>
+    <define name="db.cmdsynopsis.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.cmdsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.cmdsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.cmdsynopsis.sepchar.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.cmdsynopsis.cmdlength.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.cmdsynopsis.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.cmdsynopsis.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.cmdsynopsis">
+      <element name="cmdsynopsis">
+        <a:documentation>A syntax summary for a software command</a:documentation>
+        <ref name="db.cmdsynopsis.attlist"/>
+        <ref name="db.cmdsynopsis.info"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.command"/>
+            <ref name="db.arg"/>
+            <ref name="db.group"/>
+            <ref name="db.sbr"/>
+          </choice>
+        </oneOrMore>
+        <zeroOrMore>
+          <ref name="db.synopfragment"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <define name="db.rep.enumeration">
+    <choice>
+      <value>norepeat</value>
+      <a:documentation>Can not be repeated.</a:documentation>
+      <value>repeat</value>
+      <a:documentation>Can be repeated.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.rep.attribute">
+    <attribute name="rep" a:defaultValue="norepeat">
+      <a:documentation>Indicates whether or not repetition is possible.</a:documentation>
+      <ref name="db.rep.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.choice.enumeration">
+    <choice>
+      <value>opt</value>
+      <a:documentation>Formatted to indicate that it is optional.</a:documentation>
+      <value>plain</value>
+      <a:documentation>Formatted without indication.</a:documentation>
+      <value>req</value>
+      <a:documentation>Formatted to indicate that it is required.</a:documentation>
+    </choice>
+  </define>
+  <define name="db.choice.opt.attribute">
+    <attribute name="choice" a:defaultValue="opt">
+      <a:documentation>Indicates optionality.</a:documentation>
+      <ref name="db.choice.enumeration"/>
+    </attribute>
+  </define>
+  <define name="db.choice.req.attribute">
+    <attribute name="choice" a:defaultValue="req">
+      <a:documentation>Indicates optionality.</a:documentation>
+      <ref name="db.choice.enumeration"/>
+    </attribute>
+  </define>
+  <div>
+    <define name="db.arg.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.arg.rep.attribute">
+      <ref name="db.rep.attribute"/>
+    </define>
+    <define name="db.arg.choice.attribute">
+      <ref name="db.choice.opt.attribute"/>
+    </define>
+    <define name="db.arg.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.arg.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.arg.rep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.arg.choice.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.arg">
+      <element name="arg">
+        <a:documentation>An argument in a CmdSynopsis</a:documentation>
+        <ref name="db.arg.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.arg"/>
+            <ref name="db.group"/>
+            <ref name="db.option"/>
+            <ref name="db.synopfragmentref"/>
+            <ref name="db.sbr"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.group.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.group.rep.attribute">
+      <ref name="db.rep.attribute"/>
+    </define>
+    <define name="db.group.choice.attribute">
+      <ref name="db.choice.opt.attribute"/>
+    </define>
+    <define name="db.group.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.group.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.group.rep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.group.choice.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.group">
+      <element name="group">
+        <a:documentation>A group of elements in a CmdSynopsis</a:documentation>
+        <ref name="db.group.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.arg"/>
+            <ref name="db.group"/>
+            <ref name="db.option"/>
+            <ref name="db.synopfragmentref"/>
+            <ref name="db.replaceable"/>
+            <ref name="db.sbr"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.sbr.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.sbr.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.sbr.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.sbr">
+      <element name="sbr">
+        <a:documentation>An explicit line break in a command synopsis</a:documentation>
+        <ref name="db.sbr.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.synopfragment.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.synopfragment.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.synopfragment.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.synopfragment">
+      <element name="synopfragment">
+        <a:documentation>A portion of a CmdSynopsis broken out from the main body of the synopsis</a:documentation>
+        <ref name="db.synopfragment.attlist"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.arg"/>
+            <ref name="db.group"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.synopfragmentref.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.synopfragmentref.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.synopfragmentref.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.linkend.attribute"/>
+      </interleave>
+    </define>
+    <define name="db.synopfragmentref">
+      <element name="synopfragmentref">
+        <a:documentation>A reference to a fragment of a command synopsis</a:documentation>
+        <s:pattern name="Synopsis fragment type constraint">
+          <s:rule context="db:synopfragmentref">
+            <s:assert test="local-name(//*[@xml:id=current()/@linkend]) = 'synopfragment' and namespace-uri(//*[@xml:id=current()/@linkend]) = 'http://docbook.org/ns/docbook'">@linkend on synopfragmentref must point to a synopfragment.</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.synopfragmentref.attlist"/>
+        <text/>
+      </element>
+    </define>
+  </div>
+  <define name="db.programming.inlines">
+    <choice>
+      <ref name="db.function"/>
+      <ref name="db.parameter"/>
+      <ref name="db.varname"/>
+      <ref name="db.returnvalue"/>
+      <ref name="db.type"/>
+      <ref name="db.classname"/>
+      <ref name="db.exceptionname"/>
+      <ref name="db.interfacename"/>
+      <ref name="db.methodname"/>
+      <ref name="db.modifier"/>
+      <ref name="db.initializer"/>
+      <ref name="db.oo.inlines"/>
+    </choice>
+  </define>
+  <define name="db.oo.inlines">
+    <choice>
+      <ref name="db.ooclass"/>
+      <ref name="db.ooexception"/>
+      <ref name="db.oointerface"/>
+    </choice>
+  </define>
+  <define name="db.synopsis.blocks">
+    <choice>
+      <choice>
+        <ref name="db.funcsynopsis"/>
+        <ref name="db.classsynopsis"/>
+        <ref name="db.methodsynopsis"/>
+        <ref name="db.constructorsynopsis"/>
+        <ref name="db.destructorsynopsis"/>
+        <ref name="db.fieldsynopsis"/>
+      </choice>
+      <ref name="db.cmdsynopsis"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.synopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.synopsis.label.attribute">
+      <ref name="db.label.attribute"/>
+    </define>
+    <define name="db.synopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.synopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+        <optional>
+          <ref name="db.synopsis.label.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.synopsis">
+      <element name="synopsis">
+        <a:documentation>A general-purpose element for representing the syntax of commands or functions</a:documentation>
+        <ref name="db.synopsis.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.funcsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.funcsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.funcsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.funcsynopsis.info">
+      <ref name="db._info.title.forbidden"/>
+    </define>
+    <define name="db.funcsynopsis">
+      <element name="funcsynopsis">
+        <a:documentation>The syntax summary for a function definition</a:documentation>
+        <ref name="db.funcsynopsis.attlist"/>
+        <ref name="db.funcsynopsis.info"/>
+        <oneOrMore>
+          <choice>
+            <ref name="db.funcsynopsisinfo"/>
+            <ref name="db.funcprototype"/>
+          </choice>
+        </oneOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.funcsynopsisinfo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.funcsynopsisinfo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.funcsynopsisinfo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.funcsynopsisinfo">
+      <element name="funcsynopsisinfo">
+        <a:documentation>Information supplementing the FuncDefs of a FuncSynopsis</a:documentation>
+        <ref name="db.funcsynopsisinfo.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.funcprototype.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.funcprototype.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.funcprototype.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.funcprototype">
+      <element name="funcprototype">
+        <a:documentation>The prototype of a function</a:documentation>
+        <ref name="db.funcprototype.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <ref name="db.funcdef"/>
+        <choice>
+          <ref name="db.void"/>
+          <ref name="db.varargs"/>
+          <group>
+            <oneOrMore>
+              <ref name="db.paramdef"/>
+            </oneOrMore>
+            <optional>
+              <ref name="db.varargs"/>
+            </optional>
+          </group>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.funcdef.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.funcdef.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.funcdef.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.funcdef">
+      <element name="funcdef">
+        <a:documentation>A function (subroutine) name and its return type</a:documentation>
+        <ref name="db.funcdef.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.type"/>
+            <ref name="db.function"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.function.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.function.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.function.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.function">
+      <element name="function">
+        <a:documentation>The name of a function or subroutine, as in a programming language</a:documentation>
+        <ref name="db.function.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.void.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.void.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.void.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.void">
+      <element name="void">
+        <a:documentation>An empty element in a function synopsis indicating that the function in question takes no arguments</a:documentation>
+        <ref name="db.void.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.varargs.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.varargs.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.varargs.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.varargs">
+      <element name="varargs">
+        <a:documentation>An empty element in a function synopsis indicating a variable number of arguments</a:documentation>
+        <ref name="db.varargs.attlist"/>
+        <empty/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.paramdef.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.paramdef.choice.enumeration">
+      <choice>
+        <value>opt</value>
+        <a:documentation>Formatted to indicate that it is optional.</a:documentation>
+        <value>req</value>
+        <a:documentation>Formatted to indicate that it is required.</a:documentation>
+      </choice>
+    </define>
+    <define name="db.paramdef.choice.attribute">
+      <attribute name="choice" a:defaultValue="opt">
+        <a:documentation>Indicates optionality.</a:documentation>
+        <ref name="db.paramdef.choice.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.paramdef.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.paramdef.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.paramdef.choice.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.paramdef">
+      <element name="paramdef">
+        <a:documentation>Information about a function parameter in a programming language</a:documentation>
+        <ref name="db.paramdef.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db._text"/>
+            <ref name="db.initializer"/>
+            <ref name="db.type"/>
+            <ref name="db.parameter"/>
+            <ref name="db.funcparams"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.funcparams.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.funcparams.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.funcparams.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.funcparams">
+      <element name="funcparams">
+        <a:documentation>Parameters for a function referenced through a function pointer in a synopsis</a:documentation>
+        <ref name="db.funcparams.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.classsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.classsynopsis.class.enumeration">
+      <choice>
+        <value>class</value>
+        <a:documentation>This is the synopsis of a class</a:documentation>
+        <value>interface</value>
+        <a:documentation>This is the synopsis of an interface</a:documentation>
+      </choice>
+    </define>
+    <define name="db.classsynopsis.class.attribute">
+      <attribute name="class">
+        <a:documentation>Specifies the nature of the synopsis</a:documentation>
+        <ref name="db.classsynopsis.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.classsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.classsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.classsynopsis.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.classsynopsis">
+      <element name="classsynopsis">
+        <a:documentation>The syntax summary for a class definition</a:documentation>
+        <ref name="db.classsynopsis.attlist"/>
+        <oneOrMore>
+          <ref name="db.oo.inlines"/>
+        </oneOrMore>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.classsynopsisinfo"/>
+            <ref name="db.methodsynopsis"/>
+            <ref name="db.constructorsynopsis"/>
+            <ref name="db.destructorsynopsis"/>
+            <ref name="db.fieldsynopsis"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.classsynopsisinfo.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.classsynopsisinfo.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.classsynopsisinfo.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.classsynopsisinfo">
+      <element name="classsynopsisinfo">
+        <a:documentation>Information supplementing the contents of a ClassSynopsis</a:documentation>
+        <ref name="db.classsynopsisinfo.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.ooclass.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.ooclass.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.ooclass.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.ooclass">
+      <element name="ooclass">
+        <a:documentation>A class in an object-oriented programming language</a:documentation>
+        <ref name="db.ooclass.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.package"/>
+            <ref name="db.modifier"/>
+          </choice>
+        </zeroOrMore>
+        <ref name="db.classname"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.oointerface.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.oointerface.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.oointerface.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.oointerface">
+      <element name="oointerface">
+        <a:documentation>An interface in an object-oriented programming language</a:documentation>
+        <ref name="db.oointerface.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.package"/>
+            <ref name="db.modifier"/>
+          </choice>
+        </zeroOrMore>
+        <ref name="db.interfacename"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.ooexception.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.ooexception.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.ooexception.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.ooexception">
+      <element name="ooexception">
+        <a:documentation>An exception in an object-oriented programming language</a:documentation>
+        <ref name="db.ooexception.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.package"/>
+            <ref name="db.modifier"/>
+          </choice>
+        </zeroOrMore>
+        <ref name="db.exceptionname"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.modifier.xml.space.attribute">
+    <attribute name="xml:space">
+      <a:documentation>Can be used to indicate that whitespace in the modifier should be preserved (for multi-line annotations, for example).</a:documentation>
+      <value>preserve</value>
+      <a:documentation>Extra whitespace and line breaks must be preserved.</a:documentation>
+<!--
+        Ideally the definition of xml:space used on modifier would be
+        different from the definition used on the verbatim elements. The
+        verbatim elements forbid the use of xml:space="default" which
+        wouldn't be a problem on modifier. But doing that causes the
+        generated XSD schemas to be broken so I'm just reusing the existing
+        definition for now. It won't be backwards incompatible to fix this
+        problem in the future.
+           | ## Extra whitespace and line breaks are not preserved.
+             "default"
+      -->
+    </attribute>
+  </define>
+  <div>
+    <define name="db.modifier.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.modifier.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.modifier.xml.space.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.modifier.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.modifier">
+      <element name="modifier">
+        <a:documentation>Modifiers in a synopsis</a:documentation>
+        <ref name="db.modifier.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.interfacename.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.interfacename.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.interfacename.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.interfacename">
+      <element name="interfacename">
+        <a:documentation>The name of an interface</a:documentation>
+        <ref name="db.interfacename.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.exceptionname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.exceptionname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.exceptionname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.exceptionname">
+      <element name="exceptionname">
+        <a:documentation>The name of an exception</a:documentation>
+        <ref name="db.exceptionname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.fieldsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.fieldsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.fieldsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.fieldsynopsis">
+      <element name="fieldsynopsis">
+        <a:documentation>The name of a field in a class definition</a:documentation>
+        <ref name="db.fieldsynopsis.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.type"/>
+        </optional>
+        <ref name="db.varname"/>
+        <optional>
+          <ref name="db.initializer"/>
+        </optional>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.initializer.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.initializer.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.initializer.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.initializer">
+      <element name="initializer">
+        <a:documentation>The initializer for a FieldSynopsis</a:documentation>
+        <ref name="db.initializer.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.constructorsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.constructorsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.constructorsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.constructorsynopsis">
+      <element name="constructorsynopsis">
+        <a:documentation>A syntax summary for a constructor</a:documentation>
+        <ref name="db.constructorsynopsis.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.methodname"/>
+        </optional>
+        <choice>
+          <oneOrMore>
+            <ref name="db.methodparam"/>
+          </oneOrMore>
+          <optional>
+            <ref name="db.void"/>
+          </optional>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.exceptionname"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.destructorsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.destructorsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.destructorsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.destructorsynopsis">
+      <element name="destructorsynopsis">
+        <a:documentation>A syntax summary for a destructor</a:documentation>
+        <ref name="db.destructorsynopsis.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.methodname"/>
+        </optional>
+        <choice>
+          <oneOrMore>
+            <ref name="db.methodparam"/>
+          </oneOrMore>
+          <optional>
+            <ref name="db.void"/>
+          </optional>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.exceptionname"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.methodsynopsis.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.methodsynopsis.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.methodsynopsis.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.language.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.methodsynopsis">
+      <element name="methodsynopsis">
+        <a:documentation>A syntax summary for a method</a:documentation>
+        <ref name="db.methodsynopsis.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <optional>
+          <choice>
+            <ref name="db.type"/>
+            <ref name="db.void"/>
+          </choice>
+        </optional>
+        <ref name="db.methodname"/>
+        <choice>
+          <oneOrMore>
+            <ref name="db.methodparam"/>
+          </oneOrMore>
+          <ref name="db.void"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.exceptionname"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.methodname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.methodname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.methodname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.methodname">
+      <element name="methodname">
+        <a:documentation>The name of a method</a:documentation>
+        <ref name="db.methodname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.methodparam.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.methodparam.rep.attribute">
+      <ref name="db.rep.attribute"/>
+    </define>
+    <define name="db.methodparam.choice.attribute">
+      <ref name="db.choice.req.attribute"/>
+    </define>
+    <define name="db.methodparam.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.methodparam.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.methodparam.rep.attribute"/>
+        </optional>
+        <optional>
+          <ref name="db.methodparam.choice.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.methodparam">
+      <element name="methodparam">
+        <a:documentation>Parameters to a method</a:documentation>
+        <ref name="db.methodparam.attlist"/>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="db.type"/>
+        </optional>
+        <choice>
+          <group>
+            <zeroOrMore>
+              <ref name="db.modifier"/>
+            </zeroOrMore>
+            <ref name="db.parameter"/>
+            <optional>
+              <ref name="db.initializer"/>
+            </optional>
+          </group>
+          <ref name="db.funcparams"/>
+        </choice>
+        <zeroOrMore>
+          <ref name="db.modifier"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.varname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.varname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.varname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.varname">
+      <element name="varname">
+        <a:documentation>The name of a variable</a:documentation>
+        <ref name="db.varname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.returnvalue.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.returnvalue.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.returnvalue.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.returnvalue">
+      <element name="returnvalue">
+        <a:documentation>The value returned by a function</a:documentation>
+        <ref name="db.returnvalue.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.type.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.type.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.type.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.type">
+      <element name="type">
+        <a:documentation>The classification of a value</a:documentation>
+        <ref name="db.type.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.classname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.classname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.classname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.classname">
+      <element name="classname">
+        <a:documentation>The name of a class, in the object-oriented programming sense</a:documentation>
+        <ref name="db.classname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.programlisting.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.programlisting.width.attribute">
+      <ref name="db.width.characters.attribute"/>
+    </define>
+    <define name="db.programlisting.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.programlisting.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <ref name="db.verbatim.attributes"/>
+        <optional>
+          <ref name="db.programlisting.width.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.programlisting">
+      <element name="programlisting">
+        <a:documentation>A literal listing of all or part of a program</a:documentation>
+        <ref name="db.programlisting.attlist"/>
+        <ref name="db.verbatim.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.admonition.blocks">
+    <choice>
+      <ref name="db.caution"/>
+      <ref name="db.important"/>
+      <ref name="db.note"/>
+      <ref name="db.tip"/>
+      <ref name="db.warning"/>
+    </choice>
+  </define>
+  <define name="db.admonition.contentmodel">
+    <ref name="db._info.title.only"/>
+    <oneOrMore>
+      <ref name="db.all.blocks"/>
+    </oneOrMore>
+  </define>
+  <div>
+    <define name="db.caution.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.caution.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.caution.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.caution">
+      <element name="caution">
+        <a:documentation>A note of caution</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caution">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of caution</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caution">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of caution</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caution">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of caution</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caution">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of caution</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:caution">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of caution</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.caution.attlist"/>
+        <ref name="db.admonition.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.important.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.important.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.important.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.important">
+      <element name="important">
+        <a:documentation>An admonition set off from the text</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:important">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of important</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:important">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of important</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:important">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of important</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:important">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of important</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:important">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of important</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.important.attlist"/>
+        <ref name="db.admonition.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.note.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.note.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.note.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.note">
+      <element name="note">
+        <a:documentation>A message set off from the text</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:note">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of note</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:note">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of note</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:note">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of note</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:note">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of note</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:note">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of note</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.note.attlist"/>
+        <ref name="db.admonition.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.tip.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.tip.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.tip.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.tip">
+      <element name="tip">
+        <a:documentation>A suggestion to the user, set off from the text</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:tip">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of tip</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:tip">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of tip</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:tip">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of tip</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:tip">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of tip</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:tip">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of tip</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.tip.attlist"/>
+        <ref name="db.admonition.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.warning.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.warning.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.warning.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.warning">
+      <element name="warning">
+        <a:documentation>An admonition set off from the text</a:documentation>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:warning">
+            <s:assert test="not(.//db:caution)">caution must not occur in the descendants of warning</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:warning">
+            <s:assert test="not(.//db:important)">important must not occur in the descendants of warning</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:warning">
+            <s:assert test="not(.//db:note)">note must not occur in the descendants of warning</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:warning">
+            <s:assert test="not(.//db:tip)">tip must not occur in the descendants of warning</s:assert>
+          </s:rule>
+        </s:pattern>
+        <s:pattern name="Element exclusion">
+          <s:rule context="db:warning">
+            <s:assert test="not(.//db:warning)">warning must not occur in the descendants of warning</s:assert>
+          </s:rule>
+        </s:pattern>
+        <ref name="db.warning.attlist"/>
+        <ref name="db.admonition.contentmodel"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.error.inlines">
+    <choice>
+      <ref name="db.errorcode"/>
+      <ref name="db.errortext"/>
+      <ref name="db.errorname"/>
+      <ref name="db.errortype"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.errorcode.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.errorcode.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.errorcode.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.errorcode">
+      <element name="errorcode">
+        <a:documentation>An error code</a:documentation>
+        <ref name="db.errorcode.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.errorname.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.errorname.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.errorname.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.errorname">
+      <element name="errorname">
+        <a:documentation>An error name</a:documentation>
+        <ref name="db.errorname.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.errortext.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.errortext.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.errortext.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.errortext">
+      <element name="errortext">
+        <a:documentation>An error message.</a:documentation>
+        <ref name="db.errortext.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.errortype.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.errortype.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.errortype.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.errortype">
+      <element name="errortype">
+        <a:documentation>The classification of an error message</a:documentation>
+        <ref name="db.errortype.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <define name="db.systemitem.inlines">
+    <choice>
+      <ref name="db._text"/>
+      <ref name="db.co"/>
+    </choice>
+  </define>
+  <div>
+    <define name="db.systemitem.class.enumeration">
+      <choice>
+        <value>daemon</value>
+        <a:documentation>A daemon or other system process (syslogd)</a:documentation>
+        <value>domainname</value>
+        <a:documentation>A domain name (example.com)</a:documentation>
+        <value>etheraddress</value>
+        <a:documentation>An ethernet address (00:05:4E:49:FD:8E)</a:documentation>
+        <value>event</value>
+        <a:documentation>An event of some sort (SIGHUP)</a:documentation>
+        <value>eventhandler</value>
+        <a:documentation>An event handler of some sort (hangup)</a:documentation>
+        <value>filesystem</value>
+        <a:documentation>A filesystem (ext3)</a:documentation>
+        <value>fqdomainname</value>
+        <a:documentation>A fully qualified domain name (my.example.com)</a:documentation>
+        <value>groupname</value>
+        <a:documentation>A group name (wheel)</a:documentation>
+        <value>ipaddress</value>
+        <a:documentation>An IP address (127.0.0.1)</a:documentation>
+        <value>library</value>
+        <a:documentation>A library (libncurses)</a:documentation>
+        <value>macro</value>
+        <a:documentation>A macro</a:documentation>
+        <value>netmask</value>
+        <a:documentation>A netmask (255.255.255.192)</a:documentation>
+        <value>newsgroup</value>
+        <a:documentation>A newsgroup (comp.text.xml)</a:documentation>
+        <value>osname</value>
+        <a:documentation>An operating system name (Hurd)</a:documentation>
+        <value>process</value>
+        <a:documentation>A process (gnome-cups-icon)</a:documentation>
+        <value>protocol</value>
+        <a:documentation>A protocol (ftp)</a:documentation>
+        <value>resource</value>
+        <a:documentation>A resource</a:documentation>
+        <value>server</value>
+        <a:documentation>A server (mail.example.com)</a:documentation>
+        <value>service</value>
+        <a:documentation>A service (ppp)</a:documentation>
+        <value>systemname</value>
+        <a:documentation>A system name (hephaistos)</a:documentation>
+        <value>username</value>
+        <a:documentation>A user name (ndw)</a:documentation>
+      </choice>
+    </define>
+    <define name="db.systemitem.class.attribute">
+      <attribute name="class">
+        <a:documentation>Identifies the nature of the system item</a:documentation>
+        <ref name="db.systemitem.class.enumeration"/>
+      </attribute>
+    </define>
+    <define name="db.systemitem.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.systemitem.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.systemitem.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+        <optional>
+          <ref name="db.systemitem.class.attribute"/>
+        </optional>
+      </interleave>
+    </define>
+    <define name="db.systemitem">
+      <element name="systemitem">
+        <a:documentation>A system-related item or term</a:documentation>
+        <ref name="db.systemitem.attlist"/>
+        <zeroOrMore>
+          <ref name="db.systemitem.inlines"/>
+        </zeroOrMore>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.option.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.option.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.option.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.option">
+      <element name="option">
+        <a:documentation>An option for a software command</a:documentation>
+        <ref name="db.option.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.optional.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.optional.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.optional.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.optional">
+      <element name="optional">
+        <a:documentation>Optional information</a:documentation>
+        <ref name="db.optional.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+  <div>
+    <define name="db.property.role.attribute">
+      <attribute name="role"/>
+    </define>
+    <define name="db.property.attlist">
+      <interleave>
+        <optional>
+          <ref name="db.property.role.attribute"/>
+        </optional>
+        <ref name="db.common.attributes"/>
+        <ref name="db.common.linking.attributes"/>
+      </interleave>
+    </define>
+    <define name="db.property">
+      <element name="property">
+        <a:documentation>A unit of data associated with some part of a computer system</a:documentation>
+        <ref name="db.property.attlist"/>
+        <ref name="db._text"/>
+      </element>
+    </define>
+  </div>
+</grammar>


### PR DESCRIPTION
RNG attribute completion doesn't generate the proper prefix if the namespace is not declared

Fixes #1489