### PR TITLE
Support xsi:type overrides when resolving content model

### DIFF
--- a/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -67,6 +67,8 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	private final XSElementDeclaration elementDeclaration;
 
+	private final XSTypeDefinition typeDefinition;
+
 	private Collection<CMAttributeDeclaration> attributes;
 
 	private Collection<CMElementDeclaration> elements;
@@ -79,9 +81,19 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	private Map<String, Boolean> elementOptionality;
 
-	public CMXSDElementDeclaration(CMXSDDocument document, XSElementDeclaration elementDeclaration) {
+	private CMXSDElementDeclaration(CMXSDDocument document, XSElementDeclaration elementDeclaration,
+								   XSTypeDefinition typeDefinition) {
 		this.document = document;
 		this.elementDeclaration = elementDeclaration;
+		this.typeDefinition = typeDefinition;
+	}
+
+	public CMXSDElementDeclaration(CMXSDDocument document, XSElementDeclaration elementDeclaration) {
+		this(document, elementDeclaration, elementDeclaration.getTypeDefinition());
+	}
+
+	public CMXSDElementDeclaration refineType(XSTypeDefinition refinedType) {
+		return new CMXSDElementDeclaration(document, elementDeclaration, refinedType);
 	}
 
 	@Override
@@ -111,7 +123,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	private void collectAttributesDeclaration(XSElementDeclaration elementDecl,
 			Collection<CMAttributeDeclaration> attributes) {
-		XSTypeDefinition typeDefinition = elementDecl.getTypeDefinition();
 		switch (typeDefinition.getTypeCategory()) {
 		case XSTypeDefinition.SIMPLE_TYPE:
 			// TODO...
@@ -147,7 +158,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public Collection<CMElementDeclaration> getPossibleElements(DOMElement parentElement, int offset) {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null && typeDefinition.getTypeCategory() == XSTypeDefinition.COMPLEX_TYPE) {
 			// The type definition is complex (ex: xs:all; xs:sequence), returns list of
 			// element declaration according those XML Schema constraints
@@ -301,7 +311,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	private void collectElementsDeclaration(XSElementDeclaration elementDecl,
 			Collection<CMElementDeclaration> elements) {
-		XSTypeDefinition typeDefinition = elementDecl.getTypeDefinition();
 		switch (typeDefinition.getTypeCategory()) {
 		case XSTypeDefinition.SIMPLE_TYPE:
 			// TODO...
@@ -323,7 +332,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 	public boolean isOptional(String childElementName) {
 		if (elementOptionality == null) {
 			this.elementOptionality = new HashMap<String, Boolean>();
-			XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 			switch (typeDefinition.getTypeCategory()) {
 			case XSTypeDefinition.SIMPLE_TYPE:
 				break;
@@ -404,7 +412,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 			return annotation;
 		}
 		// Try get xs:annotation from the type of element declaration
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition == null) {
 			return null;
 		}
@@ -467,7 +474,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public boolean isEmpty() {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null && typeDefinition.getTypeCategory() == XSTypeDefinition.COMPLEX_TYPE) {
 			XSComplexTypeDefinition complexTypeDefinition = (XSComplexTypeDefinition) typeDefinition;
 			return complexTypeDefinition.getContentType() == XSComplexTypeDefinition.CONTENTTYPE_EMPTY;
@@ -482,7 +488,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public Collection<String> getEnumerationValues() {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null) {
 			XSSimpleTypeDefinition simpleDefinition = null;
 			if (typeDefinition.getTypeCategory() == XSTypeDefinition.SIMPLE_TYPE) {
@@ -530,7 +535,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 	}
 
 	private XSObjectList getTextAnnotations(String textContent) {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null) {
 			XSSimpleTypeDefinition simpleDefinition = null;
 			if (typeDefinition.getTypeCategory() == XSTypeDefinition.SIMPLE_TYPE) {
@@ -560,7 +564,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public boolean isStringType() {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null) {
 			XSSimpleTypeDefinition simpleDefinition = null;
 			if (typeDefinition.getTypeCategory() == XSTypeDefinition.SIMPLE_TYPE) {
@@ -577,7 +580,6 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 
 	@Override
 	public boolean isMixedContent() {
-		XSTypeDefinition typeDefinition = elementDeclaration.getTypeDefinition();
 		if (typeDefinition != null && typeDefinition.getTypeCategory() == XSTypeDefinition.COMPLEX_TYPE) {
 			XSComplexTypeDefinition complexTypeDefinition = (XSComplexTypeDefinition) typeDefinition;
 			return complexTypeDefinition.getContentType() == XSComplexTypeDefinition.CONTENTTYPE_MIXED;

--- a/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
+++ b/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/contentmodel/XMLSchemaHoverDocumentationTypeTest.java
@@ -24,13 +24,14 @@ import org.eclipse.lemminx.settings.SharedSettings;
 import org.eclipse.lsp4j.HoverCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
  * XML hover tests with XML Schema.
  *
  */
-public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest {
+public abstract class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest {
 
 	private static final String schemaName = "docAppinfo.xsd";
 	private static final String schemaPath = "src/test/resources/" + schemaName;
@@ -40,6 +41,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 	private static String plainTextDocPrefix = "xs:documentation:" + System.lineSeparator() + System.lineSeparator();
 	private static String plainTextAppinfoPrefix = "xs:appinfo:" + System.lineSeparator() + System.lineSeparator();
 	private static String plainTextSource;
+	private String extraAttributes = "";
 
 	@BeforeAll
 	public static void setup() throws MalformedURIException {
@@ -213,6 +215,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	attribu|teNameOnlyDocumentation=\"onlyDocumentation\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -225,6 +228,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	attributeNameOnlyDocumentation=\"o|nlyDocumentation\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -237,6 +241,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	a|ttributeNameOnlyAppinfo=\"onlyAppinfo\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -249,6 +254,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	attributeNameOnlyAppinfo=\"o|nlyAppinfo\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -261,6 +267,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	a|ttributeNameBoth=\"bothDocumentationAndAppinfo\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -273,6 +280,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	attributeNameBoth=\"b|othDocumentationAndAppinfo\">\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -285,6 +293,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	<e|lementOnlyDocumentation></elementOnlyDocumentation>\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -297,6 +306,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	<e|lementOnlyAppinfo></elementOnlyAppinfo>\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -309,6 +319,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	<e|lementBoth></elementBoth>\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -321,6 +332,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" +
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+				extraAttributes + //
 				"	<e|lementMultipleBoth></elementMultipleBoth>\n" +
 				"</root>\n";
 		assertHover(xml, expected, docSource, markdownSupported);
@@ -332,6 +344,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" + //
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" + //
+				extraAttributes + //
 				"	<e|lementNoAnnotation></elementNoAnnotation>\n" + //
 				"</root>\n";
 		assertHover(xml, null, docSource, markdownSupported);
@@ -343,6 +356,7 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"	xmlns=\"http://docAppinfo\"\n" + //
 				"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
 				"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" + //
+				extraAttributes + //
 				"	<e|lementWhitespaceAnnotation></elementWhitespaceAnnotation>\n" + //
 				"</root>\n";
 		assertHover(xml, null, docSource, markdownSupported);
@@ -379,5 +393,56 @@ public class XMLSchemaHoverDocumentationTypeTest extends AbstractCacheBasedTest 
 				"/");
 	}
 
+	@Nested
+	public static class BaseTypeTest extends XMLSchemaHoverDocumentationTypeTest {
+	}
 
+	@Nested
+	public static class DerivedTypeTest extends XMLSchemaHoverDocumentationTypeTest {
+		public DerivedTypeTest() {
+			super.extraAttributes = "  xsi:type=\"Derived\"";
+		}
+
+		@Test
+		public void testHoverDerivedAttributeNameDoc() throws BadLocationException, MalformedURIException {
+			assertDerivedAttributeNameDocHover("derived attribute name documentation", SchemaDocumentationType.documentation, true);
+			assertDerivedAttributeNameDocHover(null, SchemaDocumentationType.appinfo, true);
+			assertDerivedAttributeNameDocHover("derived attribute name documentation", SchemaDocumentationType.all, true);
+			assertDerivedAttributeNameDocHover(null, SchemaDocumentationType.none, true);
+		};
+
+		@Test
+		public void testHoverDerivedElementDoc() throws BadLocationException, MalformedURIException {
+			assertDerivedElementDocHover("derived element documentation", SchemaDocumentationType.documentation, true);
+			assertDerivedElementDocHover(null, SchemaDocumentationType.appinfo, true);
+			assertDerivedElementDocHover("derived element documentation", SchemaDocumentationType.all, true);
+			assertDerivedElementDocHover(null, SchemaDocumentationType.none, true);
+		};
+
+		private void assertDerivedAttributeNameDocHover(String expected, SchemaDocumentationType docSource,
+												 boolean markdownSupported) throws BadLocationException {
+			String xml =
+					"<root\n" +
+							"	xmlns=\"http://docAppinfo\"\n" +
+							"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+							"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+							super.extraAttributes + //
+							"	derivedAttribu|teNameOnlyDocumentation=\"onlyDocumentation\">\n" +
+							"</root>\n";
+			super.assertHover(xml, expected, docSource, markdownSupported);
+		}
+
+		private void assertDerivedElementDocHover(String expected, SchemaDocumentationType docSource,
+										   boolean markdownSupported) throws BadLocationException {
+			String xml =
+					"<root\n" +
+							"	xmlns=\"http://docAppinfo\"\n" +
+							"	xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+							"	xsi:schemaLocation=\"http://docAppinfo xsd/" + schemaName + "\"\n" +
+							super.extraAttributes + //
+							"	<derivedE|lementOnlyDocumentation></derivedElementOnlyDocumentation>\n" +
+							"</root>\n";
+			super.assertHover(xml, expected, docSource, markdownSupported);
+		}
+	}
 }

--- a/org.eclipse.lemminx/src/test/resources/xsd/docAppinfo.xsd
+++ b/org.eclipse.lemminx/src/test/resources/xsd/docAppinfo.xsd
@@ -22,84 +22,102 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:element name='root'>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name='elementOnlyDocumentation'>
-                    <xs:annotation>
-                        <xs:documentation>element documentation</xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name='elementOnlyAppinfo'>
-                    <xs:annotation>
-                        <xs:appinfo>element appinfo</xs:appinfo>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name='elementBoth'>
-                    <xs:annotation>
-                        <xs:documentation>element documentation</xs:documentation>
-                        <xs:appinfo>element appinfo</xs:appinfo>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name='elementMultipleDocuentation'>
-                    <xs:annotation>
-                        <xs:documentation>first element documentation</xs:documentation>
-                        <xs:documentation>second element documentation</xs:documentation>
-                        <xs:documentation>third element documentation</xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name='elementMultipleAppinfo'>
-                    <xs:annotation>
-                        <xs:appinfo>first element appinfo</xs:appinfo>
-                        <xs:appinfo>second element appinfo</xs:appinfo>
-                        <xs:appinfo>third element appinfo</xs:appinfo>
-                    </xs:annotation>
-                </xs:element>
-                <xs:element name='elementMultipleBoth'>
-                    <xs:annotation>
-                        <xs:documentation>first element documentation</xs:documentation>
-                        <xs:documentation>second element documentation</xs:documentation>
-                        <xs:documentation>third element documentation</xs:documentation>
-                        <xs:appinfo>first element appinfo</xs:appinfo>
-                        <xs:appinfo>second element appinfo</xs:appinfo>
-                        <xs:appinfo>third element appinfo</xs:appinfo>
-                    </xs:annotation>
-                </xs:element>
-				<xs:element name='elementNoAnnotation'></xs:element>
-				<xs:element name='elementWhitespaceAnnotation'>
-					<xs:annotation>
-						<xs:documentation>
+    <xs:element name='root' type="Root" />
 
-
-
-
-						</xs:documentation>
-						<xs:appinfo>
-									  
-						   
-						</xs:appinfo>
-						<xs:appinfo>  		  </xs:appinfo>
-					</xs:annotation>
-				</xs:element>
-            </xs:sequence>
-
-            <xs:attribute name='attributeNameOnlyDocumentation' type='attributeValue' use='required'>
+    <xs:complexType name="Root">
+        <xs:sequence>
+            <xs:element name='elementOnlyDocumentation'>
                 <xs:annotation>
-                    <xs:documentation>attribute name documentation</xs:documentation>
+                    <xs:documentation>element documentation</xs:documentation>
                 </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name='attributeNameOnlyAppinfo' type='attributeValue' use='required'>
+            </xs:element>
+            <xs:element name='elementOnlyAppinfo'>
                 <xs:annotation>
-                    <xs:appinfo>attribute name appinfo</xs:appinfo>
+                    <xs:appinfo>element appinfo</xs:appinfo>
                 </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name='attributeNameBoth' type='attributeValue' use='required'>
+            </xs:element>
+            <xs:element name='elementBoth'>
                 <xs:annotation>
-                    <xs:documentation>attribute name documentation</xs:documentation>
-                    <xs:appinfo>attribute name appinfo</xs:appinfo>
+                    <xs:documentation>element documentation</xs:documentation>
+                    <xs:appinfo>element appinfo</xs:appinfo>
                 </xs:annotation>
-            </xs:attribute>
-        </xs:complexType>
-    </xs:element>
+            </xs:element>
+            <xs:element name='elementMultipleDocuentation'>
+                <xs:annotation>
+                    <xs:documentation>first element documentation</xs:documentation>
+                    <xs:documentation>second element documentation</xs:documentation>
+                    <xs:documentation>third element documentation</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name='elementMultipleAppinfo'>
+                <xs:annotation>
+                    <xs:appinfo>first element appinfo</xs:appinfo>
+                    <xs:appinfo>second element appinfo</xs:appinfo>
+                    <xs:appinfo>third element appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name='elementMultipleBoth'>
+                <xs:annotation>
+                    <xs:documentation>first element documentation</xs:documentation>
+                    <xs:documentation>second element documentation</xs:documentation>
+                    <xs:documentation>third element documentation</xs:documentation>
+                    <xs:appinfo>first element appinfo</xs:appinfo>
+                    <xs:appinfo>second element appinfo</xs:appinfo>
+                    <xs:appinfo>third element appinfo</xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name='elementNoAnnotation'></xs:element>
+            <xs:element name='elementWhitespaceAnnotation'>
+                <xs:annotation>
+                    <xs:documentation>
 
+
+
+
+                    </xs:documentation>
+                    <xs:appinfo>
+
+
+                    </xs:appinfo>
+                    <xs:appinfo>  		  </xs:appinfo>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name='attributeNameOnlyDocumentation' type='attributeValue' use='required'>
+            <xs:annotation>
+                <xs:documentation>attribute name documentation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='attributeNameOnlyAppinfo' type='attributeValue' use='required'>
+            <xs:annotation>
+                <xs:appinfo>attribute name appinfo</xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name='attributeNameBoth' type='attributeValue' use='required'>
+            <xs:annotation>
+                <xs:documentation>attribute name documentation</xs:documentation>
+                <xs:appinfo>attribute name appinfo</xs:appinfo>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="Derived">
+        <xs:complexContent>
+            <xs:extension base="Root">
+                <xs:sequence>
+                    <xs:element name='derivedElementOnlyDocumentation'>
+                        <xs:annotation>
+                            <xs:documentation>derived element documentation</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name='derivedAttributeNameOnlyDocumentation' type='attributeValue' use='required'>
+                    <xs:annotation>
+                        <xs:documentation>derived attribute name documentation</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Changes the content model to resolve `xsi:type` based polymorphism when navigating from a DOMElement to a CMXSDElement, fixing a bug where documentation and hints for the derived types were not presented.