### PR TITLE
Do not record number of file.identifier, file.extension instances.

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/DocumentTelemetryInfo.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/DocumentTelemetryInfo.java
@@ -31,6 +31,7 @@ public class DocumentTelemetryInfo {
 	private static final String DOC_PROP_GRAMMAR_NONE = "file.grammar.none";
 	private static final String DOC_PROP_GRAMMAR_DOCTYPE = "file.grammar.doctype";
 	private static final String DOC_PROP_GRAMMAR_XMLMODEL = "file.grammar.xmlmodel";
+	private static final String DOC_PROP_GRAMMAR_RELAXNG = "file.grammar.relaxng";
 	private static final String DOC_PROP_GRAMMAR_SCHEMALOC = "file.grammar.schemalocation";
 	private static final String DOC_PROP_GRAMMAR_NONSSCHEMALOC = "file.grammar.nonsschemalocation";
 
@@ -40,7 +41,7 @@ public class DocumentTelemetryInfo {
 		String fileExtension = uri.substring(index + 1, uri.length()).toLowerCase();
 		boolean isXML = !DOMUtils.isXSD(doc) && !DOMUtils.isDTD(uri);
 		Set<ReferencedGrammarInfo> referencedGrammarInfos = manager.getReferencedGrammarInfos(doc);
-		cache.put(String.join(".", DOC_PROP_EXT, fileExtension));
+		cache.put(DOC_PROP_EXT, fileExtension);
 
 		if (referencedGrammarInfos.isEmpty()) {
 			if (isXML) {
@@ -60,7 +61,11 @@ public class DocumentTelemetryInfo {
 						cache.put(DOC_PROP_GRAMMAR_DOCTYPE);
 						break;
 					case "xml-model":
-						cache.put(DOC_PROP_GRAMMAR_XMLMODEL);
+						if (DOMUtils.isRelaxNGUri(info.getIdentifierURI())) {
+							cache.put(DOC_PROP_GRAMMAR_RELAXNG);
+						} else {
+							cache.put(DOC_PROP_GRAMMAR_XMLMODEL);
+						}
 						break;
 					case "xsi:schemaLocation":
 						cache.put(DOC_PROP_GRAMMAR_SCHEMALOC);
@@ -76,7 +81,7 @@ public class DocumentTelemetryInfo {
 						if (new URI(identifier).getScheme() != null && !URIUtils.isFileResource(identifier)) {
 							int limit = Math.min(identifier.length(), 200); // 200 char limit
 							String shortId = identifier.substring(0, limit);
-							cache.put(String.join(".", DOC_PROP_IDENTIFIER, shortId));
+							cache.put(DOC_PROP_IDENTIFIER, shortId);
 						}
 					} catch (URISyntaxException e) {
 						// continue

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryCache.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry/TelemetryCache.java
@@ -12,20 +12,33 @@
 package org.eclipse.lemminx.telemetry;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Store telemetry data for transmission at a later time
  */
 public class TelemetryCache {
 
-	private Map<String, Integer> cache = new HashMap<>();
+	private Map<String, Object> cache = new HashMap<>();
 
-	public void put (String key) {
-		cache.put(key, cache.getOrDefault(key, 0) + 1);
+	public void put(String key) {
+		cache.put(key, ((Integer)cache.getOrDefault(key, 0)) + 1);
 	}
 
-	public Map<String, Integer> getProperties() {
+	public void put(String key, String value) {
+		Set<String> tmp = new HashSet<>();
+		Object val = cache.get(key);
+		if (val == null) {
+			tmp.add(value);
+			cache.put(key, tmp);
+		} else {
+			((Set<String>) cache.get(key)).add(value);
+		}
+	}
+
+	public Map<String, Object> getProperties() {
 		return cache;
 	}
 


### PR DESCRIPTION
- Add support for RelaxNG grammar detection in telemetry manager

Basic idea here is instead of recording properties of the form `("file.extension.xml", "10")` for each file extension we simply record `("file.extension", [ xml, xsd, rng ])`. Metrics regarding amount will be lost, but the format is more elegant and should be easier to process. Also I think the resolver kind could be used to get a rough idea of the raw number of different formats, which we do still record.

CC @datho7561 