### PR TITLE
bump LSP4J version 0.14.0 to 0.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,10 @@
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<lsp4j.version>0.14.0</lsp4j.version>
-		<junit.version>5.9.1</junit.version>
+		<!--<lsp4j.version>0.14.0</lsp4j.version>-->
+		<lsp4j.version>0.20.1</lsp4j.version>
+		<org.eclipse.xtend.lib.version>2.29.0</org.eclipse.xtend.lib.version>
+		<junit.version>5.9.2</junit.version>
 	</properties>
 	<url>https://github.com/eclipse/lemminx</url>
 	<licenses>
@@ -46,7 +48,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.10</version>
+				<version>2.10.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.lsp4j</groupId>
@@ -85,11 +87,11 @@
 				<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
 				<version>${lsp4j.version}</version>
 			</dependency>
-			<dependency>
+			<!--<dependency>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>org.eclipse.xtend.lib</artifactId>
-				<version>2.16.0.M1</version>
-			</dependency>
+				<version>${org.eclipse.xtend.lib.version}</version>
+			</dependency>-->
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
bump junit version 5.9.1 to 5.9.2
bump gson version 2.10 to 2.10.1
remove org.eclipse.xtend.lib from dependencyManagement(Transitive by LSP4J)