### PR TITLE
Fix builds on MacOS ARM64 with Java 8 (Temurin).

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         java-version: '8'
         distribution: 'temurin'
+        architecture: ${{ matrix.os == 'macos-latest' && 'x64' || '' }}
         cache: 'maven'
     - name: Run Tests
       run: ./mvnw -B '-Dlemminx.cacheInRepoDir' clean verify


### PR DESCRIPTION
On macos-latest, https://github.com/eclipse/lemminx/actions/runs/9259761464/job/25472300010 :

```
Error: Could not find satisfied version for SemVer '8'. 
  Available versions: 22.0.1+8, 22.0.0+36, 21.0.3+9.0.LTS, 21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9, 20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9, 18.0.1+10, 18.0.0+36, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101, 17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7, 17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.23+9, 11.0.22+7.1, 11.0.22+7, 11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8, 11.0.16+101, 11.0.16+8, 11.0.15+10
```

- macos-latest is an arm64 runner, and  'temurin' has no support for this architecture on Java 8
- Force 'x64' architecture on macos-latest since Rosetta layer should provide necessary support

See https://github.com/rgrunber/lemminx/actions/runs/9275969014 , although certain test cases are fragile.