### PR TITLE
Implement itemDefaults for completionList

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/CompletionResponse.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/CompletionResponse.java
@@ -23,7 +23,7 @@ import org.eclipse.lsp4j.CompletionList;
  * Completion response implementation.
  *
  */
-class CompletionResponse extends CompletionList implements ICompletionResponse {
+public class CompletionResponse extends CompletionList implements ICompletionResponse {
 
 	private transient List<String> seenAttributes;
 	private transient boolean hasSomeItemFromGrammar;

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -48,6 +48,7 @@ import org.eclipse.lemminx.services.extensions.completion.ICompletionResponse;
 import org.eclipse.lemminx.services.snippets.IXMLSnippetContext;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lemminx.settings.XMLCompletionSettings;
+import org.eclipse.lemminx.utils.CompletionItemDefaultsUtils;
 import org.eclipse.lemminx.utils.StringUtils;
 import org.eclipse.lemminx.utils.XMLPositionUtility;
 import org.eclipse.lsp4j.CompletionItem;
@@ -288,6 +289,8 @@ public class XMLCompletions {
 			return completionResponse;
 		} finally {
 			collectSnippetSuggestions(completionRequest, completionResponse);
+			// Manage itemDefaults
+			CompletionItemDefaultsUtils.process(completionResponse, settings);
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLCompletionSettings.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/settings/XMLCompletionSettings.java
@@ -114,6 +114,21 @@ public class XMLCompletionSettings {
 	}
 
 	/**
+	 * Returns <code>true</code> if the client support completion list itemDefaults given the field and
+	 * <code>false</code> otherwise.
+	 *
+	 * @param field the completionList itemDefaults field
+	 * 
+	 * @return <code>true</code> if the client support completion list itemDefaults given the field and
+	 * <code>false</code> otherwise.
+	 */
+	public boolean isCompletionListItemDefaultsSupport(String field) {
+		return completionCapabilities != null && completionCapabilities.getCompletionList() != null
+			&& completionCapabilities.getCompletionList().getItemDefaults() != null
+			&& completionCapabilities.getCompletionList().getItemDefaults().contains(field);
+	}
+
+	/**
 	 * Merge only the given completion settings (and not the capability) in the
 	 * settings.
 	 *

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/CompletionItemDefaultsUtils.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/utils/CompletionItemDefaultsUtils.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lemminx.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.lemminx.services.CompletionResponse;
+import org.eclipse.lemminx.settings.SharedSettings;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemDefaults;
+import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+/**
+ * CompletionItemDefaultsUtils for implementing itemDefaults in completion list
+ */
+public class CompletionItemDefaultsUtils {
+
+	private static final String ITEM_DEFAULTS_EDIT_RANGE = "editRange";
+
+	private static final String ITEM_DEFAULTS_INSERT_TEXT_FORMAT = "insertTextFormat";
+
+	/**
+	 * Processes the completion list and manages item defaults.
+	 *
+	 * @param completionResponse the completion response
+	 * @param sharedSettings     the shared settings
+	 */
+	public static void process(CompletionResponse completionResponse, SharedSettings sharedSettings) {
+		CompletionItemDefaults itemDefaults = new CompletionItemDefaults();
+		List<CompletionItem> completionList = completionResponse.getItems();
+		if (sharedSettings.getCompletionSettings().isCompletionListItemDefaultsSupport(ITEM_DEFAULTS_EDIT_RANGE)) {
+			setToMostCommonEditRange(completionList, itemDefaults);
+			completionResponse.setItemDefaults(itemDefaults);
+		}
+		if (sharedSettings.getCompletionSettings()
+				.isCompletionListItemDefaultsSupport(ITEM_DEFAULTS_INSERT_TEXT_FORMAT)) {
+			setToMostCommonInsertTextFormat(completionList, itemDefaults);
+			completionResponse.setItemDefaults(itemDefaults);
+		}
+	}
+
+	/**
+	 * Sets the most common editRange in the completion list in item
+	 * defaults and processes the completion list.
+	 *
+	 * @param completionList the completion list
+	 * @param itemDefaults   the item defaults
+	 */
+	private static void setToMostCommonEditRange(List<CompletionItem> completionList,
+			CompletionItemDefaults itemDefaults) {
+		Map<Range, List<CompletionItem>> itemsByRange = completionList.stream()
+				.collect(Collectors.groupingBy(item -> item.getTextEdit().getLeft().getRange()));
+		int maxCount = 0;
+		Range mostCommonRange = null;
+		for (Map.Entry<Range, List<CompletionItem>> entry : itemsByRange.entrySet()) {
+			int currentSize = entry.getValue().size();
+			if (currentSize > maxCount) {
+				maxCount = currentSize;
+				mostCommonRange = entry.getKey();
+			}
+		}
+		itemsByRange.get(mostCommonRange).forEach(item -> {
+			item.setTextEditText(item.getTextEdit().getLeft().getNewText());
+			item.setTextEdit(null);
+		});
+		itemDefaults.setEditRange(Either.forLeft(mostCommonRange));
+		completionList = itemsByRange.values().stream().flatMap(Collection::stream)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Sets the most common InsertTextFormat in the completion list in item
+	 * defaults and processes the completion list.
+	 *
+	 * @param completionList the completion list
+	 * @param itemDefaults   the item defaults
+	 */
+	private static void setToMostCommonInsertTextFormat(List<CompletionItem> completionList,
+			CompletionItemDefaults itemDefaults) {
+		Map<InsertTextFormat, List<CompletionItem>> itemsByInsertTextFormat = completionList.stream()
+				.filter(item -> item.getInsertTextFormat() != null)
+				.collect(Collectors.groupingBy(item -> item.getInsertTextFormat()));
+		int maxCount = 0;
+		InsertTextFormat mostCommonInsertTextFormat = null;
+		for (Map.Entry<InsertTextFormat, List<CompletionItem>> entry : itemsByInsertTextFormat.entrySet()) {
+			int currentSize = entry.getValue().size();
+			if (currentSize > maxCount) {
+				maxCount = currentSize;
+				mostCommonInsertTextFormat = entry.getKey();
+			}
+		}
+		if (mostCommonInsertTextFormat == null) {
+			return;
+		}
+		itemsByInsertTextFormat.get(mostCommonInsertTextFormat).forEach(item -> {
+			item.setInsertTextFormat(null);
+		});
+		itemDefaults.setInsertTextFormat(mostCommonInsertTextFormat);
+		completionList = itemsByInsertTextFormat.values().stream().flatMap(Collection::stream)
+				.collect(Collectors.toList());
+	}
+}

--- a/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/org.eclipse.lemminx/src/main/resources/META-INF/native-image/reflect-config.json
@@ -722,6 +722,14 @@
 		}]
 	},
 	{
+		"name": "org.eclipse.lsp4j.CompletionItemDefaults",
+		"allDeclaredFields": true,
+		"methods": [{
+			"name": "<init>",
+			"parameterTypes": []
+		}]
+	},
+	{
 		"name": "org.eclipse.lsp4j.CompletionItemKind",
 		"fields": [{
 				"name": "Class"

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/DTDCompletionExtensionsTest.java
@@ -173,6 +173,31 @@ public class DTDCompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void externalDTDCompletionAllDeclsItemDefaults() throws BadLocationException {
+		// completion on <|
+		String xml = "<?xml version = \"1.0\"?>\r\n" + //
+				"<!DOCTYPE Folks [\r\n" + //
+				"	<!ELEMENT Folks (Person*)>\r\n" + //
+				"	|\r\n" + //
+				"]>\r\n" + //
+				"<Folks>\r\n" + //
+				"	" + //
+				"</Folks>";
+		testCompletionFor(xml, true, true, //
+				DTDNODE_SNIPPETS /* DTD node snippets */ + //
+						COMMENT_SNIPPETS /* Comment snippets */ , "catalog.xml", //
+				c("Insert DTD Element Declaration", te(3, 1, 3, 1, "<!ELEMENT ${1:element-name} (${2:#PCDATA})>"),
+						"<!ELEMENT"),
+				c("Insert Internal DTD Entity Declaration",
+						te(3, 1, 3, 1, "<!ENTITY ${1:entity-name} \"${2:entity-value}\">"), "<!ENTITY"),
+				c("Insert DTD Attributes List Declaration",
+						te(3, 1, 3, 1, "<!ATTLIST ${1:element-name} ${2:attribute-name} ${3:ID} ${4:#REQUIRED}>"),
+						"<!ATTLIST"),
+				c("Insert External DTD Entity Declaration",
+						te(3, 1, 3, 1, "<!ENTITY ${1:entity-name} SYSTEM \"${2:entity-value}\">"), "<!ENTITY"));
+	}
+
+	@Test
 	public void externalDTDCompletionAllDeclsSnippetsNotSupported() throws BadLocationException {
 		// completion on <|
 		String xml = "<?xml version = \"1.0\"?>\r\n" + //
@@ -270,6 +295,12 @@ public class DTDCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	private void testCompletionFor(String xml, boolean isSnippetsSupported, Integer expectedCount, String catalog,
 			CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(xml, isSnippetsSupported, false, expectedCount, catalog, expectedItems);
+	}
+
+	private void testCompletionFor(String xml, boolean isSnippetsSupported, boolean enableItemDefaults,
+			Integer expectedCount, String catalog,
+			CompletionItem... expectedItems) throws BadLocationException {
 		CompletionCapabilities completionCapabilities = new CompletionCapabilities();
 		CompletionItemCapabilities completionItem = new CompletionItemCapabilities(isSnippetsSupported); // activate
 																											// snippets
@@ -278,6 +309,6 @@ public class DTDCompletionExtensionsTest extends AbstractCacheBasedTest {
 		SharedSettings sharedSettings = new SharedSettings();
 		sharedSettings.getCompletionSettings().setCapabilities(completionCapabilities);
 		XMLAssert.testCompletionFor(new XMLLanguageService(), xml, "src/test/resources/catalogs/" + catalog, null, null,
-				expectedCount, sharedSettings, expectedItems);
+				expectedCount, sharedSettings, enableItemDefaults, expectedItems);
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLModelCompletionExtensionsTest.java
@@ -49,6 +49,22 @@ public class XMLModelCompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void completionBasedOnDTDWithXMLModelItemDefaults() throws BadLocationException {
+		// completion on <|
+		String xml = "<?xml version=\"1.0\"?>\r\n" + //
+				"<?xml-model href=\"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd\"?>\r\n" + //
+				"\r\n" + //
+				"  <catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\"\r\n" + //
+				"           prefer=\"public\">\r\n" + //
+				"\r\n" + //
+				"    <|";
+		testCompletionFor(xml, true, true, null, 
+				c("delegatePublic", te(6, 4, 6, 5, "<delegatePublic publicIdStartString=\"$1\" catalog=\"$2\" />$0"),
+						"<delegatePublic"), //
+				c("public", te(6, 4, 6, 5, "<public publicId=\"$1\" uri=\"$2\" />$0"), "<public"));
+	}
+
+	@Test
 	public void completionBasedOnXSDWithXMLModel() throws BadLocationException {
 		String xml = "<?xml-model href=\"http://maven.apache.org/xsd/maven-4.0.0.xsd\"?>\r\n" + //
 				"<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\r\n" + //
@@ -77,6 +93,11 @@ public class XMLModelCompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	private static void testCompletionFor(String xml, boolean isSnippetsSupported, Integer expectedCount,
 			CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(xml, isSnippetsSupported, false, expectedCount, expectedItems);
+	}
+
+	private static void testCompletionFor(String xml, boolean isSnippetsSupported, boolean enableItemDefaults,
+			Integer expectedCount, CompletionItem... expectedItems) throws BadLocationException {
 		CompletionCapabilities completionCapabilities = new CompletionCapabilities();
 		CompletionItemCapabilities completionItem = new CompletionItemCapabilities(isSnippetsSupported); // activate
 																											// snippets
@@ -85,7 +106,7 @@ public class XMLModelCompletionExtensionsTest extends AbstractCacheBasedTest {
 		SharedSettings sharedSettings = new SharedSettings();
 		sharedSettings.getCompletionSettings().setCapabilities(completionCapabilities);
 		XMLAssert.testCompletionFor(new XMLLanguageService(), xml, "src/test/resources/catalogs/catalog.xml", null,
-				null, expectedCount, sharedSettings, expectedItems);
+				null, expectedCount, sharedSettings, enableItemDefaults, expectedItems);
 	}
 
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -109,6 +109,19 @@ public class XMLSchemaCompletionExtensionsTest extends BaseFileTempTest {
 	}
 
 	@Test
+	public void completionInRootWithCloseBracketItemDefaults() throws BadLocationException {
+		String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n" + //
+				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+				"	xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\r\n"
+				+ //
+				"	<|  >" + // here last '<' is replaced with <modelVersion></modelVersion>
+				"</project>";
+		testCompletionWithCatalogFor(xml,
+				c("modelVersion", te(3, 1, 3, 5, "<modelVersion></modelVersion>"), "<modelVersion"), //
+				c("parent", "<parent></parent>", "<parent"));
+	}
+
+	@Test
 	public void completionInChildElement() throws BadLocationException {
 		String xml = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\r\n" + //
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/entities/EntitiesCompletionExtensionsTest.java
@@ -113,6 +113,24 @@ public class EntitiesCompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void underscoreEntityNameItemDefaults() throws BadLocationException {
+		// &foo_b|
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<!DOCTYPE root [\r\n" + //
+				"  <!ENTITY foo_bar \"&#x2014;\">\r\n" + //
+				"  <!ENTITY foo_baz \"&#x2014;\">\r\n" + //
+				"]>\r\n" + //
+				"<root>\r\n" + //
+				"  &foo_b|\r\n" + // <- here completion shows mdash entity
+				"</root>";
+		testCompletionFor(xml, 2 + //
+				2 /* CDATA and Comments */ + //
+				PredefinedEntity.values().length /* predefined entities */, true,
+				c("&foo_bar;", "&foo_bar;", r(6, 2, 6, 8), "&foo_bar;"), //
+				c("&foo_baz;", "&foo_baz;", r(6, 2, 6, 8), "&foo_baz;"));
+	}
+
+	@Test
 	public void insideWithAmp() throws BadLocationException {
 		// &m|d;blablabla
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/prolog/PrologCompletionExtensionsTest.java
@@ -97,6 +97,18 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void completionVersionValueItemDefaults() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=| ?>\r\n" + //
+				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">";
+		testCompletionFor(true, xml,
+				c(PrologModel.VERSION_1, te(0, 14, 0, 14, "\"" + PrologModel.VERSION_1 + "\""),
+						"\"" + PrologModel.VERSION_1 + "\""),
+				c(PrologModel.VERSION_1_1, te(0, 14, 0, 14, "\"" + PrologModel.VERSION_1_1 + "\""),
+						"\"" + PrologModel.VERSION_1_1 + "\""));
+	}
+
+	@Test
 	public void completionVersionNoSpaceAfterEquals() throws BadLocationException {
 		// completion on |
 		String xml = "<?xml version=|?>\r\n" + // <- no space after the '='
@@ -328,6 +340,10 @@ public class PrologCompletionExtensionsTest extends AbstractCacheBasedTest {
 						"<?xml version=\"${1|1.0,1.1|}\" encoding=\"${2|UTF-8,ISO-8859-1,Windows-1251,Windows-1252,Shift JIS,GB2312,EUC-KR|}\"?>${0}", //
 						r(0, 0, 0, 7), //
 						"<?xml"));
+	}
+
+	private void testCompletionFor(boolean enableItemDefaults, String xml, CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(xml, null, enableItemDefaults, expectedItems);
 	}
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/relaxng/grammar/rng/RNGCompletionExtensionsTest.java
@@ -44,6 +44,20 @@ public class RNGCompletionExtensionsTest extends BaseFileTempTest {
 	}
 
 	@Test
+	public void completionOnRootItemDefaults() throws BadLocationException {
+		// completion on <|
+		String xml = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\">\r\n" + //
+				"  <|\r\n" + //
+				"</grammar>";
+		testCompletionFor(xml, true, //
+				4 + CDATA_SNIPPETS + COMMENT_SNIPPETS, //
+				c("include", te(1, 2, 1, 3, "<include href=\"\"></include>"), "<include"), //
+				c("div", te(1, 2, 1, 3, "<div></div>"), "<div"), //
+				c("start", te(1, 2, 1, 3, "<start></start>"), "<start"), //
+				c("define", te(1, 2, 1, 3, "<define name=\"\"></define>"), "<define"));
+	}
+
+	@Test
 	public void completionOnElementNoName() throws BadLocationException {
 		// completion on <|
 		String xml = "<grammar xmlns=\"http://relaxng.org/ns/structure/1.0\"\r\n" + //
@@ -157,6 +171,11 @@ public class RNGCompletionExtensionsTest extends BaseFileTempTest {
 
 	private static void testCompletionFor(String value, Integer expectedCount, CompletionItem... expectedItems)
 			throws BadLocationException {
+		testCompletionFor(value, false, expectedCount, expectedItems);
+	}
+
+	private static void testCompletionFor(String value, boolean enableItemDefaults, Integer expectedCount,
+			CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(new XMLLanguageService(), value, null, null, "src/test/resources/relaxng/test.xml",
 				expectedCount, true, expectedItems);
 	}

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsd/XSDCompletionExtensionsTest.java
@@ -81,6 +81,21 @@ public class XSDCompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void completionOnElementTypeItemDefaults() throws BadLocationException {
+		// completion on | xs:element/@type -> xs:complexType/@name, xs:simpleType/@name
+		String xml = "<?xml version=\"1.1\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\r\n"
+				+ //
+				"	<xs:element name=\"elt\" type=\"|\" />\r\n" + //
+				"	<xs:complexType name=\"aComplexType\" />\r\n" + //
+				"	<xs:simpleType name=\"aSimpleType\" />\r\n" + //
+				"</xs:schema>";
+		testCompletionFor(xml, true, c("xs:aComplexType", te(2, 30, 2, 30, "xs:aComplexType"), "xs:aComplexType"),
+				c("xs:aSimpleType", te(2, 30, 2, 30, "xs:aSimpleType"), "xs:aSimpleType"),
+				c("xs:string", te(2, 30, 2, 30, "xs:string"), "xs:string"));
+	}
+
+	@Test
 	public void completionOnAttributeType() throws BadLocationException {
 		// completion on | xs:attribute/@type -> xs:simpleType/@name
 		String xml = "<?xml version=\"1.1\" ?>\r\n" + //
@@ -169,6 +184,10 @@ public class XSDCompletionExtensionsTest extends AbstractCacheBasedTest {
 		XMLAssert.testCompletionFor(xml, null, "test.xml", 2,
 				c("TypeFromB", te(6, 20, 6, 20, "TypeFromB"), "TypeFromB"),
 				c("TypeFromC", te(6, 20, 6, 20, "TypeFromC"), "TypeFromC"));
+	}
+
+	private void testCompletionFor(String xml, boolean enableItemDefaults, CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(xml, null, enableItemDefaults, expectedItems);
 	}
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsi/XSICompletionExtensionsTest.java
@@ -43,6 +43,16 @@ public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 	}
 
 	@Test
+	public void completionItemDefaults() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=\"1.0\"?>\r\n" + //
+				"<project xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=|>";
+		testCompletionFor(xml, true,
+				c("true", te(1, 71, 1, 71, "\"true\""), "\"true\""),
+				c("false", te(1, 71, 1, 71, "\"false\""), "\"false\""));
+	}
+
+	@Test
 	public void completion2() throws BadLocationException {
 		// completion on |
 		String xml = "<?xml version=\"1.0\"?>\r\n" + //
@@ -156,5 +166,9 @@ public class XSICompletionExtensionsTest extends AbstractCacheBasedTest {
 
 	private void testCompletionFor(String xml, SharedSettings sharedSettings, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(new XMLLanguageService(), xml, null, null, null, null, sharedSettings, expectedItems);
+	}
+
+	private void testCompletionFor(String xml, boolean enableItemDefaults, CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(xml, null, enableItemDefaults, expectedItems);
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLCompletionExtensionsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/xsl/XSLCompletionExtensionsTest.java
@@ -39,7 +39,23 @@ public class XSLCompletionExtensionsTest extends AbstractCacheBasedTest {
 				c("xsl:import", te(2, 0, 2, 0, "<xsl:import href=\"\" />"), "xsl:import")); // coming from stylesheet children
 	}
 
+	@Test
+	public void completionItemDefaults() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=\"1.0\"?>\r\n" + //
+				"<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\r\n" + //
+				"|";
+		testCompletionFor(xml, true,
+				c("xsl:template", te(2, 0, 2, 0, "<xsl:template></xsl:template>"), "xsl:template"), // <-- coming from substition group of xsl:declaration
+				c("xsl:output", te(2, 0, 2, 0, "<xsl:output></xsl:output>"), "xsl:output"), // <-- coming from substition group of xsl:declaration
+				c("xsl:import", te(2, 0, 2, 0, "<xsl:import href=\"\" />"), "xsl:import")); // coming from stylesheet children
+	}
+
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(xml, null, expectedItems);
+	}
+
+	private void testCompletionFor(String xml, boolean enableItemDefaults, CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(xml, null, enableItemDefaults, expectedItems);
 	}
 }

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionSnippetsTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionSnippetsTest.java
@@ -235,6 +235,209 @@ public class XMLCompletionSnippetsTest {
 	}
 
 	@Test
+	public void emptyXMLContentItemDefaults() throws BadLocationException {
+		testCompletionFor("|", //
+				REGION_SNIPPETS /* #region */ + //
+						NEW_XML_SNIPPETS /* DOCTYPE snippets */ + //
+						XML_DECLARATION_SNIPPETS /* XML Declaration snippets */ + //
+						PROCESSING_INSTRUCTION_SNIPPETS /* Processing Instruction snippets */ + //
+						COMMENT_SNIPPETS /* Comment snippets */ + //
+						CATALOG_SNIPPETS /* Catalog snippets */ , //
+				true,
+				c("New XML with SYSTEM DOCTYPE", //
+						"<!DOCTYPE root-element SYSTEM \"file.dtd\">" + lineSeparator() + //
+								"<root-element>" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 0), "<!DOCTYPE"),
+				c("Insert XML Declaration", //
+						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
+						r(0, 0, 0, 0), "<?xml"),
+				c("Insert XML Schema association", //
+						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
+						r(0, 0, 0, 0), "<?xml-model"),
+				c("Insert DTD association", //
+						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
+						r(0, 0, 0, 0), "<?xml-model"),
+				c("New XML bound with xsi:schemaLocation", //
+						"<root-element xmlns=\"https://github.com/eclipse/lemminx\"" + lineSeparator() + //
+								"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
+								"	xsi:schemaLocation=\"" + lineSeparator() + //
+								"		https://github.com/eclipse/lemminx file.xsd\">" + lineSeparator() + //
+								"	" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 0), "schemaLocation"),
+				c("New XML bound with xsi:noNamespaceSchemaLocation", //
+						"<root-element" + lineSeparator() + //
+								"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
+								"	xsi:noNamespaceSchemaLocation=\"file.xsd\">" + lineSeparator() + //
+								"	" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 0), "noNamespaceSchemaLocation"),
+				c("New XML bound with RelaxNG", //
+						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + lineSeparator() + //
+								"<?xml-model href=\"file.rng\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>"
+								+ lineSeparator() + //
+								"<root-element>" + lineSeparator() + //
+								"	" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 0), "relaxng"),
+				c("New catalog bound using DTD", //
+						"<!DOCTYPE catalog" + lineSeparator() + //
+								"\tPUBLIC \"-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN\"" + lineSeparator() + //
+								"\t\"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd\">"
+								+ lineSeparator() + //
+								"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" prefer=\"public\">"
+								+ lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 0), "<catalog"),
+				c("New catalog bound using XSD", //
+						"<catalog" + lineSeparator() + //
+								"\txmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\"" + lineSeparator() + //
+								"\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
+								"\txsi:schemaLocation=\"urn:oasis:names:tc:entity:xmlns:xml:catalog" + lineSeparator() + //
+								"\t\thttp://www.oasis-open.org/committees/entity/release/1.1/catalog.xsd\""
+								+ lineSeparator() + //
+								"\tprefer=\"public\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 0), "<catalog"),
+				c("New catalog", //
+						"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>",
+						r(0, 0, 0, 0), "<catalog"),
+				c("<!--", //
+						"<!-- -->", //
+						r(0, 0, 0, 0), "<!--"));
+
+		testCompletionFor("<|", //
+				NEW_XML_SNIPPETS /* DOCTYPE snippets */ + //
+						XML_DECLARATION_SNIPPETS /* XML Declaration snippets */ + //
+						PROCESSING_INSTRUCTION_SNIPPETS /* Processing Instruction snippets */ + //
+						COMMENT_SNIPPETS /* Comment snippets */ + //
+						CATALOG_SNIPPETS /* Catalog snippets */ , //
+				true,
+				c("New XML with SYSTEM DOCTYPE", //
+						"<!DOCTYPE root-element SYSTEM \"file.dtd\">" + lineSeparator() + //
+								"<root-element>" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 1), "<!DOCTYPE"),
+				c("Insert XML Declaration", //
+						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
+						r(0, 0, 0, 1), "<?xml"),
+				c("Insert XML Schema association", //
+						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
+						r(0, 0, 0, 1), "<?xml-model"),
+				c("Insert DTD association", //
+						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
+						r(0, 0, 0, 1), "<?xml-model"),
+				c("<!--", //
+						"<!-- -->", //
+						r(0, 0, 0, 1), "<!--"),
+				c("New catalog bound using DTD", //
+						"<!DOCTYPE catalog" + lineSeparator() + //
+								"\tPUBLIC \"-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN\"" + lineSeparator() + //
+								"\t\"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd\">"
+								+ lineSeparator() + //
+								"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" prefer=\"public\">"
+								+ lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 1), "<catalog"),
+				c("New catalog bound using XSD", //
+						"<catalog" + lineSeparator() + //
+								"\txmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\"" + lineSeparator() + //
+								"\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
+								"\txsi:schemaLocation=\"urn:oasis:names:tc:entity:xmlns:xml:catalog" + lineSeparator() + //
+								"\t\thttp://www.oasis-open.org/committees/entity/release/1.1/catalog.xsd\""
+								+ lineSeparator() + //
+								"\tprefer=\"public\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 1), "<catalog"), //
+				c("New catalog", //
+						"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>",
+						r(0, 0, 0, 1), "<catalog"));
+
+		testCompletionFor("<|>", //
+				NEW_XML_SNIPPETS /* DOCTYPE snippets */ + //
+						XML_DECLARATION_SNIPPETS /* XML Declaration snippets */ + //
+						PROCESSING_INSTRUCTION_SNIPPETS /* Processing Instruction snippets */ + //
+						COMMENT_SNIPPETS /* Comment snippets */ + //
+						CATALOG_SNIPPETS /* Catalog snippets */ , //
+				true,
+				c("New XML with SYSTEM DOCTYPE", //
+						"<!DOCTYPE root-element SYSTEM \"file.dtd\">" + lineSeparator() + //
+								"<root-element>" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 2), "<!DOCTYPE"),
+				c("Insert XML Declaration", //
+						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
+						r(0, 0, 0, 2), "<?xml"),
+				c("Insert XML Schema association", //
+						"<?xml-model href=\"file.xsd\" type=\"application/xml\" schematypens=\"http://www.w3.org/2001/XMLSchema\"?>", //
+						r(0, 0, 0, 2), "<?xml-model"),
+				c("Insert DTD association", //
+						"<?xml-model href=\"file.dtd\" type=\"application/xml-dtd\"?>", //
+						r(0, 0, 0, 2), "<?xml-model"),
+				c("<!--", //
+						"<!-- -->", //
+						r(0, 0, 0, 2), "<!--"),
+				c("New catalog bound using DTD", //
+						"<!DOCTYPE catalog" + lineSeparator() + //
+								"\tPUBLIC \"-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN\"" + lineSeparator() + //
+								"\t\"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd\">"
+								+ lineSeparator() + //
+								"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\" prefer=\"public\">"
+								+ lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 2), "<catalog"),
+				c("New catalog bound using XSD", //
+						"<catalog" + lineSeparator() + //
+								"\txmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\"" + lineSeparator() + //
+								"\txmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + lineSeparator() + //
+								"\txsi:schemaLocation=\"urn:oasis:names:tc:entity:xmlns:xml:catalog" + lineSeparator() + //
+								"\t\thttp://www.oasis-open.org/committees/entity/release/1.1/catalog.xsd\""
+								+ lineSeparator() + //
+								"\tprefer=\"public\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>", //
+						r(0, 0, 0, 2), "<catalog"), //
+				c("New catalog", //
+						"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">" + lineSeparator() + //
+								"\t<public publicId=\"\" uri=\"\" />" + lineSeparator() + //
+								"</catalog>",
+						r(0, 0, 0, 2), "<catalog"));
+
+		testCompletionFor("<!|", //
+				NEW_XML_SNIPPETS /* DOCTYPE snippets */ + //
+						XML_DECLARATION_SNIPPETS /* XML Declaration snippets */ + //
+						PROCESSING_INSTRUCTION_SNIPPETS /* Processing Instruction snippets */ + //
+						COMMENT_SNIPPETS /* Comment snippets */ + //
+						CATALOG_SNIPPETS /*
+											 * Catalog snippets (are counted here but get filtered by the prefix in the
+											 * editor )
+											 */, // TODO
+				true,
+				c("New XML with SYSTEM DOCTYPE", //
+						"<!DOCTYPE root-element SYSTEM \"file.dtd\">" + lineSeparator() + //
+								"<root-element>" + lineSeparator() + //
+								"</root-element>", //
+						r(0, 0, 0, 2), "<!DOCTYPE"),
+				c("Insert XML Declaration", //
+						"<?xml version=\"1.0\" encoding=\"UTF-8\"?>", //
+						r(0, 0, 0, 2), "<?xml"),
+				c("<!--", //
+						"<!-- -->", //
+						r(0, 0, 0, 2), "<!--"));
+
+	}
+
+	@Test
 	public void afterComment() throws BadLocationException {
 		testCompletionFor("<!-- -->|", //
 				NEW_XML_SNIPPETS /* DOCTYPE snippets */ + //


### PR DESCRIPTION
Fixes #1561
* moves `editRange` and `insertTextFormat` to `itemDefaults` when supported