### PR TITLE
ci: use actions/setup-java temurin distribution

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: 'maven'
     - name: Run Tests on Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates

See : https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
