### PR TITLE
Add completions support inside CDATA content

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -290,7 +290,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.10.0</version>
+			<version>4.11.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lemminx</groupId>
 		<artifactId>lemminx-parent</artifactId>
-		<version>0.27.1-SNAPSHOT</version>
+		<version>0.28.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lemminx</artifactId>
 	<properties>
@@ -285,6 +285,12 @@
 			<artifactId>jetty-server</artifactId>
 			<!-- Need to stick to 9.x as long as build is running with Java 1.8-->
 			<version>9.4.53.v20231009</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.10.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/XMLCompletions.java
@@ -262,6 +262,14 @@ public class XMLCompletions {
 							return completionResponse;
 						}
 						break;
+					// CDATA
+					case CDATATagOpen:
+					case CDATAContent:
+						if (scanner.getTokenOffset() <= offset && offset <= scanner.getTokenEnd()) {
+							collectCDATAContentSuggestions(completionRequest, completionResponse, cancelChecker);
+							return completionResponse;
+						}
+						break;
 					// DTD
 					case DTDAttlistAttributeName:
 					case DTDAttlistAttributeType:
@@ -866,6 +874,21 @@ public class XMLCompletions {
 			}
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "While performing collectRegionCompletion", e);
+		}
+	}
+
+	private void collectCDATAContentSuggestions(CompletionRequest request, CompletionResponse response,
+												CancelChecker cancelChecker){
+		// Participant completion on CDATA content
+		for (ICompletionParticipant participant : getCompletionParticipants()) {
+			try {
+				participant.onCDATAContent(request, response, cancelChecker);
+			} catch (CancellationException e) {
+				throw e;
+			} catch (Exception e) {
+				LOGGER.log(Level.SEVERE, "While performing ICompletionParticipant#onCDATAContent for participant '"
+						+ participant.getClass().getName() + "'.", e);
+			}
 		}
 	}
 

--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/completion/ICompletionParticipant.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/services/extensions/completion/ICompletionParticipant.java
@@ -60,6 +60,17 @@ public interface ICompletionParticipant {
 			throws Exception;
 
 	/**
+	 * Collects and stores completion items within the provided response <code>response</code>
+	 *
+	 * @param request     the completion request
+	 * @param response    the completion response
+	 * @param cancelChecker object used to monitor if this execution should finish
+	 * @throws Exception
+	 */
+	default void onCDATAContent(ICompletionRequest request, ICompletionResponse response, CancelChecker cancelChecker)
+			throws Exception {}
+
+	/**
 	 * Returns the completion item resolver that corresponds to the given
 	 * participant id or null otherwise.
 	 *

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/services/XMLCompletionTest.java
@@ -21,6 +21,10 @@ import static org.eclipse.lemminx.XMLAssert.testTagCompletion;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +34,7 @@ import org.eclipse.lemminx.commons.BadLocationException;
 import org.eclipse.lemminx.customservice.AutoCloseTagResponse;
 import org.eclipse.lemminx.dom.DOMDocument;
 import org.eclipse.lemminx.dom.DOMParser;
+import org.eclipse.lemminx.services.extensions.completion.ICompletionParticipant;
 import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
@@ -267,7 +272,23 @@ public class XMLCompletionTest {
 		String xml = "<aaa attr=\"value</|";
 		XMLAssert.testTagCompletion(xml, (AutoCloseTagResponse) null, settings);
 	}
+	@Test
+	public void testCDATAContentStart() throws Exception {
+		ICompletionParticipant mockParticipant = mock(ICompletionParticipant.class);
+		SharedSettings settings = new SharedSettings();
+		this.languageService.registerCompletionParticipant(mockParticipant);
+		testCompletionFor(this.languageService,"<a> <![CDATA[|]]></a>",null,null,null, 0,settings);
+		verify(mockParticipant).onCDATAContent(any(),any(),any());
+	}
 
+	@Test
+	public void testCDATAContent() throws Exception {
+		ICompletionParticipant mockParticipant = mock(ICompletionParticipant.class);
+		SharedSettings settings = new SharedSettings();
+		this.languageService.registerCompletionParticipant(mockParticipant);
+		testCompletionFor(this.languageService,"<a> <![CDATA[SELECT * FROM |]]></a>",null,null,null, 0,settings);
+		verify(mockParticipant).onCDATAContent(any(),any(),any());
+	}
 	// -------------------Tools----------------------------------------------------------
 
 	public void assertOpenStartTagCompletion(String xmlText, int expectedStartTagOffset, boolean startWithTagOpen,

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lemminx</groupId>
 	<artifactId>lemminx-parent</artifactId>
-	<version>0.27.1-SNAPSHOT</version>
+	<version>0.28.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse LemMinX</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
Addresses [this](https://github.com/eclipse/lemminx/issues/1625) enhancement request 

To facilitate the implementation of embedded language features inside the XML supporting the completion request inside CDATA blocks is required.

The changes where added in a backward compatible way an as such an increment in version was pushed from 0.27.1-SNAPSHOT to 0.28.0-SNAPSHOT

Mockito was added as a dependency as it is easier to mock interfaces and verify invocations rather than implement a new completion participant