### PR TITLE
Relocation remark from kotcrab to w6et

### DIFF
--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -231,9 +231,9 @@
 			<version>2.0.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.kotcrab.remark</groupId>
+			<groupId>io.github.w6et</groupId>
 			<artifactId>remark</artifactId>
-			<version>1.0.0</version>
+			<version>1.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jsoup</groupId>

--- a/org.eclipse.lemminx/pom.xml
+++ b/org.eclipse.lemminx/pom.xml
@@ -238,7 +238,7 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.14.2</version>
+			<version>1.17.2</version>
 		</dependency>
 		<dependency>
 			<groupId>xml-resolver</groupId>


### PR DESCRIPTION
Replace com.kotcrab.remark:remark:1.2.1 with Replace io.github.w6et:remark:1.2.3
Bump jsoup from 1.14.2 to 1.17.2

[https://github.com/w6et/remark-java/releases/tag/v1.2.3](https://github.com/w6et/remark-java/releases/tag/v1.2.3)