### PR TITLE
Adjust error range for RelaxNG element-not-allow-yet error

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorCode.java
@@ -127,6 +127,7 @@ public enum RelaxNGErrorCode implements IXMLErrorCode {
 			// XML Validation based on RNG, RNC errors
 			case unknown_element:
 			case out_of_context_element:
+			case element_not_allowed_yet:
 			case incomplete_element_required_elements_missing_expected:
 			case unexpected_element_required_element_missing:
 			case incomplete_element_required_element_missing:

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorHandler.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/relaxng/xml/validator/RelaxNGErrorHandler.java
@@ -103,6 +103,10 @@ public class RelaxNGErrorHandler implements XMLErrorHandler {
 				// out_of_context_element=element {0} not allowed here{1}
 				return new RelaxNGReportInfo(RelaxNGErrorCode.out_of_context_element);
 			}
+			if (message.contains("not allowed yet")) {
+				// element {0} not allowed yet{1}
+				return new RelaxNGReportInfo(RelaxNGErrorCode.element_not_allowed_yet);
+			}
 
 			// Required attributes
 

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/xml/diagnostics/RelaxNGDiagnosticsTest.java
@@ -161,4 +161,14 @@ public class RelaxNGDiagnosticsTest extends AbstractCacheBasedTest {
 				d(1, 1, 4, RelaxNGErrorCode.incomplete_element_required_elements_missing_expected));
 	}
 
+	@Test
+	public void not_allowed_yet() throws Exception {
+		String xml = "<?xml-model href=\"notAllowedYet.rng\"?>\r\n" + //
+				"<root>\r\n" + //
+				"	<element2></element2>\r\n" + //
+				"</root>";
+		testDiagnosticsFor(xml, null, null, "src/test/resources/relaxng/test.xml", //
+				d(2, 2, 10, RelaxNGErrorCode.element_not_allowed_yet));
+	}
+
 }

--- a/org.eclipse.lemminx/src/test/resources/relaxng/notAllowedYet.rng
+++ b/org.eclipse.lemminx/src/test/resources/relaxng/notAllowedYet.rng
@@ -1,0 +1,21 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+  datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <ref name="rootElt" />
+  </start>
+  <define name="rootElt">
+    <element name="root">
+      <choice>
+        <element name="elementA">
+          <text />
+        </element>
+        <element name="elementB">
+          <text />
+        </element>
+      </choice>
+      <element name="element2">
+        <text />
+      </element>
+    </element>
+  </define>
+</grammar>


### PR DESCRIPTION
Fixes #1459 

![Screenshot from 2023-03-09 13-49-37](https://user-images.githubusercontent.com/73968480/224125647-73f3aaff-5d27-4d86-9591-0b0ef6989c41.png)
