### PR TITLE
Make ICodeActionParticipant members default

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lemminx</groupId>
 		<artifactId>lemminx-parent</artifactId>
-		<version>0.25.1-SNAPSHOT</version>
+		<version>0.26.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lemminx</artifactId>
 	<properties>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/codeaction/ICodeActionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/codeaction/ICodeActionParticipant.java
@@ -13,6 +13,7 @@
 package org.eclipse.lemminx.services.extensions.codeaction;
 
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -32,8 +33,11 @@ public interface ICodeActionParticipant {
 	 * @param request       the code action request.
 	 * @param codeActions   list of code actions to fill.
 	 * @param cancelChecker the cancel checker.
+	 * @throws CancellationException if the computation was cancelled
 	 */
-	void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker);
+	default void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker)
+			throws CancellationException {
+	}
 
 	/**
 	 * Collect the code action in the given <code>codeActions</code> for the given
@@ -42,8 +46,12 @@ public interface ICodeActionParticipant {
 	 * @param request       the code action request.
 	 * @param codeActions   list of code actions to fill.
 	 * @param cancelChecker the cancel checker.
+	 * @throws CancellationException if the computation was cancelled
+	 * 
+	 * @since 0.26
 	 */
-	default void doCodeActionUnconditional(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
+	default void doCodeActionUnconditional(ICodeActionRequest request, List<CodeAction> codeActions,
+			CancelChecker cancelChecker) throws CancellationException {
 	}
 
 	/**

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/extensions/ErrorParticipantLanguageServiceTest.java
@@ -113,20 +113,21 @@ public class ErrorParticipantLanguageServiceTest extends AbstractCacheBasedTest 
 		public ErrorParticipantLanguageService() {
 			super();
 
-			this.registerCodeActionParticipant((request, codeActions, cancelChecker) -> {
-				throw new RuntimeException("This participant is broken");
+			this.registerCodeActionParticipant(new ICodeActionParticipant() {
+				public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
+					throw new RuntimeException("This participant is broken");
+				}
 			});
-			this.registerCodeActionParticipant((request, codeActions, cancelChecker) -> {
-				// This Code Action Participant should add  its code actions based on diagnostic code
-				Diagnostic diagnostic = request.getDiagnostic();
-				if (diagnostic != null) {
-					codeActions.add(ca(diagnostic, te(0, 0, 0, 0, "a")));
+			this.registerCodeActionParticipant(new ICodeActionParticipant() {
+				public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
+					// This Code Action Participant should add  its code actions based on diagnostic code
+					Diagnostic diagnostic = request.getDiagnostic();
+					if (diagnostic != null) {
+						codeActions.add(ca(diagnostic, te(0, 0, 0, 0, "a")));
+					}
 				}
 			});
 			this.registerCodeActionParticipant(new ICodeActionParticipant () {
-				public void doCodeAction(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
-					// Nothing to do for a diagnostic, even if provided
-				}
 				public void doCodeActionUnconditional(ICodeActionRequest request, List<CodeAction> codeActions, CancelChecker cancelChecker) {
 					// This Code Action Participant should add  its code actions independently of
 					// diagnostic provided

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lemminx</groupId>
 	<artifactId>lemminx-parent</artifactId>
-	<version>0.25.1-SNAPSHOT</version>
+	<version>0.26.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse LemMinX</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
Also this PR bumps lemminx version to 0.26.0-SNAPSHOT and adds `@since 0.26` annotation to the new `ICodeActionParticipant.doCodeActionUnconditional` method 